### PR TITLE
fix: add missing `__all__` in init file

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -53,7 +53,7 @@ mkdir multi_tool_agent/
 Now create an `__init__.py` file in the folder:
 
 ```shell
-echo "from . import agent" > multi_tool_agent/__init__.py
+echo "from . import agent\n\n__all__ = [\"agent\"]" > multi_tool_agent/__init__.py
 ```
 
 Your `__init__.py` should now look like this:

--- a/examples/python/snippets/get-started/multi_tool_agent/__init__.py
+++ b/examples/python/snippets/get-started/multi_tool_agent/__init__.py
@@ -1,1 +1,3 @@
 from . import agent
+
+__all__ = ["agent"]


### PR DESCRIPTION
Without it the user will see the following error:
```
2025-04-10 12:13:29,627 - ERROR - fast_api.py:616 - Error in event_generator: module 'multi_tool_agent.agent' has no attribute 'root_agent'
Traceback (most recent call last):
  File "/Users/sroze/git/adk-agent-test/.venv/lib/python3.13/site-packages/google/adk/cli/fast_api.py", line 604, in event_generator
    runner = _get_runner(req.app_name)
  File "/Users/sroze/git/adk-agent-test/.venv/lib/python3.13/site-packages/google/adk/cli/fast_api.py", line 756, in _get_runner
    root_agent = _get_root_agent(app_name)
  File "/Users/sroze/git/adk-agent-test/.venv/lib/python3.13/site-packages/google/adk/cli/fast_api.py", line 748, in _get_root_agent
    root_agent: Agent = agent_module.agent.root_agent
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```