### PR TITLE
fix: integration-connector code sample unformatted

### DIFF
--- a/docs/tools/google-cloud-tools.md
+++ b/docs/tools/google-cloud-tools.md
@@ -231,7 +231,7 @@ Connect your agent to enterprise applications using
 
     `ApplicationIntegrationToolset` now also supports providing auth_scheme and auth_credential for dynamic OAuth2 authentication for Integration Connectors. To use it create a tool similar to this within your `tools.py` file:
 
-     ```py
+    ```py
     from google.adk.tools.application_integration_tool.application_integration_toolset import ApplicationIntegrationToolset
     from google.adk.tools.openapi_tool.auth.auth_helpers import dict_to_auth_scheme
     from google.adk.auth import AuthCredential


### PR DESCRIPTION
Hey

Little issue that can be easily solved

So far :

![image](https://github.com/user-attachments/assets/8dad2b1a-2dee-4b41-891d-bc308c88c2a1)

As an extra space has somehow been added prior code block

Which is solved by removing that extra space

Reg,

LL