### PR TITLE
docs: Fix init.py -> __init__.py

### DIFF
--- a/docs/evaluate/index.md
+++ b/docs/evaluate/index.md
@@ -316,7 +316,7 @@ adk eval \
 
 Here are the details for each command line argument:
 
-* `AGENT_MODULE_FILE_PATH`: The path to the `init.py` file that contains a module by the name "agent". "agent" module contains a `root_agent`.  
+* `AGENT_MODULE_FILE_PATH`: The path to the `__init__.py` file that contains a module by the name "agent". "agent" module contains a `root_agent`.  
 * `EVAL_SET_FILE_PATH`: The path to evaluations file(s). You can specify one or more eval set file paths. For each file, all evals will be run by default. If you want to run only specific evals from a eval set, first create a comma separated list of eval names and then add that as a suffix to the eval set file name, demarcated by a colon `:` .
 * For example: `sample_eval_set_file.json:eval_1,eval_2,eval_3`  
   `This will only run eval_1, eval_2 and eval_3 from sample_eval_set_file.json`  


### PR DESCRIPTION
Thanks to great docs.

I first read https://google.github.io/adk-docs/get-started/quickstart/#__init__py ,
then read evaluation doc and I found that `init.py` is wired.

Refer to https://github.com/google/adk-python/blob/v0.1.0/src/google/adk/cli/cli_tools_click.py#L111

```
The path to the __init__.py file that contains a
```