### PR TITLE
fix: (#273) updated model name to Claude-3-Sonnet

### DIFF
--- a/examples/python/tutorial/agent_team/adk-tutorial/step_2 _anthropic/agent.py
+++ b/examples/python/tutorial/agent_team/adk-tutorial/step_2 _anthropic/agent.py
@@ -54,8 +54,8 @@ root_agent = Agent(
         name="weather_agent_gpt",
         # Key change: Wrap the LiteLLM model identifier
         model=LiteLlm(model=MODEL_CLAUDE_SONNET),
-        description="Provides weather information (using GPT-4o).",
-        instruction="You are a helpful weather assistant powered by GPT-4o. "
+        description="Provides weather information (using Claude-3-Sonnet-20240229).",
+        instruction="You are a helpful weather assistant powered by Claude-3-Sonnet-20240229. "
                     "Use the 'get_weather' tool for city weather requests. "
                     "Clearly present successful reports or polite error messages based on the tool's output status.",
         tools=[get_weather], # Re-use the same tool


### PR DESCRIPTION
**Description**

This is to address the issue #273 

Go to "cd adk-docs/examples/python/tutorial/agent_team/adk-tutorial/" and inside step_2_anthropic, the model given is Claude-3-sonnet-20240229, but the model name given in "description" and "Instruction" under "root_agent" is "gpt-4o".

**Screenshot of the issue:**
![image](https://github.com/user-attachments/assets/45ddd0cd-3d91-4f0e-bfc7-b31a266a0024)


**Fix/Solution**

Updated the model name in description and instruction as "Claude-3-Sonnet-20240229".

**Screenshot after the fix:**

![image](https://github.com/user-attachments/assets/23030f6e-d7c4-4545-8cde-1fddea34723d)

I participate in Agent-Development-Kit Hackathon hosted by Google and Devpost, and it has bonus points for contribution. Hope this is a valid issue.


