### PR TITLE
Fix incorrect helper file in tool authentication

### DIFF
--- a/docs/tools/authentication.md
+++ b/docs/tools/authentication.md
@@ -249,7 +249,7 @@ from google.genai import types
 
 def get_auth_request_function_call(event: Event) -> types.FunctionCall:
     # Get the special auth request function call from the event
-    if not event.content or event.content.parts:
+    if not event.content or not event.content.parts:
         return
     for part in event.content.parts:
         if (


### PR DESCRIPTION
Fix the incorrect helper.py file for authenticated tool access.

Function `get_auth_request_function_call` immediately returns whenever there are ANY parts. 
As written it always returns None (if parts exist you return before looping; if parts empty you loop over nothing).

_I was pulling my hair out for a good 3 hours trying to understand why my calls weren't attempting to be authenticated_