### PR TITLE
Initial commit of Community Resources page

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -1,18 +1,19 @@
 # Community Resources
 
-!!! Note
+Welcome! This page highlights resources maintained by the Agent Development Kit
+community.
+
+!!! info
 
     Google and the ADK team do not provide support for the content linked in
     these external community resources.
 
-Welcome! This page highlights resources maintained by the Agent Development Kit
-community.
-
 ## Translations
 
-Community-provided translations of the official documentation.
+Community-provided translations of the ADK documentation.
 
-*   **[adk.wiki - Chinese Documentation](https://adk.wiki/)**
+*   **[adk.wiki - ADK Documentation (Chinese)](https://adk.wiki/)**
+
     > adk.wiki is the Chinese version of the Agent Development Kit
     > documentation, maintained by an individual. The documentation is
     > continuously updated and translated to provide a localized reading
@@ -20,26 +21,18 @@ Community-provided translations of the official documentation.
 
 ## Tutorials, Guides & Blog Posts
 
-*(Find community-written guides covering ADK features, use cases, and
-integrations here.)*
+*Find community-written guides covering ADK features, use cases, and
+integrations here.*
 
 ## Videos & Screencasts
 
-*(Discover video walkthroughs, talks, and demos showcasing ADK.)*
+*Discover video walkthroughs, talks, and demos showcasing ADK.*
 
 ## Contributing Your Resource
 
 Have an ADK resource to share (tutorial, translation, tool, video, example)?
-Help grow the ecosystem!
 
-- Submit a Pull Request (PR) to this page in the
-  [`google/adk-docs`](https://github.com/google/adk-docs/pulls) repository.
-- Open an issue in the
-  [`google/adk-docs`](https://github.com/google/adk-docs/issues) repository.
-- In your PR or issue, provide a link, brief description, and category.
-- Refer to the [Contributing Guide](contributing-guide.md) for details
-  (including the CLA).
-  - Want to discuss first? Join our
-    [GitHub Discussions](https://github.com/google/adk-python/discussions).
+Refer to the steps in the [Contributing Guide](contributing-guide.md) for more
+information on how to get involved!
 
 Thank you for your contributions to Agent Development Kit! ❤️

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,0 +1,45 @@
+# Community Resources
+
+!!! Note
+
+    Google and the ADK team do not provide support for the content linked in
+    these external community resources.
+
+Welcome! This page highlights resources maintained by the Agent Development Kit
+community.
+
+## Translations
+
+Community-provided translations of the official documentation.
+
+*   **[adk.wiki - Chinese Documentation](https://adk.wiki/)**
+    > adk.wiki is the Chinese version of the Agent Development Kit
+    > documentation, maintained by an individual. The documentation is
+    > continuously updated and translated to provide a localized reading
+    > experience for developers in China.
+
+## Tutorials, Guides & Blog Posts
+
+*(Find community-written guides covering ADK features, use cases, and
+integrations here.)*
+
+## Videos & Screencasts
+
+*(Discover video walkthroughs, talks, and demos showcasing ADK.)*
+
+## Contributing Your Resource
+
+Have an ADK resource to share (tutorial, translation, tool, video, example)?
+Help grow the ecosystem!
+
+- Submit a Pull Request (PR) to this page in the
+  [`google/adk-docs`](https://github.com/google/adk-docs/pulls) repository.
+- Open an issue in the
+  [`google/adk-docs`](https://github.com/google/adk-docs/issues) repository.
+- In your PR or issue, provide a link, brief description, and category.
+- Refer to the [Contributing Guide](contributing-guide.md) for details
+  (including the CLA).
+  - Want to discuss first? Join our
+    [GitHub Discussions](https://github.com/google/adk-python/discussions).
+
+Thank you for your contributions to Agent Development Kit! ❤️

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -91,7 +91,7 @@ Create a `.env` file in the same folder:
 touch multi_tool_agent/.env
 ```
 
-More instructions about this file are describe in the next section on [Set up the model](#set-up-the-model).
+More instructions about this file are described in the next section on [Set up the model](#set-up-the-model).
 
 ![intro_components.png](../assets/quickstart-flow-tool.png)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,5 +143,6 @@ nav:
     - evaluate/index.md
   - Guides:
     - Responsible Agents: guides/responsible-agents.md
+  - Community Resources: community.md
   - Contributing Guide: contributing-guide.md
   - API Reference: api-reference/index.html


### PR DESCRIPTION
Closes #80. Creates a community page with a link to the translated ADK docs page mentioned in #79, and opens up the opportunity for us to showcase the latest community resources for ADK!