### PR TITLE
[PR fixes]This PR is fixing multiple old PRs due to merge conflicts.

### DIFF
--- a/docs/agents/models.md
+++ b/docs/agents/models.md
@@ -286,6 +286,25 @@ layer, providing a standardized, OpenAI-compatible interface to over 100+ LLMs.
         )
         ```
 
+!!!info "Note for Windows users"
+
+    ### Avoiding LiteLLM UnicodeDecodeError on Windows
+    When using ADK agents with LiteLlm on Windows, users might encounter the following error:
+    ```
+    UnicodeDecodeError: 'charmap' codec can't decode byte...
+    ```
+    This issue occurs because `litellm` (used by LiteLlm) reads cached files (e.g., model pricing information) using the default Windows encoding (`cp1252`) instead of UTF-8.
+    Windows users can prevent this issue by setting the `PYTHONUTF8` environment variable to `1`. This forces Python to use UTF-8 globally.
+    **Example (PowerShell):**
+    ```powershell
+    # Set for current session
+    $env:PYTHONUTF8 = "1"
+    # Set persistently for the user
+    [System.Environment]::SetEnvironmentVariable('PYTHONUTF8', '1', [System.EnvironmentVariableTarget]::User)
+    Applying this setting ensures that Python reads cached files using UTF-8, avoiding the decoding error.
+    ```
+
+
 ## Using Open & Local Models via LiteLLM
 
 ![python_only](https://img.shields.io/badge/Supported_in-Python-blue)

--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -207,6 +207,11 @@ agent will be unable to function.
         ```shell
         adk web
         ```
+        
+        !!!info "Note for Windows users"
+
+            When hitting the `_make_subprocess_transport NotImplementedError`, consider using `adk web --no-reload` instead.
+
 
         **Step 1:** Open the URL provided (usually `http://localhost:8000` or
         `http://127.0.0.1:8000`) directly in your browser.

--- a/docs/get-started/streaming/quickstart-streaming.md
+++ b/docs/get-started/streaming/quickstart-streaming.md
@@ -137,6 +137,11 @@ Then, run the dev UI:
 adk web
 ```
 
+!!!info "Note for Windows users"
+
+    When hitting the `_make_subprocess_transport NotImplementedError`, consider using `adk web --no-reload` instead.
+
+
 Open the URL provided (usually `http://localhost:8000` or
 `http://127.0.0.1:8000`) **directly in your browser**. This connection stays
 entirely on your local machine. Select `google_search_agent`.

--- a/docs/sessions/session.md
+++ b/docs/sessions/session.md
@@ -15,10 +15,8 @@ are its key properties:
 
 *   **Identification (`id`, `appName`, `userId`):** Unique labels for the
     conversation.
-    *   `id`: A unique identifier for *this specific* conversation thread,
-        essential for retrieving it later.
-    *   `appName`: Identifies which agent application this conversation belongs
-        to.
+    * `id`: A unique identifier for *this specific* conversation thread, essential for retrieving it later. A SessionService object can handle multiple `Session`(s). This field identifies which particular session object are we referring to. For example, "test_id_modification".
+    * `app_name`: Identifies which agent application this conversation belongs to. For example, "id_modifier_workflow". 
     *   `userId`: Links the conversation to a particular user.
 *   **History (`events`):** A chronological sequence of all interactions
     (`Event` objects – user messages, agent responses, tool actions) that have

--- a/docs/tools/mcp-tools.md
+++ b/docs/tools/mcp-tools.md
@@ -17,7 +17,7 @@ This guide covers two primary integration patterns:
 
 Before you begin, ensure you have the following set up:
 
-* **Set up ADK:** Follow the standard ADK [setup instructions](../get-started/quickstart.md) in the quickstart.
+* **Set up ADK:** Follow the standard ADK [setup instructions](../get-started/quickstart.md/#venv-install) in the quickstart.
 * **Install/update Python/Java:** MCP requires Python version of 3.9 or higher for Python or Java 17+.
 * **Setup Node.js and npx:** **(Python only)** Many community MCP servers are distributed as Node.js packages and run using `npx`. Install Node.js (which includes npx) if you haven't already. For details, see [https://nodejs.org/en](https://nodejs.org/en).
 * **Verify Installations:** **(Python only)** Confirm `adk` and `npx` are in your PATH within the activated virtual environment:
@@ -53,6 +53,7 @@ This example demonstrates connecting to a local MCP server that provides file sy
 Create an `agent.py` file (e.g., in `./adk_agent_samples/mcp_agent/agent.py`). The `MCPToolset` is instantiated directly within the `tools` list of your `LlmAgent`.
 
 *   **Important:** Replace `"/path/to/your/folder"` in the `args` list with the **absolute path** to an actual folder on your local system that the MCP server can access.
+*   **Important:** Place the `.env` file in the parent directory of the `./adk_agent_samples` directory.
 
 ```python
 # ./adk_agent_samples/mcp_agent/agent.py
@@ -113,6 +114,11 @@ Navigate to the parent directory of `mcp_agent` (e.g., `adk_agent_samples`) in y
 cd ./adk_agent_samples # Or your equivalent parent directory
 adk web
 ```
+
+!!!info "Note for Windows users"
+
+    When hitting the `_make_subprocess_transport NotImplementedError`, consider using `adk web --no-reload` instead.
+
 
 Once the ADK Web UI loads in your browser:
 


### PR DESCRIPTION
…flicts, we are doing all those small changes in this PR. Each changes are listed below:

- #254 docs/sessions/session.md -> …part of session object's identification. In the session object identification description, it was unclear (for first time readers), what exactly is id, and app_name and how they are different. Added some examples according to my own understanding. Please change accordingly if you feel so. Thanks.

- #252 Multiple files: quickstart-streaming.md,  quickstart.md, mcp-tools.md add an option in the CLI to enable or disable the reload feature. So users(esp. windows) can disable this if they come across the '_make_subprocess_transport NotImplementedError' bug on windows.

- #179 docs/agents/models.md -> Add Windows Encoding Note for LiteLLM When using ADK agents with LiteLlm on Windows, users might encounter a UnicodeDecodeError: 'charmap' codec can't decode byte... error. This often happens when litellm (used by LiteLlm) tries to read cached files (like model pricing information) using the default Windows encoding (cp1252) instead of UTF-8.

- #170 docs/tools/mcp-tools.md  fix: update ADK setup link and add .env file location note in MCPTools.
Also resolved the issue: #169