### PR TITLE
Fix social cards - Update image URL

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -26,7 +26,7 @@
   <meta property="og:type" content="website">
   <meta property="og:title" content="Agent Development Kit">
   <meta property="og:description" content="Build powerful multi-agent systems with Agent Development Kit">
-  <meta property="og:image" content="https://google.github.io/adk-docs/assets/agent-development-kit.png">
+  <meta property="og:image" content="https://google.github.io/adk-docs/assets/adk-social-card.png">
 
   <!-- Twitter Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
@@ -34,5 +34,5 @@
   <meta property="twitter:url" content="https://google.github.io/adk-docs">
   <meta name="twitter:title" content="Agent Development Kit">
   <meta name="twitter:description" content="Build powerful multi-agent systems with Agent Development Kit">
-  <meta name="twitter:image" content="https://google.github.io/adk-docs/assets/agent-development-kit.png">
+  <meta name="twitter:image" content="https://google.github.io/adk-docs/assets/adk-social-card.png">
 {% endblock %}


### PR DESCRIPTION
Followup PR to #84 and #85 to fix the URL path to the ADK social media preview card image.