### PR TITLE
fix: Prevent overwriting of function response

### DIFF
--- a/examples/python/snippets/tools/function-tools/human_in_the_loop.py
+++ b/examples/python/snippets/tools/function-tools/human_in_the_loop.py
@@ -118,8 +118,9 @@ async def call_agent_async(query):
         if not long_running_function_call:
             long_running_function_call = get_long_running_function_call(event)
         else:
-            long_running_function_response = get_function_response(event, long_running_function_call.id)
-            if long_running_function_response:
+            _potential_response = get_function_response(event, long_running_function_call.id)
+            if _potential_response: # Only update if we get a non-None response
+                long_running_function_response = _potential_response
                 ticket_id = long_running_function_response.response['ticket-id']
         if event.content and event.content.parts:
             if text := ''.join(part.text or '' for part in event.content.parts):


### PR DESCRIPTION
In the human-in-the-loop example, the long_running_function_response variable could be overwritten with `None` by a subsequent event that did not contain a function response. This would cause the logic that depends on the response to fail.

Fixes #375