### PR TITLE
Updates and formatting fixes to Testing page

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -24,5 +24,5 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material
+      - run: pip install -r requirements.txt
       - run: mkdocs gh-deploy --force

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -212,8 +212,8 @@ There are multiple ways to interact with your agent:
 
     ![adk-api-server.png](../assets/adk-api-server.png)
 
-    To learn how to use `adk api_server`, see the
-    [documentation on local testing](local-testing.md).
+    To learn how to use `adk api_server` for testing, refer the
+    [documentation on testing](testing.md).
 
 ### 📝 Example prompts to try
 

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -212,7 +212,7 @@ There are multiple ways to interact with your agent:
 
     ![adk-api-server.png](../assets/adk-api-server.png)
 
-    To learn how to use `adk api_server` for testing, refer the
+    To learn how to use `adk api_server` for testing, refer to the
     [documentation on testing](testing.md).
 
 ### 📝 Example prompts to try

--- a/docs/get-started/testing.md
+++ b/docs/get-started/testing.md
@@ -1,31 +1,33 @@
-# Local testing
+# Testing your Agents
 
-Before you deploy your agent, you should test it locally to make sure it is
-working as intended.
+Before you deploy your agent, you should test it to ensure that it is working as
+intended. The easiest way to test your agent in your development environment is
+to use the `adk api_server` command. This command will launch a local FastAPI
+server, where you can run cURL commands or send API requests to test your agent.
 
-The easiest way is to test your a local agent is to use the ADK CLI with `adk api_server`, which launches a local Fast API server, where you can run cURL commands to test your agent.
+## Local testing
 
-## Working directory
-
-First, ensure you are in the correct working directory:
+Local testing involves launching a local API server, creating a session, and
+sending queries to your agent. First, ensure you are in the correct working
+directory:
 
 ```console
-parent_folder    <-- you should be here
+parent_folder  <-- you should be here
 |- my_sample_agent
   |- __init__.py
   |- .env
   |- agent.py
 ```
 
-### Launching your local Fast API server with `adk api_server`
+**Launch the Local Server**
 
-Next, launch the local Fast API server:
+Next, launch the local FastAPI server:
 
 ```shell
-adk api_server 
+adk api_server
 ```
 
-#### Expected Output
+The output should appear similar to:
 
 ```shell
 INFO:     Started server process [12345]
@@ -36,9 +38,10 @@ INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
 
 Your server is now running locally at `http://0.0.0.0:8000`.
 
-### Creating a new session for your agent
+**Create a new session**
 
-Without closing this terminal, open a new terminal and create a new session with the agent using:
+With the API server still running, open a new terminal window or tab and create
+a new session with the agent using:
 
 ```shell
 curl -X POST http://0.0.0.0:8000/apps/my_sample_agent/users/u_123/sessions/s_123 \
@@ -46,31 +49,46 @@ curl -X POST http://0.0.0.0:8000/apps/my_sample_agent/users/u_123/sessions/s_123
   -d '{"state": {"key1": "value1", "key2": 42}}'
 ```
 
-Let's break down what's happening:  
+Let's break down what's happening:
 
-* `http://0.0.0.0:8000/apps/my_sample_agent/users/u_123/sessions/s_123`: This creates a new session for your agent `my_sample_agent`, which is the name of the agent folder, for a user ID (`u_123`) and for a session ID (`s_123`). You can replace `my_sample_agent` with the name of your agent folder. You can replace `u_123` with a specific user ID, and `s_123` with a specific session ID.  
-* `{"state": {"key1": "value1", "key2": 42}}`: This is optional. You can use this to customize the agent's pre-existing state (dict) when creating the session.  
+* `http://0.0.0.0:8000/apps/my_sample_agent/users/u_123/sessions/s_123`: This
+  creates a new session for your agent `my_sample_agent`, which is the name of
+  the agent folder, for a user ID (`u_123`) and for a session ID (`s_123`). You
+  can replace `my_sample_agent` with the name of your agent folder. You can
+  replace `u_123` with a specific user ID, and `s_123` with a specific session
+  ID.
+* `{"state": {"key1": "value1", "key2": 42}}`: This is optional. You can use
+  this to customize the agent's pre-existing state (dict) when creating the
+  session.
 
