### PR TITLE
fix: Correct broken [setup]() link in MCP Tools documentation

### DIFF
--- a/docs/tools/mcp-tools.md
+++ b/docs/tools/mcp-tools.md
@@ -17,7 +17,7 @@ This guide covers two primary integration patterns:
 
 Before you begin, ensure you have the following set up:
 
-* **Set up ADK:** Follow the standard ADK \[setup\]() instructions in the quickstart.
+* **Set up ADK:** Follow the standard ADK \[setup\](https://google.github.io/adk-docs/get-started/quickstart/#venv-install) instructions in the quickstart.
 * **Install/update Python:** MCP requires Python version of 3.9 or higher.
 * **Setup Node.js and npx:** Many community MCP servers are distributed as Node.js packages and run using `npx`. Install Node.js (which includes npx) if you haven't already. For details, see [https://nodejs.org/en](https://nodejs.org/en).
 * **Verify Installations:** Confirm `adk` and `npx` are in your PATH within the activated virtual environment:


### PR DESCRIPTION
**Describe the bug**
In the "Set up ADK" section under Tools > MCP Tools > Prerequisites, the 'setup' markdown link is missing its URL, resulting in an empty link.

**To Reproduce**

1. Go to: https://google.github.io/adk-docs/tools/mcp-tools/#what-is-model-context-protocol-mcp
2. Scroll to the "Set up ADK" section
3. The' [setup] ()' link is missing its URL.

**Expected behavior**
The link should direct users to the proper ADK setup instructions.

*Screenshots*

![Image](https://github.com/user-attachments/assets/82d8c22e-5ba4-451f-b9b3-210069e9028d)

**Versions**
- OS: Windows 11
- ADK version: 0.5.0
- Python version: 3.9.0

**Additional context**
The fix adds the correct link to the setup guide in place of the empty placeholder.