### PR TITLE
docs: add an option in the CLI to enable or disable the reload feature

### DIFF
--- a/docs/get-started/quickstart-streaming.md
+++ b/docs/get-started/quickstart-streaming.md
@@ -137,6 +137,10 @@ Then, run the dev UI:
 adk web
 ```
 
+!!!info "Note for Windows users"
+
+    When hitting the `_make_subprocess_transport NotImplementedError`, consider using `adk web --no-reload` instead.
+
 Open the URL provided (usually `http://localhost:8000` or
 `http://127.0.0.1:8000`) **directly in your browser**. This connection stays
 entirely on your local machine. Select `google_search_agent`.

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -156,6 +156,10 @@ There are multiple ways to interact with your agent:
     adk web
     ```
 
+    !!!info "Note for Windows users"
+
+        When hitting the `_make_subprocess_transport NotImplementedError`, consider using `adk web --no-reload` instead.
+
     **Step 1:** Open the URL provided (usually `http://localhost:8000` or
     `http://127.0.0.1:8000`) directly in your browser.
 

--- a/docs/tools/mcp-tools.md
+++ b/docs/tools/mcp-tools.md
@@ -160,6 +160,10 @@ cd ./adk_agent_samples
 adk web
 ```
 
+!!!info "Note for Windows users"
+
+    When hitting the `_make_subprocess_transport NotImplementedError`, consider using `adk web --no-reload` instead.
+
 A successfully MCPTool interaction will yield a response by accessing your local file system, like below:
 
 <img src="../../assets/adk-tool-mcp-filesystem-adk-web-demo.png" alt="MCP with ADK Web - FileSystem Example">
@@ -234,6 +238,10 @@ Run `adk web` from the adk_agent_samples directory (ensure your virtual environm
 cd ./adk_agent_samples
 adk web
 ```
+
+!!!info "Note for Windows users"
+
+    When hitting the `_make_subprocess_transport NotImplementedError`, consider using `adk web --no-reload` instead.
 
 A successfully MCPTool interaction will yield a response with a route plan, like below:
 
@@ -360,6 +368,10 @@ Run `adk web` from the adk_agent_samples directory (ensure your virtual environm
 cd ./adk_agent_samples
 adk web
 ```
+
+!!!info "Note for Windows users"
+
+    When hitting the `_make_subprocess_transport NotImplementedError`, consider using `adk web --no-reload` instead.
 
 A successfully interaction will yield a response by accessing your remote FastMCP server, like below:
 


### PR DESCRIPTION
add an option in the CLI to enable or disable the reload feature. So users(esp. windows) can disable this if they come across the '_make_subprocess_transport NotImplementedError' bug on windows.

[issue-#414](https://github.com/google/adk-python/issues/414) 
[pull-#415](https://github.com/google/adk-python/pull/415)