### PR TITLE
docs: specify ADK version requirement for tutorial compatibility

### DIFF
--- a/docs/tutorials/agent-team.md
+++ b/docs/tutorials/agent-team.md
@@ -93,6 +93,7 @@ If you prefer a setup that handles the runner and session management automatical
 
 **Ready to build your agent team? Let's dive in!**
 
+> **Note:** This tutorial works with adk version 1.0.0 and above
 
 ```python
 # @title Step 0: Setup and Installation


### PR DESCRIPTION
This PR adds a note at the beginning of the tutorial documentation to clarify that the tutorial requires `adk >= 1.0.0`. 

This helps prevent compatibility issues, as older versions may not support some async methods used in the examples.