### PR TITLE
Update docs to add root agent instead of summary agent

### DIFF
--- a/examples/python/snippets/tools/function-tools/summarizer.py
+++ b/examples/python/snippets/tools/function-tools/summarizer.py
@@ -25,7 +25,7 @@ root_agent = Agent(
 # Session and Runner
 session_service = InMemorySessionService()
 session = session_service.create_session(app_name=APP_NAME, user_id=USER_ID, session_id=SESSION_ID)
-runner = Runner(agent=summary_agent, app_name=APP_NAME, session_service=session_service)
+runner = Runner(agent=root_agent, app_name=APP_NAME, session_service=session_service)
 
 
 # Agent Interaction


### PR DESCRIPTION
There was a mistake in the Agent-as-a-tool example in the documentation. There should be `root_agent` passed in the Runner instead of `summary_agent` which i fixed in this PR.