### PR TITLE
feat: add links to Agent Engine UI

### DIFF
--- a/docs/deploy/agent-engine.md
+++ b/docs/deploy/agent-engine.md
@@ -148,7 +148,11 @@ remote_app = agent_engines.create(
 )
 ```
 
-This step may take several minutes to finish. Each deployed agent has a unique identifier. You can run the following command to get the resource_name identifier for your deployed agent:
+This step may take several minutes to finish.
+
+You can check and monitor the deployment of your ADK agent on the [Agent Engine UI](https://console.cloud.google.com/vertex-ai/agents/agent-engines) on Google Cloud.
+
+Each deployed agent has a unique identifier. You can run the following command to get the resource_name identifier for your deployed agent:
 
 ```python
 remote_app.resource_name
@@ -156,7 +160,7 @@ remote_app.resource_name
 
 The response should look like the following string:
 
-```
+```shell
 f"projects/{PROJECT_NUMBER}/locations/{LOCATION}/reasoningEngines/{RESOURCE_ID}"
 ```
 
@@ -218,7 +222,7 @@ Expected output for `stream_query` (remote):
 {'parts': [{'text': 'The weather in New York is sunny with a temperature of 25 degrees Celsius (41 degrees Fahrenheit).'}], 'role': 'model'}
 ```
 
-
+## Using the Agent Engine UI
 
 ## Clean up
 
@@ -231,3 +235,5 @@ remote_app.delete(force=True)
 ```
 
 `force=True` will also delete any child resources that were generated from the deployed agent, such as sessions.
+
+You can also delete your deployed agent via the [Agent Engine UI](https://console.cloud.google.com/vertex-ai/agents/agent-engines) on Google Cloud.


### PR DESCRIPTION
Add link to show users how to managed their ADK agents deployed on Agent Engine via the Agent Engine UI.