### PR TITLE
fix: Update redirects and links for Safety and Security page

### DIFF
--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -37,7 +37,7 @@ agents, capable of handling complex tasks and workflows.
 
     Create your first ADK multi-agent.
 
-    [:octicons-arrow-right-24: More information](tutorial.md)
+    [:octicons-arrow-right-24: More information](../tutorials/index.md)
 
 -   :material-rocket-launch-outline: **Discover sample agents**
 

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -178,16 +178,16 @@ There are multiple ways to interact with your agent:
     ![adk-web-dev-ui-function-call.png](../assets/adk-web-dev-ui-function-call.png)
 
     **Step 5.** You can also enable your microphone and talk to your agent:
-    
+
     !!!note "Model support for voice/video streaming"
-    
+
         In order to use voice/video streaming in ADK, you will need to use Gemini models that support the Live API. You can find the **model ID(s)** that supports the Gemini Live API in the documentation:
 
         - [Google AI Studio: Gemini Live API](https://ai.google.dev/gemini-api/docs/models#live-api)
         - [Vertex AI: Gemini Live API](https://cloud.google.com/vertex-ai/generative-ai/docs/live-api)
 
         You can then replace the `model` string in `root_agent` in the `agent.py` file you created earlier ([jump to section](#agentpy)). Your code should look something like:
-        
+
         ```py
         root_agent = Agent(
             name="weather_time_agent",
@@ -236,7 +236,7 @@ You've successfully created and interacted with your first agent using ADK!
 ## 🛣️ Next steps
 
 * **Go to the tutorial**: Learn how to add memory, session, state to your agent:
-  [tutorial](tutorial.md).
+  [tutorial](../tutorials/index.md).
 * **Delve into advanced configuration:** Explore the [setup](installation.md)
   section for deeper dives into project structure, configuration, and other
   interfaces.

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ orchestration**.
 
 <p style="text-align:center;">
   <a href="get-started/quickstart/" class="md-button" style="margin:3px">Quickstart</a>
-  <a href="get-started/tutorial/" class="md-button" style="margin:3px">Tutorial</a>
+  <a href="tutorials/" class="md-button" style="margin:3px">Tutorials</a>
   <a href="http://github.com/google/adk-samples" class="md-button" target="_blank" style="margin:3px">Sample Agents</a>
   <a href="api-reference/" class="md-button" style="margin:3px">API Reference</a>
   <a href="contributing-guide/" class="md-button" style="margin:3px">Contribute ❤️</a>

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,8 +1,15 @@
 # ADK Tutorials!
 
-Get started with the Agent Development Kit (ADK) through our collection of practical guides. These tutorials are designed in a simple, progressive, step-by-step fashion, introducing you to different ADK features and capabilities.
+Get started with the Agent Development Kit (ADK) through our collection of
+practical guides. These tutorials are designed in a simple, progressive,
+step-by-step fashion, introducing you to different ADK features and
+capabilities.
 
-This approach allows you to learn and build incrementally – starting with foundational concepts and gradually tackling more advanced agent development techniques. You'll explore how to apply these features effectively across various use cases, equipping you to build your own sophisticated agentic applications with ADK. Explore our collection below and happy building: 
+This approach allows you to learn and build incrementally – starting with
+foundational concepts and gradually tackling more advanced agent development
+techniques. You'll explore how to apply these features effectively across
+various use cases, equipping you to build your own sophisticated agentic
+applications with ADK. Explore our collection below and happy building:
 
 <div class="grid cards" markdown>
 
@@ -10,17 +17,11 @@ This approach allows you to learn and build incrementally – starting with foun
 
     ---
 
-    Learn to build an intelligent multi-agent weather bot and master key ADK features: defining Tools, using multiple LLMs (Gemini, GPT, Claude) with LiteLLM, orchestrating agent delegation, adding memory with session state, and ensuring safety via callbacks.
+    Learn to build an intelligent multi-agent weather bot and master key ADK
+    features: defining Tools, using multiple LLMs (Gemini, GPT, Claude) with
+    LiteLLM, orchestrating agent delegation, adding memory with session state,
+    and ensuring safety via callbacks.
 
     [:octicons-arrow-right-24: Start learning here](agent-team.md)
-
--   :material-console-line: **More Tutorials Coming Soon!**
-
-    ---
-
-    Stay tuned for upcoming tutorials covering advanced ADK topics, including dedicated guides on Guardrails, Agent-to-Agent communication (A2A) & Multi-Context Prompting (MCP), advanced Delegation patterns (like Human-in-the-Loop and Agent Transfer), Multi-Tool usage, and Database integrations.
-
-    [:octicons-arrow-right-24: Check back later for updates]()
-
 
 </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ plugins:
       redirect_maps:
         'get-started/local-testing.md': 'get-started/testing.md'
         'get-started/tutorial.md': 'tutorials/index.md'
+        'guides/responsible-agents.md': 'safety/index.md'
 
 # Navigation
 nav:


### PR DESCRIPTION
A followup PR to #151 to add redirects for Safety and Security page. Also fixed links to tutorial page.