### PR TITLE
docs: update community Translations

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -19,6 +19,20 @@ Community-provided translations of the ADK documentation.
     > continuously updated and translated to provide a localized reading
     > experience for developers in China.
 
+*   **[ADK Documentation (Korean, 한국어)](https://adk-labs.github.io/adk-docs/ko/)**
+
+    > the Korean version of the Agent Development Kit
+    > documentation, maintained by an individual. The documentation is
+    > continuously updated and translated to provide a localized reading
+    > experience for developers in South Korea.
+
+*   **[ADK Documentation (Japanese, 日本語)](https://adk-labs.github.io/adk-docs/ja/)**
+
+    > the Japanese version of the Agent Development Kit
+    > documentation, maintained by an individual. The documentation is
+    > continuously updated and translated to provide a localized reading
+    > experience for developers in Japan.
+
 ## Tutorials, Guides & Blog Posts
 
 *Find community-written guides covering ADK features, use cases, and


### PR DESCRIPTION
Hi,

I translated the ADK documentation into Korean & Japanese to support South Korea & Japan developers.

This PR includes:

A link update to include the Korean documentation.
- https://adk-labs.github.io/adk-docs/ko/

A link update to include the Japanese documentation.
- https://adk-labs.github.io/adk-docs/ja/


Thanks