### PR TITLE
Update multi-agent.md

### DIFF
--- a/docs/tutorials/multi-agent.md
+++ b/docs/tutorials/multi-agent.md
@@ -913,7 +913,7 @@ session_stateful = session_service_stateful.create_session(
 print(f"✅ Session '{SESSION_ID_STATEFUL}' created for user '{USER_ID_STATEFUL}'.")
 
 # Verify the initial state was set correctly
-retrieved_session = session_service_stateful.get_session(app_name=APP_NAME,
+retrieved_session = await session_service_stateful.get_session(app_name=APP_NAME,
                                                          user_id=USER_ID_STATEFUL,
                                                          session_id = SESSION_ID_STATEFUL)
 print("\n--- Initial Session State ---")


### PR DESCRIPTION
This addresses a bug in step 4.1 of multi-agent tutorial where `get_session()` was called without `await`, resulting in an AttributeError due to accessing the .state attribute on a coroutine object.

I have added await to the get_session(...) call to properly resolve the coroutine and access the session state. Verified that the session state prints correctly after retrieval. And ensured that the tutorial logic aligns with Python’s asynchronous execution model.