### PR TITLE
fix: update agent_engine parameter from root_agent to app in deployment step

### DIFF
--- a/docs/deploy/agent-engine.md
+++ b/docs/deploy/agent-engine.md
@@ -141,7 +141,7 @@ Expected output for `stream_query` (local):
 from vertexai import agent_engines
 
 remote_app = agent_engines.create(
-    agent_engine=root_agent,
+    agent_engine=app,
     requirements=[
         "google-cloud-aiplatform[adk,agent_engines]"   
     ]


### PR DESCRIPTION
Fix ADK agent engine deployment code sample which still refer to `root_agent` not the `app` that is `AdkApp` object. Resolve issue [521](https://github.com/google/adk-docs/issues/521)