### PR TITLE
Fix Contribute link on docs landing page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ orchestration**.
   <a href="get-started/tutorial/" class="md-button">Tutorial</a>
   <a href="http://github.com/google/adk-samples" class="md-button" target="_blank">Sample Agents</a>
   <a href="api-reference/" class="md-button">API Reference</a>
-  <a href="contributing-guide.md/" class="md-button">Contribute ❤️</a>
+  <a href="contributing-guide/" class="md-button">Contribute ❤️</a>
 </p>
 
 ---


### PR DESCRIPTION
Removes `.md` from the 