### PR TITLE
docs: update MCP Toolbox docs

### DIFF
--- a/docs/tools/google-cloud-tools.md
+++ b/docs/tools/google-cloud-tools.md
@@ -351,8 +351,8 @@ pip install toolbox-core
 
 ### Loading Toolbox Tools
 
-Once you’ve Toolbox server is configured and up and running, you can load tools
-from your server using the ADK:
+Once you’re Toolbox server is configured and up and running, you can load tools
+from your server using ADK:
 
 ```python
 from google.adk.agents import Agent

--- a/docs/tools/google-cloud-tools.md
+++ b/docs/tools/google-cloud-tools.md
@@ -340,29 +340,20 @@ documentation:
 * [Installing the Server](https://googleapis.github.io/genai-toolbox/getting-started/introduction/#installing-the-server)
 * [Configuring Toolbox](https://googleapis.github.io/genai-toolbox/getting-started/configure/)
 
-### Install client SDK
-
-ADK relies on the `toolbox-langchain` python package to use Toolbox. Install the
-package before getting started:
-
-```shell
-pip install toolbox-langchain langchain
-```
-
 ### Loading Toolbox Tools
 
-Once you’ve Toolbox server is configured and up and running, you can load tools
-from your server using the ADK:
+Once you’re Toolbox server is configured and up and running, you can load tools
+from your server using ADK:
 
 ```py
-from google.adk.tools.toolbox_tool import ToolboxTool
+from google.adk.tools import toolbox
 
-toolbox = ToolboxTool("https://127.0.0.1:5000")
+toolbox_client = toolbox.ToolboxSyncClient("https://127.0.0.1:5000")
 
 # Load a specific set of tools
-tools = toolbox.get_toolset(toolset_name='my-toolset-name'),
+tools = toolbox_client.load_toolset('my-toolset-name')
 # Load single tool
-tools = toolbox.get_tool(tool_name='my-tool-name'),
+tools = toolbox_client.load_tool('my-tool-name')
 
 root_agent = Agent(
     ...,

--- a/docs/tools/google-cloud-tools.md
+++ b/docs/tools/google-cloud-tools.md
@@ -340,20 +340,30 @@ documentation:
 * [Installing the Server](https://googleapis.github.io/genai-toolbox/getting-started/introduction/#installing-the-server)
 * [Configuring Toolbox](https://googleapis.github.io/genai-toolbox/getting-started/configure/)
 
+### Install client SDK
+
+ADK relies on the `toolbox-core` python package to use Toolbox. Install the
+package before getting started:
+
+```shell
+pip install toolbox-core
+```
+
 ### Loading Toolbox Tools
 
-Once you’re Toolbox server is configured and up and running, you can load tools
-from your server using ADK:
+Once you’ve Toolbox server is configured and up and running, you can load tools
+from your server using the ADK:
 
-```py
-from google.adk.tools import toolbox
+```python
+from google.adk.agents import Agent
+from toolbox_core import ToolboxSyncClient
 
-toolbox_client = toolbox.ToolboxSyncClient("https://127.0.0.1:5000")
+toolbox = ToolboxSyncClient("https://127.0.0.1:5000")
 
 # Load a specific set of tools
-tools = toolbox_client.load_toolset('my-toolset-name')
+tools = toolbox.load_toolset('my-toolset-name'),
 # Load single tool
-tools = toolbox_client.load_tool('my-tool-name')
+tools = toolbox.load_tool('my-tool-name'),
 
 root_agent = Agent(
     ...,


### PR DESCRIPTION
This change is dependent on https://github.com/google/adk-python/pull/763 getting merged and released.

Updating MCP Toolbox for Databases section to now showcase lightweight `toolbox-core` import and guidance to use it directly over the soon to be deleted `ToolboxTool`

```python
from google.adk.agents import Agent
# NEW IMPORT
from toolbox_core import ToolboxSyncClient

# Full control over MCP Toolbox
toolbox = ToolboxSyncClient("http://127.0.0.1:5000")
toolbox_tools = toolbox.load_toolset("my-toolset")

root_agent = Agent(
    model="gemini-2.0-flash",
    name="root_agent",
    instruction=agent_instruction,
    # Add Toolbox tools to ADK agent
    tools=toolbox_tools,
)
```