### PR TITLE
docs: add `--log-level` option in ADK logging documentation

### DIFF
--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -31,6 +31,29 @@ logging.basicConfig(
 # ...
 ```
 
+### Configuring Logging with the ADK CLI
+
+When running agents using the ADK's built-in web or API servers, you can easily control the log verbosity directly from the command line. The `adk web`, `adk api_server`, and `adk deploy cloud_run` commands all accept a `--log-level` option.
+
+This provides a convenient way to set the logging level without modifying your agent's source code.
+
+**Example using `adk web`:**
+
+To start the web server with `DEBUG` level logging, run:
+
+```bash
+adk web --log-level DEBUG path/to/your/agents_dir
+```
+
+The available log levels for the `--log-level` option are:
+- `DEBUG`
+- `INFO` (default)
+- `WARNING`
+- `ERROR`
+- `CRITICAL`
+
+This command-line setting overrides any programmatic configuration (like `logging.basicConfig`) you might have in your code for the ADK's loggers.
+
 ### Log Levels
 
 ADK uses standard log levels to categorize the importance of a message:


### PR DESCRIPTION
We changed some logs from info to debug in https://github.com/google/adk-python/commit/ff31f57dc95149f8f309f83f2ec983ef40f1122c,  this doc change will help user figure out how to see the previous default logs.