-This should return the session information, if created successfully.
-
-#### Expected Output
+This should return the session information if it was created successfully. The
+output should appear similar to:
 
 ```shell
 {"id":"s_123","app_name":"my_sample_agent","user_id":"u_123","state":{"state":{"key1":"value1","key2":42}},"events":[],"last_update_time":1743711430.022186}
 ```
 
-💡 Tip:  
+!!! info
 
-* you cannot create multiple sessions with exactly the same user ID and session ID. If you try to, you may see a response, like: `{"detail":"Session already exists: s_123"}`. To fix this, you can either delete that session (e.g. `s_123`), or choose a different session ID.
+    You cannot create multiple sessions with exactly the same user ID and
+    session ID. If you try to, you may see a response, like:
+    `{"detail":"Session already exists: s_123"}`. To fix this, you can either
+    delete that session (e.g., `s_123`), or choose a different session ID.
 
-### Sending a query to your agent
+**Send a query**
 
-There are two ways to send queries via POST to your agent, via `/run` or `/run_sse`.  
+There are two ways to send queries via POST to your agent, via the `/run` or
+`/run_sse` routes.
 
-* `POST http://0.0.0.0:8000/run`: collects all events as a list and returns the list all at once. Suitable for most users (if you are unsure, we recommend using this one).  
-* `POST http://0.0.0.0:8000/run_sse`: returns as Server-Sent-Events, which is a stream of event objects. Suitable for those who want to be notified as soon as the event is available. With `/run_sse`, you can also set `streaming` to `true` to enable token-level streaming.
+* `POST http://0.0.0.0:8000/run`: collects all events as a list and returns the
+  list all at once. Suitable for most users (if you are unsure, we recommend
+  using this one).
+* `POST http://0.0.0.0:8000/run_sse`: returns as Server-Sent-Events, which is a
+  stream of event objects. Suitable for those who want to be notified as soon as
+  the event is available. With `/run_sse`, you can also set `streaming` to
+  `true` to enable token-level streaming.
 
-#### With `/run`
+**Using `/run`**
 
 ```shell
 curl -X POST http://0.0.0.0:8000/run \
@@ -88,15 +106,14 @@ curl -X POST http://0.0.0.0:8000/run \
 }'
 ```
 
-##### Expected Output
-
-If using `/run`, you will see the full output of events at the same time, as a list:
+If using `/run`, you will see the full output of events at the same time, as a
+list, which should appear similar to:
 
 ```shell
 [{"content":{"parts":[{"functionCall":{"id":"af-e75e946d-c02a-4aad-931e-49e4ab859838","args":{"city":"new york"},"name":"get_weather"}}],"role":"model"},"invocation_id":"e-71353f1e-aea1-4821-aa4b-46874a766853","author":"weather_time_agent","actions":{"state_delta":{},"artifact_delta":{},"requested_auth_configs":{}},"long_running_tool_ids":[],"id":"2Btee6zW","timestamp":1743712220.385936},{"content":{"parts":[{"functionResponse":{"id":"af-e75e946d-c02a-4aad-931e-49e4ab859838","name":"get_weather","response":{"status":"success","report":"The weather in New York is sunny with a temperature of 25 degrees Celsius (41 degrees Fahrenheit)."}}}],"role":"user"},"invocation_id":"e-71353f1e-aea1-4821-aa4b-46874a766853","author":"weather_time_agent","actions":{"state_delta":{},"artifact_delta":{},"requested_auth_configs":{}},"id":"PmWibL2m","timestamp":1743712221.895042},{"content":{"parts":[{"text":"OK. The weather in New York is sunny with a temperature of 25 degrees Celsius (41 degrees Fahrenheit).\n"}],"role":"model"},"invocation_id":"e-71353f1e-aea1-4821-aa4b-46874a766853","author":"weather_time_agent","actions":{"state_delta":{},"artifact_delta":{},"requested_auth_configs":{}},"id":"sYT42eVC","timestamp":1743712221.899018}]
 ```
 
-#### With `/run_sse`
+**Using `/run_sse`**
 
 ```shell
 curl -X POST http://0.0.0.0:8000/run_sse \
@@ -111,13 +128,14 @@ curl -X POST http://0.0.0.0:8000/run_sse \
     "text": "Hey whats the weather in new york today"
     }]
 },
-"streaming": false 
+"streaming": false
 }'
 ```
 
