### PR TITLE
Fixed example in Artifacts index.md

### DIFF
--- a/docs/artifacts/index.md
+++ b/docs/artifacts/index.md
@@ -350,7 +350,7 @@ The artifact interaction methods are available directly on instances of `Callbac
 
         async def save_generated_report_py(context: CallbackContext, report_bytes: bytes):
             """Saves generated PDF report bytes as an artifact."""
-            report_artifact = types.Part.from_data(
+            report_artifact = types.Part.from_bytes(
                 data=report_bytes,
                 mime_type="application/pdf"
             )


### PR DESCRIPTION
There's no `types.Part.from_data`; `types.Part.from_bytes` works as expected