### PR TITLE
docs(memory): Fixed the example code MultiMemory Agent

### DIFF
--- a/docs/sessions/memory.md
+++ b/docs/sessions/memory.md
@@ -267,7 +267,7 @@ class MultiMemoryAgent(Agent):
 
         # 1. Search conversational history using the framework-provided memory
         #    (This would be InMemoryMemoryService if configured)
-        conversation_context = await self.search_memory(query=user_query)
+        conversation_context = await self.memory_service.search_memory(query=user_query)
 
         # 2. Search the document knowledge base using the manually created service
         document_context = await self.vertexai_memorybank_service.search_memory(query=user_query)


### PR DESCRIPTION
There was a small issue with the example code for Two Memory Services.
This PR includes the fix to the example code where conversation_context is referenced properly from in memory service.