### PR TITLE
Change eval_dataset to eval_dataset_file_path_or_dir

### DIFF
--- a/docs/evaluate/index.md
+++ b/docs/evaluate/index.md
@@ -254,7 +254,7 @@ def test_with_single_test_file():
     """Test the agent's basic ability via a session file."""
     AgentEvaluator.evaluate(
         agent_module="tests.integration.fixture.home_automation_agent",
-        eval_dataset="tests/integration/fixture/home_automation_agent/simple_test.test.json",
+        eval_dataset_file_path_or_dir="tests/integration/fixture/home_automation_agent/simple_test.test.json",
     )
 ```
 
@@ -287,7 +287,7 @@ def test_with_single_test_file():
     """Test the agent's basic ability via a session file."""
     AgentEvaluator.evaluate(
         agent_module="tests.integration.fixture.trip_planner_agent",
-        eval_dataset="tests/integration/fixture/trip_planner_agent/simple_test.test.json",
+        eval_dataset_file_path_or_dir="tests/integration/fixture/trip_planner_agent/simple_test.test.json",
         initial_session_file="tests/integration/fixture/trip_planner_agent/initial.session.json"
     )
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -585,7 +585,7 @@ Assessing agent performance.
 ### Methods (`adk web`, `pytest`, `adk eval`)
 
 *   **`adk web`:** Interactive evaluation via "Eval" tab in the dev UI. Can create evalsets from sessions.
-*   **`pytest`:** Programmatic evaluation using `AgentEvaluator.evaluate(agent_module=..., eval_dataset=...)`. Good for CI/CD.
+*   **`pytest`:** Programmatic evaluation using `AgentEvaluator.evaluate(agent_module=..., eval_dataset_file_path_or_dir=...)`. Good for CI/CD.
 *   **`adk eval <AGENT_MODULE> <EVAL_SET_FILE(S)>`:** CLI command to run evaluations on evalsets.
 
 ### Criteria


### PR DESCRIPTION
This section of the docs doesn't work: https://google.github.io/adk-docs/evaluate/#example-test-code
`eval_dataset` was renamed to `eval_dataset_file_path_or_dir`

I have been struggling to get the evaluation working following the docs, it would be great if someone could review the evaluation docs.