### PR TITLE
Add new community maintained ADK client SDKs

### DIFF
--- a/docs/clients/index.md
+++ b/docs/clients/index.md
@@ -1,0 +1,11 @@
+# Clients
+
+The Agent Development Kit (ADK) exposes a FastAPI web server by either running `adk web` or `adk api_server`. If you prefer idomatic clients for calling ADK from other clients, libraries in different languages are available below:
+
+## Community maintained (unofficial)
+
+These are not owned or maintained by Google, but instead are community contributed.
+
+### TypeScript / Node.js
+
+- `google-adk-client-node` <https://github.com/bih/google-adk-client-node>


### PR DESCRIPTION
We're using ADK pretty heavily and really enjoying using it compared to other agent frameworks. As we've been exploring productionizing some of these prototypes, we've needed some reliable SDKs for communicating with the FastAPI endpoints provided by either `adk web` or `adk api_server`.

This adds a section containing the TypeScript / Node.js client we created based on the OpenAPI specification with a bit of idomatic styling. We plan on adding a bunch of clients in other languages, such as Python and Java and I'm sure the community can add others.

Thanks for all the hard work you're doing with ADK. Let me know if there's any changes we should make to better suit the information architecture you already have for the ADK docs!