### PR TITLE
docs: added third-party testing solutions

### DIFF
--- a/docs/get-started/local-testing.md
+++ b/docs/get-started/local-testing.md
@@ -137,3 +137,9 @@ Here are some ways you can deploy your agent:
 
 * Deploying to [Agent Engine](../deploy/agent-engine.md), the easiest way to deploy your ADK agents to Vertex AI on Google Cloud.  
 * Deploying to [Cloud Run](../deploy/cloud-run.md), and have full control over how you want to manage your auto-scaling container on Google Cloud.  
+
+## Test Intergrations
+
+ADK can be integrated with third-party observability solutions using [Callbacks](../callbacks/index.md) to capture traces of agent calls, interactions and usage. Supported third-party solutions:
+
+* [Comet Opik](https://github.com/comet-ml/opik) is an open-source LLM observability and evaluation platform that natively supports ADK [docs](https://www.comet.com/docs/opik/tracing/integrations/adk).


### PR DESCRIPTION
## Change
Suggesting adding a `third-party test intergrations` to the `local-testing.md`. The open-source LLM testing and observability toolkit natively supports ADK following a [feature request on adk-python](https://github.com/google/adk-python/issues/48) this was released publicly by Opik team yesterday on build [1.7.2](https://github.com/comet-ml/opik/releases/tag/1.7.2) following the ADK annoucement.

The implementation of the callback and tracing of ADK on Opik supports all uses from costs to tool usage (_see screenshots below_).
## Suggestions
Opik the fastest growing agent framework and llm-agnostic tracing solution that has been widley adopted. Happy for maintainers to suggest alternatives to documentation but felt its best suited within the testing/debuging section rather than opening a new page like `intergrations.md`.

## Example
See screenshots of the integration which are part of the Opik docs.
![Screenshot 2025-04-10 at 16-37-08 Comet Opik](https://github.com/user-attachments/assets/ac10e5e8-6908-41af-ba28-6ad4617a046a)
![Screenshot 2025-04-10 at 16-38-30 Comet Opik](https://github.com/user-attachments/assets/c5f18a47-42ee-4307-b357-163356f62fab)