### PR TITLE
fix: add a stub index page for the Agent Config API docs

### DIFF
--- a/docs/api-reference/agentconfig/index.html
+++ b/docs/api-reference/agentconfig/index.html
@@ -6,6 +6,6 @@
     <title>stub page</title>
 </head>
 <body>
-    <h1>stub page</h1>
+    <h1>stub page extended</h1>
 </body>
 </html>

--- a/docs/api-reference/agentconfig/index.html
+++ b/docs/api-reference/agentconfig/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>stub page</title>
+</head>
+<body>
+    <h1>stub page</h1>
+</body>
+</html>


### PR DESCRIPTION
fix: add a stub page for the Agent Config API docs 