### PR TITLE
fix(docs): Link checker config update

### DIFF
--- a/.link-checker-config.json
+++ b/.link-checker-config.json
@@ -5,6 +5,12 @@
     },
     {
       "pattern": "^((?!http).)*$"
+    },
+    {
+      "pattern": "^https://console.cloud.google.com/"
+    },
+    {
+      "pattern": "^https://a2aprotocol.ai/"
     }
   ],
   "aliveStatusCodes": [


### PR DESCRIPTION
Updating the link checker to add cloud console and a2aprotocol links as valid.