### PR TITLE
Docs: Quickstart (streaming): Correct the agent name in drop-down menu

### DIFF
--- a/docs/get-started/quickstart-streaming.md
+++ b/docs/get-started/quickstart-streaming.md
@@ -139,7 +139,7 @@ adk web
 
 Open the URL provided (usually `http://localhost:8000` or
 `http://127.0.0.1:8000`) **directly in your browser**. This connection stays
-entirely on your local machine. Select `basic_search_agent`.
+entirely on your local machine. Select `google_search_agent`.
 
 ### Try with text
 


### PR DESCRIPTION
Issue:
A typo was identified in the file **get-started/quickstart-streaming.md**. In the demo streaming agent example, documentation mentions to select `**basic_search_agent**` from agent drop-down menu. However, this agent name does not show up and `**google_search_agent**` needs to be selected instead as only the directory name shows up in the drop-down menu.

Fix:
The typographical error of agent name has been corrected in get-started/quickstart-streaming.md file. This change improves the accuracy and readability of the project's documentation.

PFB screenshot for reference:
![image](https://github.com/user-attachments/assets/be90e50b-a7dc-4451-a151-a91350bcdcc7)
