### PR TITLE
fix: remove .as_dict() usage from final session state logging

### DIFF
--- a/docs/tutorials/agent-team.md
+++ b/docs/tutorials/agent-team.md
@@ -1562,7 +1562,7 @@ if 'runner_root_model_guardrail' in globals() and runner_root_model_guardrail:
         print(f"Guardrail Triggered Flag: {final_session.state.get('guardrail_block_keyword_triggered', 'Not Set (or False)')}")
         print(f"Last Weather Report: {final_session.state.get('last_weather_report', 'Not Set')}") # Should be London weather if successful
         print(f"Temperature Unit: {final_session.state.get('user_preference_temperature_unit', 'Not Set')}") # Should be Fahrenheit
-        # print(f"Full State Dict: {final_session.state.as_dict()}") # For detailed view
+        # print(f"Full State Dict: {final_session.state}") # For detailed view
     else:
         print("\n❌ Error: Could not retrieve final session state.")
 

--- a/docs/tutorials/agent-team.md
+++ b/docs/tutorials/agent-team.md
@@ -1853,7 +1853,7 @@ if 'runner_root_tool_guardrail' in globals() and runner_root_tool_guardrail:
         print(f"Tool Guardrail Triggered Flag: {final_session.state.get('guardrail_tool_block_triggered', 'Not Set (or False)')}")
         print(f"Last Weather Report: {final_session.state.get('last_weather_report', 'Not Set')}") # Should be London weather if successful
         print(f"Temperature Unit: {final_session.state.get('user_preference_temperature_unit', 'Not Set')}") # Should be Fahrenheit
-        # print(f"Full State Dict: {final_session.state.as_dict()}") # For detailed view
+        # print(f"Full State Dict: {final_session.state}") # For detailed view
     else:
         print("\n❌ Error: Could not retrieve final session state.")
 


### PR DESCRIPTION
This addresses a bug in the session inspection logic where `final_session.state.as_dict()` was being called. Since `final_session.state` is already a Python dictionary, calling `.as_dict()` results in:
```
AttributeError: 'dict' object has no attribute 'as_dict'
```

Changes Made:
- Removed the `.as_dict()` call.

Impact:
- Fixes the runtime error and ensures correct behavior when inspecting session state.