### PR TITLE
fix(docs): add pip dependency for a2a

### DIFF
--- a/docs/a2a/quickstart-consuming.md
+++ b/docs/a2a/quickstart-consuming.md
@@ -29,6 +29,12 @@ The A2A Basic sample consists of:
 
 ### 1. Getting the Sample Code
 
+First, make sure you have the necessary dependencies installed:
+
+```bash
+pip install google-adk[a2a]
+```
+
 You can clone and navigate to the [**a2a_basic** sample](https://github.com/google/adk-python/tree/main/contributing/samples/a2a_basic) here:
 
 ```bash

--- a/docs/a2a/quickstart-consuming.md
+++ b/docs/a2a/quickstart-consuming.md
@@ -39,7 +39,6 @@ You can clone and navigate to the [**a2a_basic** sample](https://github.com/goog
 
 ```bash
 git clone https://github.com/google/adk-python.git
-cd adk-python/contributing/samples/a2a_basic
 ```
 
 As you'll see, the folder structure is as follows:

--- a/docs/a2a/quickstart-exposing.md
+++ b/docs/a2a/quickstart-exposing.md
@@ -67,11 +67,16 @@ Now let's dive into the sample code.
 
 ### 1. Getting the Sample Code
 
+First, make sure you have the necessary dependencies installed:
+
+```bash
+pip install google-adk[a2a]
+```
+
 You can clone and navigate to the [**a2a_root** sample](https://github.com/google/adk-python/tree/main/contributing/samples/a2a_root) here:
 
 ```bash
 git clone https://github.com/google/adk-python.git
-cd adk-python/contributing/samples/a2a_root
 ```
 
 As you'll see, the folder structure is as follows:


### PR DESCRIPTION
Adds in a pip install for google-adk[a2a] that is required for users to try out the A2A integrations in ADK.