### PR TITLE
fix: google_search import issue

### DIFF
--- a/docs/get-started/quickstart-streaming.md
+++ b/docs/get-started/quickstart-streaming.md
@@ -51,7 +51,7 @@ For `model`, please double check the model ID as described earlier in the [Model
 
 ```py
 from google.adk.agents import Agent
-from google.adk.tools import built_in_google_search  # Import the tool
+from google.adk.tools import google_search  # Import the tool
 
 root_agent = Agent(
    # A unique name for the agent.
@@ -64,7 +64,7 @@ root_agent = Agent(
    # Instructions to set the agent's behavior.
    instruction="You are an expert researcher. You always stick to the facts.",
    # Add google_search tool to perform grounding with Google search.
-   tools=[built_in_google_search]
+   tools=[google_search]
 )
 ```
 


### PR DESCRIPTION
This PR fixes #216 

fixed the google search import from `built_in_google_search` to  `google_search`