### PR TITLE
docs: add guide for MCP tool authentication and deployment

### DIFF
--- a/docs/tools/authentication.md
+++ b/docs/tools/authentication.md
@@ -27,6 +27,8 @@ You set up authentication when defining your tool:
 
 * **RestApiTool / OpenAPIToolset**: Pass `auth_scheme` and `auth_credential` during initialization
 
+*   **`MCPToolset`**: For tools provided by a remote, secured [Model Context Protocol server](./mcp-tools.md).
+
 * **GoogleApiToolSet Tools**: ADK has built-in 1st party tools like Google Calendar, BigQuery etc,. Use the toolset's specific method.
 
 * **APIHubToolset / ApplicationIntegrationToolset**: Pass `auth_scheme` and `auth_credential`during initialization, if the API managed in API Hub / provided by Application Integration requires authentication.

--- a/docs/tools/mcp-authentication.md
+++ b/docs/tools/mcp-authentication.md
@@ -1,0 +1,118 @@
+# Authenticating with Remote MCP Servers
+
+![python_only](https://img.shields.io/badge/Currently_supported_in-Python-blue){ title="This feature is currently available for Python."}
+
+This guide explains how to connect your ADK agent to a remote Model Context Protocol (MCP) server that requires authentication. This is a common requirement for production environments where MCP servers expose sensitive tools or data and must be secured.
+
+You will learn how to use ADK's built-in authentication framework with `MCPToolset` to securely pass credentials, such as Bearer tokens, to a remote MCP server.
+
+## Core Concepts
+
+ADK integrates its standard authentication system with `MCPToolset`, allowing you to secure connections to remote MCP servers in the same way you would for a REST API or OpenAPI tool.
+
+The key components are:
+
+1.  **`MCPToolset`**: The ADK toolset for integrating with MCP servers.
+2.  **`StreamableHTTPConnectionParams`**: The recommended connection parameter class for connecting to remote MCP servers over HTTP. It allows you to specify the server's URL.
+3.  **`auth_scheme`**: An object defining *how* the server expects credentials. For many modern services, this will be `HTTPBearer()` for sending an `Authorization: Bearer <token>` header.
+4.  **`auth_credential`**: An object holding the *actual* credential information, such as the Bearer token itself.
+
+When you provide an `auth_scheme` and `auth_credential` to `MCPToolset`, ADK automatically constructs the correct `Authorization` header and includes it in all requests to the MCP server.
+
+## Example: Connecting to a Secured Server with a Bearer Token
+
+This example demonstrates how to build an agent that connects to a remote MCP server protected by Bearer token authentication. We will provide a complete, runnable example that includes a mock server, so you can test the entire flow locally.
+
+### Step 1: Create a Mock Authenticated MCP Server
+
+First, let's create a simple MCP server using FastAPI that requires an `Authorization` header. This simulates a real-world secured service.
+
+Save this code as `mock_mcp_server.py`:
+
+```python title="mock_mcp_server.py"
+--8<-- "examples/python/snippets/tools/mcp_auth/mock_mcp_server.py:init"
+```
+
+This server does the following:
+*   It listens for POST requests on the `/mcp` endpoint.
+*   It checks for an `Authorization` header.
+*   If the header is missing or the token is incorrect, it returns a `401 Unauthorized` error.
+*   If the token is valid (`secret-token-123`), it responds with a mock list of tools, simulating a real MCP server.
+
+### Step 2: Create the ADK Agent with Authentication
+
+Next, create the ADK agent. This agent will be configured to send the required Bearer token to the mock server.
+
+Save this code as `agent_with_auth.py`:
+
+```python title="agent_with_auth.py"
+--8<-- "examples/python/snippets/tools/mcp_auth/agent_with_auth.py:init"
+```
+
+Key parts of this agent configuration:
+
+*   **`StreamableHTTPConnectionParams`**: We use this to point to our mock server's URL (`http://127.0.0.1:8001/mcp`).
+*   **`auth_scheme = HTTPBearer()`**: This tells ADK that the authentication method is a Bearer token sent via an HTTP header.
+*   **`auth_credential`**: This holds the actual token. We use `AuthCredential` with `auth_type=AuthCredentialTypes.HTTP` and provide the token value.
+
+!!! tip "Best Practice: Use Environment Variables for Tokens"
+    In the example, the token is hardcoded for simplicity. In a real application, you should **never** hardcode secrets. Load them from environment variables or a secure secret manager.
+    ```python
+    import os
+    my_token = os.environ.get("MY_MCP_API_TOKEN")
+    ```
+
+### Step 3: Run and Test the Example
+
+1.  **Install dependencies:**
+    ```shell
+    pip install fastapi uvicorn
+    ```
+
+2.  **Start the mock server:**
+    Open a terminal and run:
+    ```shell
+    uvicorn mock_mcp_server:app --host 127.0.0.1 --port 8001
+    ```
+    The server is now running and waiting for connections.
+
+3.  **Run the ADK agent:**
+    Open a *second* terminal, ensure your ADK environment is active, and run:
+    ```shell
+    python agent_with_auth.py
+    ```
+
+**Expected Output:**
+
+In the terminal running `agent_with_auth.py`, you should see the agent successfully get the tool list and then call the `get_user_profile` tool:
+
+```console
+User Query: 'What is the profile for user 42?'
+Running agent...
+Event received: ... 'function_call': {'name': 'get_user_profile', 'args': {'user_id': '42'}} ...
+Event received: ... 'function_response': {'name': 'get_user_profile', 'response': {'id': '42', 'name': 'Jane Doe', 'email': 'jane.doe@example.com'}} ...
+Event received: ... 'text': 'The user profile for user ID 42 belongs to Jane Doe, with the email address jane.doe@example.com.' ...
+```
+
+In the terminal running the `mock_mcp_server.py`, you will see logs confirming it received the requests with the correct authorization:
+
+```console
+INFO:     Uvicorn running on http://127.0.0.1:8001 (Press CTRL+C to quit)
+INFO:     Application startup complete.
+INFO:     127.0.0.1:xxxx - "POST /mcp HTTP/1.1" 200 OK
+INFO:     127.0.0.1:xxxx - "POST /mcp HTTP/1.1" 200 OK
+```
+
+This confirms that the ADK agent successfully authenticated with the remote MCP server.
+
+## Deployment Considerations
+
+When deploying agents that use authenticated MCP tools to production environments like Cloud Run or Agent Engine, special considerations are necessary.
+
+*   **Avoid `StdioConnectionParams`**: Do not use `stdio`-based connections in a serverless or containerized environment. The MCP server should always be a separate, network-accessible service.
+*   **Secure Credential Management**: Use a service like Google Secret Manager to store and retrieve API tokens and other credentials at runtime. Do not store them in source code or as plain text environment variables.
+*   **Service-to-Service Authentication**: In cloud environments, leverage built-in service-to-service authentication mechanisms. For example, a Cloud Run service can be configured to only accept requests from other specific services, using automatically managed identity tokens.
+
+For detailed guidance, see the new sections on deploying agents with MCP tools in the deployment guides:
+*   [**Deploy to Cloud Run**](../deploy/cloud-run.md#deploying-agents-with-mcp-tools)
+*   [**Deploy to Agent Engine**](../deploy/agent-engine.md#deploying-agents-with-mcp-tools)

--- a/examples/python/snippets/tools/mcp_auth/agent_with_auth.py
+++ b/examples/python/snippets/tools/mcp_auth/agent_with_auth.py
@@ -1,0 +1,105 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# --8<-- [start:init]
+
+import asyncio
+import os
+
+from google.adk.agents import LlmAgent
+from google.adk.auth import AuthCredential, AuthCredentialTypes, HttpAuth, HttpCredentials
+from google.adk.auth.auth_schemes import HTTPBearer
+from google.adk.tools.mcp_tool.mcp_toolset import (
+    MCPToolset,
+    StreamableHTTPConnectionParams,
+)
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.genai import types
+
+# --- Authentication Configuration ---
+# In a real application, load the token from an environment variable or secret manager.
+# e.g., MY_MCP_API_TOKEN = os.environ.get("MY_MCP_API_TOKEN")
+MY_MCP_API_TOKEN = "secret-token-123"  # This must match the mock server's token
+
+# Define the authentication scheme: HTTP Bearer token.
+auth_scheme = HTTPBearer()
+
+# Define the credential containing the actual token.
+auth_credential = AuthCredential(
+    auth_type=AuthCredentialTypes.HTTP,
+    http=HttpAuth(
+        scheme="bearer", credentials=HttpCredentials(token=MY_MCP_API_TOKEN)
+    ),
+)
+# --- End Authentication Configuration ---
+
+# --- MCP Toolset Configuration ---
+mcp_toolset = MCPToolset(
+    # Use StreamableHTTPConnectionParams for remote HTTP servers.
+    connection_params=StreamableHTTPConnectionParams(
+        url="http://127.0.0.1:8001/mcp",
+    ),
+    # Provide the authentication scheme and credential to the toolset.
+    auth_scheme=auth_scheme,
+    auth_credential=auth_credential,
+)
+# --- End MCP Toolset Configuration ---
+
+# --- Agent Definition ---
+root_agent = LlmAgent(
+    model="gemini-1.5-flash",
+    name="profile_assistant_agent",
+    instruction="You can access user profiles through a secure MCP tool.",
+    tools=[mcp_toolset],
+)
+# --- End Agent Definition ---
+
+# --- Main Execution Logic ---
+async def main():
+    """Runs the agent to test the authenticated MCP tool call."""
+    session_service = InMemorySessionService()
+    session = await session_service.create_session(
+        app_name="mcp_auth_app", user_id="test_user"
+    )
+
+    query = "What is the profile for user 42?"
+    print(f"User Query: '{query}'")
+    content = types.Content(role="user", parts=[types.Part(text=query)])
+
+    runner = Runner(agent=root_agent, session_service=session_service)
+
+    print("Running agent...")
+    events_async = runner.run_async(
+        session_id=session.id, user_id=session.user_id, new_message=content
+    )
+
+    async for event in events_async:
+        print(f"Event received: {event}")
+
+    # Clean up the MCP connection when done.
+    await mcp_toolset.close()
+    print("Cleanup complete.")
+
+if __name__ == "__main__":
+    # Set GOOGLE_API_KEY environment variable if not already set
+    if not os.environ.get("GOOGLE_API_KEY"):
+        print("Error: GOOGLE_API_KEY environment variable not set.")
+    else:
+        try:
+            asyncio.run(main())
+        except Exception as e:
+            print(f"An error occurred: {e}")
+
+# --8<-- [end:init]

--- a/examples/python/snippets/tools/mcp_auth/mock_mcp_server.py
+++ b/examples/python/snippets/tools/mcp_auth/mock_mcp_server.py
@@ -1,0 +1,92 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# --8<-- [start:init]
+
+import json
+from typing import Annotated, Any, Dict, List
+
+from fastapi import FastAPI, Header, HTTPException, Request
+import uvicorn
+
+app = FastAPI(
+    title="Mock Authenticated MCP Server",
+    description="A simple server to simulate an MCP endpoint requiring Bearer token auth.",
+)
+
+EXPECTED_TOKEN = "secret-token-123"
+
+async def check_auth(authorization: Annotated[str | None, Header()] = None):
+    """Dependency to check for a valid Bearer token."""
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Authorization header missing")
+    try:
+        scheme, token = authorization.split()
+        if scheme.lower() != "bearer" or token != EXPECTED_TOKEN:
+            raise HTTPException(status_code=401, detail="Invalid token")
+    except ValueError:
+        raise HTTPException(status_code=401, detail="Invalid authorization header format")
+
+@app.post("/mcp")
+async def mcp_endpoint(request: Request):
+    """Main MCP endpoint that handles list_tools and call_tool methods."""
+    await check_auth(request.headers.get("authorization"))
+
+    body = await request.json()
+    method = body.get("method")
+
+    if method == "list_tools":
+        return {
+            "tools": [
+                {
+                    "name": "get_user_profile",
+                    "description": "Gets the profile for a given user ID.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "user_id": {
+                                "type": "string",
+                                "description": "The ID of the user.",
+                            }
+                        },
+                        "required": ["user_id"],
+                    },
+                }
+            ]
+        }
+
+    if method == "call_tool":
+        tool_name = body.get("name")
+        if tool_name == "get_user_profile":
+            user_id = body.get("arguments", {}).get("user_id")
+            return {
+                "content": [
+                    {
+                        "type": "json",
+                        "json": {
+                            "id": user_id,
+                            "name": "Jane Doe",
+                            "email": "jane.doe@example.com",
+                        },
+                    }
+                ]
+            }
+
+    raise HTTPException(status_code=400, detail=f"Unsupported method: {method}")
+
+if __name__ == "__main__":
+    print("Starting mock authenticated MCP server on http://127.0.0.1:8001")
+    uvicorn.run(app, host="127.0.0.1", port=8001)
+
+# --8<-- [end:init]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,6 +136,7 @@ nav:
     - Third party tools: tools/third-party-tools.md
     - Google Cloud tools: tools/google-cloud-tools.md
     - MCP tools: tools/mcp-tools.md
