### PR TITLE
Use third-person (this agent) instead of second-person (you) in the agent description

### DIFF
--- a/examples/python/snippets/tools/function-tools/func_tool.py
+++ b/examples/python/snippets/tools/function-tools/func_tool.py
@@ -36,8 +36,8 @@ def get_stock_price(symbol: str):
 stock_price_agent = Agent(
     model='gemini-2.0-flash',
     name='stock_agent',
-    instruction= 'You are an agent to retrieve stock prices. If a ticker symbol is provided, fetch the current price. If only a company name is given, first perform a Google search to find the correct ticker symbol before retrieving the stock price.If the provided ticker symbol is invalid or data cannot be retrieved, inform the user that the stock price could not be found.',
-    description='You specialize in retrieving real-time stock prices. Given a stock ticker symbol (e.g., AAPL, GOOG, MSFT) or the stock name, use the tools and reliable data sources to provide the most up-to-date price.',
+    instruction= 'You are an agent who retrieves stock prices. If a ticker symbol is provided, fetch the current price. If only a company name is given, first perform a Google search to find the correct ticker symbol before retrieving the stock price. If the provided ticker symbol is invalid or data cannot be retrieved, inform the user that the stock price could not be found.',
+    description='This agent specializes in retrieving real-time stock prices. Given a stock ticker symbol (e.g., AAPL, GOOG, MSFT) or the stock name, use the tools and reliable data sources to provide the most up-to-date price.',
     tools=[get_stock_price],
 )
 


### PR DESCRIPTION
Changed the agent's description from second-person (you) to third-person (this agent).

I also fixed a couple of grammatical errors in the agent's instructions.