### PR TITLE
Update responsible-agents.md: fixing typo on constrain verb

### DIFF
--- a/docs/guides/responsible-agents.md
+++ b/docs/guides/responsible-agents.md
@@ -50,7 +50,7 @@ The identity that a *tool* uses to perform actions on external systems is a cruc
 
 #### Agent-Auth
 
-The **tool interacts with external systems using the agent's own identity** (e.g., a service account). The agent identity must be explicitly authorized in the external system access policies, like adding an agent's service account to a database's IAM policy for read access. Such policies constraint the agent in only performing actions that the developer intended as possible: by giving read-only permissions to a resource, no matter what the model decides, the tool will be prohibited from performing write actions.
+The **tool interacts with external systems using the agent's own identity** (e.g., a service account). The agent identity must be explicitly authorized in the external system access policies, like adding an agent's service account to a database's IAM policy for read access. Such policies constrain the agent in only performing actions that the developer intended as possible: by giving read-only permissions to a resource, no matter what the model decides, the tool will be prohibited from performing write actions.
 
 This approach is simple to implement, and it is **appropriate for agents where all users share the same level of access.** If not all users have the same level of access, such an approach alone doesn't provide enough protection and must be complemented with other techniques below. In tool implementation, ensure that logs are created to maintain attribution of actions to users, as all agents' actions will appear as coming from the agent.
 


### PR DESCRIPTION
Hi,
Just fixing  typo for verb to constrain spelled with superfluous 't'.

See commit diff for details.

Didier