+    - MCP Authentication: tools/mcp-authentication.md
     - OpenAPI tools: tools/openapi-tools.md
     - Authentication: tools/authentication.md
   - Running Agents:


### PR DESCRIPTION
This PR addresses a significant documentation gap regarding the use of external, authenticated MCP servers with ADK.

### The Problem
Currently, there is no documentation explaining how to pass authentication credentials (e.g., Bearer tokens) to a remote MCP server. While the underlying ADK framework supports this via the standard `auth_scheme` and `auth_credential` parameters on `MCPToolset`, this is not documented anywhere. This leaves users unable to integrate with secured, real-world MCP services.

Additionally, there is no guidance on how to deploy agents that use MCP tools to cloud environments like Cloud Run or Agent Engine, which presents challenges with process management and service-to-service authentication.

### The Solution
This PR introduces a comprehensive solution:

1.  **New Guide:** A new page, `docs/tools/mcp-authentication.md`, is created to serve as the single source of truth for this topic.
2.  **Code Example:** A complete, runnable code example is added (`agent_with_auth.py` and `mock_mcp_server.py`), to demonstrate the pattern clearly.
3.  **Updated MCP Docs:** The main `mcp-tools.md` page is updated to link to the new guide and modernize its connection parameter examples.
4.  **Updated Auth Docs:** The core `authentication.md` page is updated to list `MCPToolset` as a supported tool for the ADK auth framework.
5.  **Updated Deployment Docs:** Both the `cloud-run.md` and `agent-engine.md` guides are updated with new sections on best practices for deploying agents with MCP dependencies.

This change provides a clear, documented path for users to securely integrate ADK with external MCP tools and confidently deploy their agents to production environments.

Addresses #466 