### PR TITLE
docs: add gcloud auth instructions for Vertex AI users in quickstart

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -222,6 +222,17 @@ agent will be unable to function.
     There are multiple ways to interact with your agent:
 
     === "Dev UI (adk web)"
+
+        !!! success "Authentication Setup for Vertex AI Users"
+            If you selected **"Gemini - Google Cloud Vertex AI"** in the previous step, you must authenticate with Google Cloud before launching the dev UI.
+            
+            Run this command and follow the prompts:
+            ```bash
+            gcloud auth application-default login
+            ```
+            
+            **Note:** Skip this step if you're using "Gemini - Google AI Studio".
+
         Run the following command to launch the **dev UI**.
 
         ```shell


### PR DESCRIPTION
Add prominent authentication instructions for Vertex AI users in the quickstart guide