### PR TITLE
Add Windows Encoding Note for LiteLLM

### DIFF
--- a/docs/agents/models.md
+++ b/docs/agents/models.md
@@ -176,6 +176,23 @@ layer, providing a standardized, OpenAI-compatible interface to over 100+ LLMs.
         )
         ```
 
+## Avoiding LiteLLM UnicodeDecodeError on Windows
+
+When using ADK agents with LiteLlm on Windows, users might encounter the following error:
+```
+UnicodeDecodeError: 'charmap' codec can't decode byte...
+```
+This issue occurs because `litellm` (used by LiteLlm) reads cached files (e.g., model pricing information) using the default Windows encoding (`cp1252`) instead of UTF-8.
+Windows users can prevent this issue by setting the `PYTHONUTF8` environment variable to `1`. This forces Python to use UTF-8 globally.
+**Example (PowerShell):**
+```powershell
+# Set for current session
+$env:PYTHONUTF8 = "1"
+# Set persistently for the user
+[System.Environment]::SetEnvironmentVariable('PYTHONUTF8', '1', [System.EnvironmentVariableTarget]::User)
+Applying this setting ensures that Python reads cached files using UTF-8, avoiding the decoding error.
+```
+
 ## Using Open & Local Models via LiteLLM
 
 For maximum control, cost savings, privacy, or offline use cases, you can run


### PR DESCRIPTION
When using ADK agents with `LiteLlm` on Windows, users might encounter a `UnicodeDecodeError: 'charmap' codec can't decode byte...` error. This often happens when `litellm` (used by `LiteLlm`) tries to read cached files (like model pricing information) using the default Windows encoding (`cp1252`) instead of UTF-8.

**Suggested Improvement:**

Add a note to the documentation, specifically on the Models page or where `LiteLlm` is discussed, recommending that Windows users set the `PYTHONUTF8` environment variable to `1`. This forces Python to use UTF-8 globally and can prevent this decoding error.

**Example (PowerShell):**

```powershell
# Set for current session
$env:PYTHONUTF8 = "1"

# Set persistently for the user
[System.Environment]::SetEnvironmentVariable('PYTHONUTF8', '1', [System.EnvironmentVariableTarget]::User)