### PR TITLE
docs: add line break to render bullet points in agent-team.md

### DIFF
--- a/docs/tutorials/agent-team.md
+++ b/docs/tutorials/agent-team.md
@@ -451,6 +451,7 @@ Instead of passing only a model name string (which defaults to Google's Gemini m
 Make sure you have configured the necessary API keys for OpenAI and Anthropic in Step 0. We'll use the `call_agent_async` function (defined earlier, which now accepts `runner`, `user_id`, and `session_id`) to interact with each agent immediately after its setup.
 
 Each block below will:
+
 *   Define the agent using a specific LiteLLM model (`MODEL_GPT_4O` or `MODEL_CLAUDE_SONNET`).
 *   Create a *new, separate* `InMemorySessionService` and session specifically for that agent's test run. This keeps the conversation histories isolated for this demonstration.
 *   Create a `Runner` configured for the specific agent and its session service.


### PR DESCRIPTION
Without this change, there is a block that should be bulleted, but is rendering as a paragraph block:

<img width="693" alt="Screenshot 2025-05-28 at 11 07 16 AM" src="https://github.com/user-attachments/assets/ac823a1b-5960-40c2-a0dc-709c31007ef4" />
