### PR TITLE
 fix(mcp_tool): resolve import error for MCPToolset and StdioServerParameters

### DIFF
--- a/docs/tools/mcp-tools.md
+++ b/docs/tools/mcp-tools.md
@@ -391,7 +391,7 @@ Create an `agent.py` (e.g., in `./adk_agent_samples/mcp_client_agent/agent.py`):
 # ./adk_agent_samples/mcp_client_agent/agent.py
 import os
 from google.adk.agents import LlmAgent
-from google.adk.tools.mcp_tool import MCPToolset, StdioServerParameters
+from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, StdioServerParameters
 
 # IMPORTANT: Replace this with the ABSOLUTE path to your my_adk_mcp_server.py script
 PATH_TO_YOUR_MCP_SERVER_SCRIPT = "/path/to/your/my_adk_mcp_server.py" # <<< REPLACE

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -82018,7 +82018,7 @@ Create an `agent.py` (e.g., in `./adk_agent_samples/mcp_client_agent/agent.py`):
 # ./adk_agent_samples/mcp_client_agent/agent.py
 import os
 from google.adk.agents import LlmAgent
-from google.adk.tools.mcp_tool import MCPToolset, StdioServerParameters
+from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, StdioServerParameters
 
 # IMPORTANT: Replace this with the ABSOLUTE path to your my_adk_mcp_server.py script
 PATH_TO_YOUR_MCP_SERVER_SCRIPT = "/path/to/your/my_adk_mcp_server.py" # <<< REPLACE


### PR DESCRIPTION
This PR updates the import path for `MCPToolset` and `StdioServerParameters` to reflect the correct module structure within the `google.adk.tools.mcp_tool.mcp_toolset` package.

Error:
```
{"error": "Fail to load 'clockify_agent' module. cannot import name 'StdioServerParameters' from 'google.adk.tools.mcp_tool' (/Users/aslam/Library/Python/3.13/lib/python/site-packages/google/adk/tools/mcp_tool/init.py)"}
```

Old import:
```py
from google.adk.tools.mcp_tool import MCPToolset, StdioServerParameters
```

Updated import:
```py
from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, StdioServerParameters
```