### PR TITLE
Adds permalinks to headings - update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,9 @@ markdown_extensions:
       slugify: !!python/object/apply:pymdownx.slugs.slugify
         kwds:
           case: lower
+  - toc:
+      permalink: true
+
 
 # Plugins
 plugins:


### PR DESCRIPTION
Closes #92 

Adding material toc - permalinks to docs. 

Enables permalinks to all headings - we can change to an anchor or something fancier if you wish later on.

<img width="344" alt="2025-04-15_23-27-14" src="https://github.com/user-attachments/assets/3f782f75-1237-4ea4-8352-7378b001f7a8" />
