### PR TITLE
Add internal documentation link to "Output Key" section of LLM Agent docs

### DIFF
--- a/docs/agents/workflow-agents/sequential-agents.md
+++ b/docs/agents/workflow-agents/sequential-agents.md
@@ -35,7 +35,7 @@ A `SequentialAgent` is perfect for this:
 SequentialAgent(sub_agents=[CodeWriterAgent, CodeReviewerAgent, CodeRefactorerAgent])
 ```
 
-This ensures the code is written, *then* reviewed, and *finally* refactored, in a strict, dependable order. **The output from each sub-agent is passed to the next by storing them in state via [Output Key](../llm-agents.md)**.
+This ensures the code is written, *then* reviewed, and *finally* refactored, in a strict, dependable order. **The output from each sub-agent is passed to the next by storing them in state via [Output Key](../llm-agents.md#structuring-data-input_schema-output_schema-output_key)**.
 
 ???+ "Code"
 


### PR DESCRIPTION
Updated the Markdown link to point directly to the relevant section (output_key) within the LLM Agent documentation, instead of linking to the top of the page.