### PR TITLE
use the before unused processEvent method

### DIFF
--- a/docs/get-started/streaming/quickstart-streaming-java.md
+++ b/docs/get-started/streaming/quickstart-streaming-java.md
@@ -470,6 +470,10 @@ public final class LiveAudioRun {
         if (!isRunning.get()) {
           break;
         }
+
+        AtomicBoolean audioReceived = new AtomicBoolean(false);
+        processEvent(event, audioReceived);
+        
         event.content().ifPresent(content -> content.parts().ifPresent(parts -> parts.forEach(part -> playAudioData(part, finalSpeakerLine))));
       }
 


### PR DESCRIPTION
processEvent was not used in the quickstart streaming example before. I thought that this would be a good place to use it.