### PR TITLE
Chore: Cleaned up the (failed) Google Analytics code.

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -28,8 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Configure Git Credentials
-        env:
-          GOOGLE_ANALYTICS_KEY: ${{ secrets.GOOGLE_ANALYTICS_KEY }}
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,9 +22,6 @@ extra:
   second_repo_url: https://github.com/google/adk-java
   second_repo_name: adk-java
   second_repo_icon: fontawesome/brands/github
-  analytics:
-    provider: google
-    property: !ENV GOOGLE_ANALYTICS_KEY
 
 # Configuration
 theme:


### PR DESCRIPTION
The CICD tests responsible for generating static pages are failing to add the necessary keys to the site. The current settings proved unhelpful, so they have been cleared.

Removed changes added in https://github.com/google/adk-docs/pull/556 and https://github.com/google/adk-docs/pull/580