### PR TITLE
fix: correct syntax error and typo in Python examples

### DIFF
--- a/examples/python/snippets/streaming/adk-streaming-ws/app/main.py
+++ b/examples/python/snippets/streaming/adk-streaming-ws/app/main.py
@@ -118,7 +118,7 @@ async def agent_to_client_messaging(websocket, live_events):
                 print(f"[AGENT TO CLIENT]: audio/pcm: {len(audio_data)} bytes.")
                 continue
 
-        # If it's text and a parial text, send it
+        # If it's text and a partial text, send it
         if part.text and event.partial:
             message = {
                 "mime_type": "text/plain",

--- a/examples/python/snippets/tools/built-in-tools/code_execution.py
+++ b/examples/python/snippets/tools/built-in-tools/code_execution.py
@@ -41,7 +41,7 @@ code_agent = LlmAgent(
 session_service = InMemorySessionService()
 session = asyncio.run(session_service.create_session(
     app_name=APP_NAME, user_id=USER_ID, session_id=SESSION_ID
-)
+))
 runner = Runner(agent=code_agent, app_name=APP_NAME,
                 session_service=session_service)
 


### PR DESCRIPTION
Fixed spelling and syntax errors in Python examples