### PR TITLE
docs: add line break to render bullet points in agent-team.md

### DIFF
--- a/docs/tutorials/agent-team.md
+++ b/docs/tutorials/agent-team.md
@@ -451,6 +451,7 @@ Instead of passing only a model name string (which defaults to Google's Gemini m
 Make sure you have configured the necessary API keys for OpenAI and Anthropic in Step 0. We'll use the `call_agent_async` function (defined earlier, which now accepts `runner`, `user_id`, and `session_id`) to interact with each agent immediately after its setup.
 
 Each block below will:
+
 *   Define the agent using a specific LiteLLM model (`MODEL_GPT_4O` or `MODEL_CLAUDE_SONNET`).
 *   Create a *new, separate* `InMemorySessionService` and session specifically for that agent's test run. This keeps the conversation histories isolated for this demonstration.
 *   Create a `Runner` configured for the specific agent and its session service.


### PR DESCRIPTION
Fixes this block that should be bullet points:
<img width="693" alt="Screenshot 2025-05-28 at 11 07 16 AM" src="https://github.com/user-attachments/assets/ce21f2c9-10e5-4126-9590-4678c1355230" />
