### PR TITLE
fix: Change redirect for old tutorial page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,7 +89,7 @@ plugins:
   - redirects:
       redirect_maps:
         'get-started/local-testing.md': 'get-started/testing.md'
-        'get-started/tutorials.md': 'tutorials/index.md'
+        'get-started/tutorial.md': 'tutorials/index.md'
 
 # Navigation
 nav:


### PR DESCRIPTION
Followup to #143 that fixes the redirect page / URL for the old tutorial page.