### PR TITLE
fix: add google analytics tracking to CICD pipeline

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Configure Git Credentials
+        env:
+          GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
Add Google Analytics Tag to doc-build CICD pipeline. 

https://google.github.io/adk-docs/ has analytics enabled in https://github.com/google/adk-docs/pull/556