### PR TITLE
fix(docs): fix wrong var name for memory_service

### DIFF
--- a/docs/sessions/express-mode.md
+++ b/docs/sessions/express-mode.md
@@ -91,7 +91,7 @@ instead initialize the memory object without any project or location.
            APP_ID = "your-reasoning-engine-id"
 
            # Project and location are not required when initializing with Vertex Express Mode
-           session_service = VertexAiMemoryBankService(agent_engine_id=APP_ID)
+           memory_service = VertexAiMemoryBankService(agent_engine_id=APP_ID)
            # Generate a memory from that session so the Agent can remember relevant details about the user
            # memory = await memory_service.add_session_to_memory(session)
            ```


### PR DESCRIPTION
Use the correct `memory_service` variable instead of the erroneous `session_service`