### PR TITLE
fix: remove incorrect reference to main.py in get-started streaming guide

### DIFF
--- a/docs/get-started/streaming/quickstart-streaming.md
+++ b/docs/get-started/streaming/quickstart-streaming.md
@@ -76,7 +76,7 @@ Notice how easily you integrated [grounding with Google Search](https://ai.googl
 
 ![intro_components.png](../../assets/quickstart-streaming-tool.png)
 
-Copy-paste the following code block to `__init__.py` and `main.py` files.
+Copy-paste the following code block to `__init__.py` file.
 
 ```py title="__init__.py"
 from . import agent


### PR DESCRIPTION
Removed the incorrect instruction to copy code into a non-existent `main.py` file. Now it only mentions `__init__.py`, matching the ADK streaming guide and avoiding confusion during setup.