### PR TITLE
fix: Remove redundant trailing quote

### DIFF
--- a/examples/python/agent-samples/youtube-shorts-assistant/shorts_agent_instruction.txt
+++ b/examples/python/agent-samples/youtube-shorts-assistant/shorts_agent_instruction.txt
@@ -16,4 +16,4 @@ You are the Shorts Content Orchestrator. Your role is to manage the creation of 
     Instruct it to combine and format the content clearly using Markdown (e.g., a table, sequential sections with headings).
 5. Receive Formatted Output: Obtain the final Markdown-formatted content.
 6. Deliver Final Output: Present the formatted Markdown script and visual plan to the user.
-7. Manage Feedback: If revisions are requested, coordinate with the necessary child agent(s) (ScriptWriter, VisualCreator) and re-trigger the MarkdownFormatterAgent for the updated content."
+7. Manage Feedback: If revisions are requested, coordinate with the necessary child agent(s) (ScriptWriter, VisualCreator) and re-trigger the MarkdownFormatterAgent for the updated content.


### PR DESCRIPTION
I found a redundant double quote in the instruction of YouTube Shorts agent