### PR TITLE
fix: chg repo to adk-docs to help redirect users to repo for docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,8 +6,8 @@ site_description: >-
 site_dir: site
 
 # Repository
-repo_name: adk-python
-repo_url: https://github.com/google/adk-python
+repo_name: adk-docs
+repo_url: https://github.com/google/adk-docs
 
 # Copyright
 copyright: Copyright Google 2025


### PR DESCRIPTION
Users have been reporting documentation issues in adk-python, which is the repo for the SDK itself (not the documentation). This will make the docs page point to the docs repo (adk-repo) instead to so that users naturally report bugs directly in the docs repo.