### PR TITLE
fix: Update google/adk-docs repository link

### DIFF
--- a/docs/contributing-guide.md
+++ b/docs/contributing-guide.md
@@ -6,7 +6,7 @@ This guide provides information on how to get involved.
 
 Contains the core Python library source code.
 
-## 2. [`google/adk-docs`](https://google.github.io/adk-docs/)
+## 2. [`google/adk-docs`](https://github.com/google/adk-docs)
 
 Contains the source for the documentation site you are currently reading.
 


### PR DESCRIPTION
The original link was point to the site itself rather than the git repository.