-You can set `streaming` to `true` to enable token-level streaming, which means the response will be returned to you in multiple chunks.
+You can set `streaming` to `true` to enable token-level streaming, which means
+the response will be returned to you in multiple chunks and the output should
+appear similar to:
 
-##### Expected Output
 
 ```shell
 data: {"content":{"parts":[{"functionCall":{"id":"af-f83f8af9-f732-46b6-8cb5-7b5b73bbf13d","args":{"city":"new york"},"name":"get_weather"}}],"role":"model"},"invocation_id":"e-3f6d7765-5287-419e-9991-5fffa1a75565","author":"weather_time_agent","actions":{"state_delta":{},"artifact_delta":{},"requested_auth_configs":{}},"long_running_tool_ids":[],"id":"ptcjaZBa","timestamp":1743712255.313043}
@@ -127,19 +145,29 @@ data: {"content":{"parts":[{"functionResponse":{"id":"af-f83f8af9-f732-46b6-8cb5
 data: {"content":{"parts":[{"text":"OK. The weather in New York is sunny with a temperature of 25 degrees Celsius (41 degrees Fahrenheit).\n"}],"role":"model"},"invocation_id":"e-3f6d7765-5287-419e-9991-5fffa1a75565","author":"weather_time_agent","actions":{"state_delta":{},"artifact_delta":{},"requested_auth_configs":{}},"id":"rAnWGSiV","timestamp":1743712257.391317}
 ```
 
-Note: if using `/run_sse`, you should see each event as soon as it is available.
+!!! info
 
-### Deploying your agent?
+    If you are using `/run_sse`, you should see each event as soon as it becomes
+    available.
 
-Now that you've verified the local operation of your agent, you're ready to move on to deploying your agent!
+## Integrations
 
-Here are some ways you can deploy your agent:
+ADK uses [Callbacks](../callbacks/index.md) to integrate with third-party
+observability tools. These integrations capture detailed traces of agent calls
+and interactions, which are crucial for understanding behavior, debugging
+issues, and evaluating performance.
 
-* Deploying to [Agent Engine](../deploy/agent-engine.md), the easiest way to deploy your ADK agents to Vertex AI on Google Cloud.  
-* Deploying to [Cloud Run](../deploy/cloud-run.md), and have full control over how you want to manage your auto-scaling container on Google Cloud.  
+* [Comet Opik](https://github.com/comet-ml/opik) is an open-source LLM
+  observability and evaluation platform that
+  [natively supports ADK](https://www.comet.com/docs/opik/tracing/integrations/adk).
 
-## Test Intergrations
+## Deploying your agent
 
-ADK can be integrated with third-party observability solutions using [Callbacks](../callbacks/index.md) to capture traces of agent calls, interactions and usage. Supported third-party solutions:
+Now that you've verified the local operation of your agent, you're ready to move
+on to deploying your agent! Here are some ways you can deploy your agent:
 
-* [Comet Opik](https://github.com/comet-ml/opik) is an open-source LLM observability and evaluation platform that natively supports ADK [docs](https://www.comet.com/docs/opik/tracing/integrations/adk).
+* Deploy to [Agent Engine](../deploy/agent-engine.md), the easiest way to deploy
+  your ADK agents to a managed service in Vertex AI on Google Cloud.
+* Deploy to [Cloud Run](../deploy/cloud-run.md) and have full control over how
+  you scale and manage your agents using serverless architecture on Google
+  Cloud.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,9 @@ markdown_extensions:
 # Plugins
 plugins:
   - search
+  - redirects:
+      redirect_maps:
+        'get-started/local-testing.md': 'get-started/testing.md'
 
 # Navigation
 nav:
@@ -92,7 +95,7 @@ nav:
     - Quickstart: get-started/quickstart.md
     - Quickstart (streaming): get-started/quickstart-streaming.md
     - Tutorial: get-started/tutorial.md
-    - Local testing: get-started/local-testing.md
+    - Testing: get-started/testing.md
     - Sample agents: https://github.com/google/adk-samples
     - About ADK: get-started/about.md
   - Agents:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 mkdocs-material
+mkdocs-redirects


### PR DESCRIPTION
This PR updates the content and applies formatting fixes to the testing page and expands its scope to include local and remote testing solutions. In the future, we can consider a separate guide that covers tools and workflows related to monitoring, tracing, and observability.

- Rename local testing page to testing
- Add `mkdocs-redirects` pkg and config, add redirect from old page to new page
- Simplify ToC for readability