### PR TITLE
fix(docs): Fix broken pytest example code

### DIFF
--- a/docs/evaluate/index.md
+++ b/docs/evaluate/index.md
@@ -369,10 +369,12 @@ Here is an example of a `pytest` test case that runs a single test file:
 
 ```py
 from google.adk.evaluation.agent_evaluator import AgentEvaluator
+import pytest
 
-def test_with_single_test_file():
+@pytest.mark.asyncio
+async def test_with_single_test_file():
     """Test the agent's basic ability via a session file."""
-    AgentEvaluator.evaluate(
+    await AgentEvaluator.evaluate(
         agent_module="home_automation_agent",
         eval_dataset_file_path_or_dir="tests/integration/fixture/home_automation_agent/simple_test.test.json",
     )


### PR DESCRIPTION
The example code for Evaluation - PyTest was incorrect.
Since the evaluation functions were updated to async in [this commit](https://github.com/google/adk-python/commit/e7d9cf359a082904dfe1bcacbfebedfe73a64768), the PyTest example code should be updated.