### PR TITLE
[WIP] gcloud cli instruction for cloud run deploy

### DIFF
--- a/docs/deploy/cloud-run.md
+++ b/docs/deploy/cloud-run.md
@@ -145,7 +145,7 @@ export GOOGLE_GENAI_USE_VERTEXAI=True
         # Example session DB URL (e.g., SQLite)
         SESSION_DB_URL = "sqlite:///./sessions.db"
         # Example allowed origins for CORS
-        ALLOWED_ORIGINS = ["http://localhost", "http://localhost:8000", "*"]
+        ALLOWED_ORIGINS = ["http://localhost", "http://localhost:8080", "*"]
         # Set web=True if you intend to serve a web interface, False otherwise
         SERVE_WEB_INTERFACE = True
 
@@ -165,11 +165,11 @@ export GOOGLE_GENAI_USE_VERTEXAI=True
         #     return {"Hello": "World"}
 
         if __name__ == "__main__":
-            # Use the PORT environment variable provided by Cloud Run, defaulting to 8000
-            uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", 8000)))
+            # Use the PORT environment variable provided by Cloud Run, defaulting to 8080
+            uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))
         ```
 
-        *Note: We specify `agent_dir` to the directory `main.py` is in and use `os.environ.get("PORT", 8000)` for Cloud Run compatibility.*
+        *Note: We specify `agent_dir` to the directory `main.py` is in and use `os.environ.get("PORT", 8080)` for Cloud Run compatibility.*
 
     2. List the necessary Python packages:
 
@@ -209,7 +209,6 @@ export GOOGLE_GENAI_USE_VERTEXAI=True
     --region $GOOGLE_CLOUD_LOCATION \
     --project $GOOGLE_CLOUD_PROJECT \
     --allow-unauthenticated \
-    --port 8000 \
     --set-env-vars="GOOGLE_CLOUD_PROJECT=$GOOGLE_CLOUD_PROJECT,GOOGLE_CLOUD_LOCATION=$GOOGLE_CLOUD_LOCATION,GOOGLE_GENAI_USE_VERTEXAI=$GOOGLE_GENAI_USE_VERTEXAI"
     # Add any other necessary environment variables your agent might need
     ```

--- a/docs/deploy/cloud-run.md
+++ b/docs/deploy/cloud-run.md
@@ -145,7 +145,7 @@ export GOOGLE_GENAI_USE_VERTEXAI=True
         # Example session DB URL (e.g., SQLite)
         SESSION_DB_URL = "sqlite:///./sessions.db"
         # Example allowed origins for CORS
-        ALLOWED_ORIGINS = ["http://localhost", "http://localhost:8080", "*"]
+        ALLOWED_ORIGINS = ["http://localhost", "http://localhost:8000", "*"]
         # Set web=True if you intend to serve a web interface, False otherwise
         SERVE_WEB_INTERFACE = True
 
@@ -169,7 +169,7 @@ export GOOGLE_GENAI_USE_VERTEXAI=True
             uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", 8000)))
         ```
 
-        *Note: We specify `agent_dir_name="capital_agent"` and use `os.environ.get("PORT", 8000)` for Cloud Run compatibility.*
+        *Note: We specify `agent_dir` to the directory `main.py` is in and use `os.environ.get("PORT", 8000)` for Cloud Run compatibility.*
 
     2. List the necessary Python packages:
 
@@ -209,6 +209,7 @@ export GOOGLE_GENAI_USE_VERTEXAI=True
     --region $GOOGLE_CLOUD_LOCATION \
     --project $GOOGLE_CLOUD_PROJECT \
     --allow-unauthenticated \
+    --port 8000 \
     --set-env-vars="GOOGLE_CLOUD_PROJECT=$GOOGLE_CLOUD_PROJECT,GOOGLE_CLOUD_LOCATION=$GOOGLE_CLOUD_LOCATION,GOOGLE_GENAI_USE_VERTEXAI=$GOOGLE_GENAI_USE_VERTEXAI"
     # Add any other necessary environment variables your agent might need
     ```


### PR DESCRIPTION
Fixes #52 

- Add port to gcloud run deploy command
- Add localhost:8000 to allowed origins
- Update agent_dir_name to agent_dir in note.