### PR TITLE
docs: complete in-memory memory example with retrieval step

### DIFF
--- a/docs/sessions/memory.md
+++ b/docs/sessions/memory.md
@@ -65,7 +65,6 @@ This example demonstrates the basic flow using the `InMemoryMemoryService` for s
         model=MODEL,
         name="InfoCaptureAgent",
         instruction="Acknowledge the user's statement.",
-        # output_key="captured_info" # Could optionally save to state too
     )
 
     # Agent 2: Agent that can use memory
@@ -77,40 +76,66 @@ This example demonstrates the basic flow using the `InMemoryMemoryService` for s
         tools=[load_memory] # Give the agent the tool
     )
 
-    # --- Services and Runner ---
+    # --- Services ---
+    # Services must be shared across runners to share state and memory
     session_service = InMemorySessionService()
     memory_service = InMemoryMemoryService() # Use in-memory for demo
 
-    runner = Runner(
-        # Start with the info capture agent
-        agent=info_capture_agent,
-        app_name=APP_NAME,
-        session_service=session_service,
-        memory_service=memory_service # Provide the memory service to the Runner
-    )
+    async def run_scenario():
+        # --- Scenario ---
 
-    # --- Scenario ---
+        # Turn 1: Capture some information in a session
+        print("--- Turn 1: Capturing Information ---")
+        runner1 = Runner(
+            # Start with the info capture agent
+            agent=info_capture_agent,
+            app_name=APP_NAME,
+            session_service=session_service,
+            memory_service=memory_service # Provide the memory service to the Runner
+        )
+        session1_id = "session_info"
+        await runner1.session_service.create_session(app_name=APP_NAME, user_id=USER_ID, session_id=session1_id)
+        user_input1 = Content(parts=[Part(text="My favorite project is Project Alpha.")], role="user")
 
-    # Turn 1: Capture some information in a session
-    print("--- Turn 1: Capturing Information ---")
-    session1_id = "session_info"
-    session1 = await runner.session_service.create_session(app_name=APP_NAME, user_id=USER_ID, session_id=session1_id)
-    user_input1 = Content(parts=[Part(text="My favorite project is Project Alpha.")], role="user")
+        # Run the agent
+        final_response_text = "(No final response)"
+        async for event in runner1.run_async(user_id=USER_ID, session_id=session1_id, new_message=user_input1):
+            if event.is_final_response() and event.content and event.content.parts:
+                final_response_text = event.content.parts[0].text
+        print(f"Agent 1 Response: {final_response_text}")
 
-    # Run the agent
-    final_response_text = "(No final response)"
-    async for event in runner.run_async(user_id=USER_ID, session_id=session1_id, new_message=user_input1):
-        if event.is_final_response() and event.content and event.content.parts:
-            final_response_text = event.content.parts[0].text
-    print(f"Agent 1 Response: {final_response_text}")
+        # Get the completed session
+        completed_session1 = await runner1.session_service.get_session(app_name=APP_NAME, user_id=USER_ID, session_id=session1_id)
 
-    # Get the completed session
-    completed_session1 = await runner.session_service.get_session(app_name=APP_NAME, user_id=USER_ID, session_id=session1_id)
+        # Add this session's content to the Memory Service
+        print("\n--- Adding Session 1 to Memory ---")
+        await memory_service.add_session_to_memory(completed_session1)
+        print("Session added to memory.")
 
-    # Add this session's content to the Memory Service
-    print("\n--- Adding Session 1 to Memory ---")
-    memory_service = await memory_service.add_session_to_memory(completed_session1)
-    print("Session added to memory.")
+        # Turn 2: Recall the information in a new session
+        print("\n--- Turn 2: Recalling Information ---")
+        runner2 = Runner(
+            # Use the second agent, which has the memory tool
+            agent=memory_recall_agent,
+            app_name=APP_NAME,
+            session_service=session_service, # Reuse the same service
+            memory_service=memory_service   # Reuse the same service
+        )
+        session2_id = "session_recall"
+        await runner2.session_service.create_session(app_name=APP_NAME, user_id=USER_ID, session_id=session2_id)
+        user_input2 = Content(parts=[Part(text="What is my favorite project?")], role="user")
+
+        # Run the second agent
+        final_response_text_2 = "(No final response)"
+        async for event in runner2.run_async(user_id=USER_ID, session_id=session2_id, new_message=user_input2):
+            if event.is_final_response() and event.content and event.content.parts:
+                final_response_text_2 = event.content.parts[0].text
+        print(f"Agent 2 Response: {final_response_text_2}")
+
+    # To run this example, you can use the following snippet:
+    # asyncio.run(run_scenario())
+
+    # await run_scenario()
     ```
 
 ## Vertex AI Memory Bank


### PR DESCRIPTION
Fixes: #511

This PR addresses a gap in the documentation for `InMemoryMemoryService` where the code example was incomplete.

Previously, the example defined both an `InfoCaptureAgent` and a `MemoryRecallAgent` but only demonstrated a single turn where information was stored in memory. It completely omitted the crucial step of retrieving that information, leaving users without a clear, functional example of the full memory lifecycle.

This change updates the code snippet by adding a 'Turn 2'. In this second turn, a new `Runner` is configured with the `MemoryRecallAgent` to ask a question that requires memory access. The updated example now successfully demonstrates both storing and retrieving information, providing a complete and runnable guide for developers.