### PR TITLE
docs: Clarify tool status field in example

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -329,16 +329,23 @@ Here are key guidelines for defining effective tool functions:
           order_id: The unique identifier of the order to look up.
 
       Returns:
-          A dictionary containing the order status.
-          Possible statuses: 'shipped', 'processing', 'pending', 'error'.
-          Example success: {'status': 'shipped', 'tracking_number': '1Z9...'}
+          A dictionary indicating the outcome.
+          On success, status is 'success' and includes an 'order' dictionary.
+          On failure, status is 'error' and includes an 'error_message'.
+          Example success: {'status': 'success', 'order': {'state': 'shipped', 'tracking_number': '1Z9...'}}
           Example error: {'status': 'error', 'error_message': 'Order ID not found.'}
       """
       # ... function implementation to fetch status ...
-      if status := fetch_status_from_backend(order_id):
-           return {"status": status.state, "tracking_number": status.tracking} # Example structure
+      if status_details := fetch_status_from_backend(order_id):
+        return {
+            "status": "success",
+            "order": {
+                "state": status_details.state,
+                "tracking_number": status_details.tracking,
+            },
+        }
       else:
-           return {"status": "error", "error_message": f"Order ID {order_id} not found."}
+        return {"status": "error", "error_message": f"Order ID {order_id} not found."}
 
     ```
 


### PR DESCRIPTION
The `lookup_order_status` example in the tool documentation was using the `status` field to represent both the tool's execution outcome and the business-level order status. This is ambiguous and can be confusing for the LLM.

This change refactors the example to use a dedicated `status` field for the execution outcome (`success`/`error`) and nests the order-specific data in a separate `order` dictionary. This aligns with best practices for tool design and improves clarity.

Fixes #530