### PR TITLE
fix: the ParallelAgent execute run_async instead of run() 

### DIFF
--- a/docs/agents/workflow-agents/parallel-agents.md
+++ b/docs/agents/workflow-agents/parallel-agents.md
@@ -16,7 +16,7 @@ This approach is particularly beneficial for operations like multi-source data r
 
 When the `ParallelAgent`'s `run_async()` method is called:
 
-1. **Concurrent Execution:** It initiates the `run()` method of *each* sub-agent present in the `sub_agents` list *concurrently*.  This means all the agents start running at (approximately) the same time.
+1. **Concurrent Execution:** It initiates the `run_async()` method of *each* sub-agent present in the `sub_agents` list *concurrently*.  This means all the agents start running at (approximately) the same time.
 2. **Independent Branches:**  Each sub-agent operates in its own execution branch.  There is ***no* automatic sharing of conversation history or state between these branches** during execution.
 3. **Result Collection:** The `ParallelAgent` manages the parallel execution and, typically, provides a way to access the results from each sub-agent after they have completed (e.g., through a list of results or events). The order of results may not be deterministic.
 


### PR DESCRIPTION
fix: the ParallelAgent execute run_async instead of run() base on this line [1].
[1]https://github.com/google/adk-python/blob/main/src/google/adk/agents/parallel_agent.py#L94