### PR TITLE
Update Agent instruction in quick-start example

### DIFF
--- a/examples/python/snippets/get-started/multi_tool_agent/agent.py
+++ b/examples/python/snippets/get-started/multi_tool_agent/agent.py
@@ -61,7 +61,7 @@ root_agent = Agent(
         "Agent to answer questions about the time and weather in a city."
     ),
     instruction=(
-        "I can answer your questions about the time and weather in a city."
+        "You are a helpful agent who can answer user questions about the time and weather in a city."
     ),
     tools=[get_weather, get_current_time],
 )


### PR DESCRIPTION
Use second-person (you) instead of first-person (I) in the agent instruction.