### PR TITLE
docs: fix the incorrect path reference

### DIFF
--- a/docs/agents/config.md
+++ b/docs/agents/config.md
@@ -17,7 +17,7 @@ incorporate Functions, Tools, Sub-Agents, and more. This page describes how to
 build and run ADK workflows with the Agent Config feature. For detailed
 information on the syntax and settings supported by the Agent Config format,
 see the
-[Agent Config syntax reference](/adk-docs/api-reference/agentconfig/).
+[Agent Config syntax reference](../api-reference/agentconfig).
 
 !!! example "Experimental"
     The Agent Config feature is experimental and has some
@@ -45,9 +45,9 @@ the Agent Config files.
 To setup ADK for use with Agent Config:
 
 1.  Install the ADK Python libraries by following the
-    [Installation](/adk-docs/get-started/installation/#python)
+    [Installation](../get-started/installation.md#python)
     instructions. *Python is currently required.* For more information, see the
-    [Known limitations](?tab=t.0#heading=h.xefmlyt7zh0i).
+    [Known limitations](#known-limitations).
 1.  Verify that ADK is installed by running the following command in your
     terminal:
 
@@ -59,7 +59,7 @@ To setup ADK for use with Agent Config:
     If the `adk` command fails to run and the version is not listed in step 2, make
     sure your Python environment is active. Execute `source .venv/bin/activate` in
     your terminal on Mac and Linux. For other platform commands, see the
-    [Installation](/adk-docs/get-started/installation/#python)
+    [Installation](../get-started/installation.md#python)
     page.
 
 ### Build an agent
@@ -115,7 +115,7 @@ You can discover more configuration options for your `root_agent.yaml` agent
 configuration file by referring to the ADK
 [samples repository](https://github.com/search?q=repo%3Agoogle%2Fadk-python+path%3A%2F%5Econtributing%5C%2Fsamples%5C%2F%2F+.yaml&type=code)
 or the
-[Agent Config syntax](/adk-docs/api-reference/agentconfig/)
+[Agent Config syntax](../api-reference/agentconfig)
 reference.
 
 ### Run the agent
@@ -136,9 +136,9 @@ To run your Agent Config-defined agent:
 
 For more information on the ways to run your agent, see the *Run Your Agent*
 topic in the
-[Quickstart](/adk-docs/get-started/quickstart/#run-your-agent).
+[Quickstart](../get-started/quickstart.md#run-your-agent).
 For more information about the ADK command line options, see the 
-[ADK CLI reference](/adk-docs/api-reference/cli/).
+[ADK CLI reference](../api-reference/cli).
 
 ## Example configs
 
@@ -175,7 +175,7 @@ list of numbers provided by the user are prime numbers.
 # yaml-language-server: $schema=https://raw.githubusercontent.com/google/adk-python/refs/heads/main/src/google/adk/agents/config_schemas/AgentConfig.json
 agent_class: LlmAgent
 model: gemini-2.5-flash
-name: prime_agent
+name: prime_.md
 description: Handles checking if numbers are prime.
 instruction: |
   You are responsible for checking whether numbers are prime.
@@ -223,12 +223,12 @@ For more details, see the full code for this sample in the
 ## Deploy agent configs
 
 You can deploy Agent Config agents with 
-[Cloud Run](/adk-docs/deploy/cloud-run/) and 
-[Agent Engine](/adk-docs/deploy/agent-engine/), 
+[Cloud Run](../deploy/cloud-run.md) and 
+[Agent Engine](../deploy/agent-engine.md), 
 using the same procedure as code-based agents. For more information on how 
 to prepare and deploy Agent Config-based agents, see the 
-[Cloud Run](/adk-docs/deploy/cloud-run/) and 
-[Agent Engine](/adk-docs/deploy/agent-engine/)
+[Cloud Run](../deploy/cloud-run.md) and 
+[Agent Engine](../deploy/agent-engine.md)
 deployment guides.
 
 ## Known limitations {#known-limitations}
@@ -268,4 +268,4 @@ agent definitions in the ADK
 [adk-samples](https://github.com/search?q=repo:google/adk-python+path:/%5Econtributing%5C/samples%5C//+root_agent.yaml&type=code)
 repository. For detailed information on the syntax and settings supported by 
 the Agent Config format, see the
-[Agent Config syntax reference](/adk-docs/api-reference/agentconfig/).
+[Agent Config syntax reference](../api-reference/agentconfig).

--- a/docs/agents/multi-agents.md
+++ b/docs/agents/multi-agents.md
@@ -25,7 +25,7 @@ The foundation for structuring multi-agent systems is the parent-child relations
 
 * **Establishing Hierarchy:** You create a tree structure by passing a list of agent instances to the `sub_agents` argument when initializing a parent agent. ADK automatically sets the `parent_agent` attribute on each child agent during initialization.
 * **Single Parent Rule:** An agent instance can only be added as a sub-agent once. Attempting to assign a second parent will result in a `ValueError`.
-* **Importance:** This hierarchy defines the scope for [Workflow Agents](#12-workflow-agents-as-orchestrators) and influences the potential targets for LLM-Driven Delegation. You can navigate the hierarchy using `agent.parent_agent` or find descendants using `agent.find_agent(name)`.
+* **Importance:** This hierarchy defines the scope for [Workflow Agents](#workflow-agents-as-orchestrators) and influences the potential targets for LLM-Driven Delegation. You can navigate the hierarchy using `agent.parent_agent` or find descendants using `agent.find_agent(name)`.
 
 === "Python"
 

--- a/docs/callbacks/index.md
+++ b/docs/callbacks/index.md
@@ -27,7 +27,7 @@ Callbacks are a cornerstone feature of ADK, providing a powerful mechanism to ho
 !!! tip
     When implementing security guardrails and policies, use ADK Plugins for
     better modularity and flexibility than Callbacks. For more details, see 
-    [Callbacks and Plugins for Security Guardrails](/adk-docs/safety/#callbacks-and-plugins-for-security-guardrails).
+    [Callbacks and Plugins for Security Guardrails](../safety/index.md#callbacks-and-plugins-for-security-guardrails).
 
 **How are they added:** 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ hide:
 
 !!! tip "What's new"
     Build agents without code. Check out the
-    [Agent Config](/adk-docs/agents/config/) feature.
+    [Agent Config](agents/config.md) feature.
 
 <div style="text-align: center;">
   <div class="centered-logo-text-group">

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -26,11 +26,11 @@ Some typical applications of Plugins are as follows:
 !!! tip
     When implementing security guardrails and policies, use ADK Plugins for
     better modularity and flexibility than Callbacks. For more details, see 
-    [Callbacks and Plugins for Security Guardrails](/adk-docs/safety/#callbacks-and-plugins-for-security-guardrails).
+    [Callbacks and Plugins for Security Guardrails](../safety/index.md#callbacks-and-plugins-for-security-guardrails).
 
 !!! warning "Caution"
     Plugins are not supported by the 
-    [ADK web interface](../evaluate/#1-adk-web-run-evaluations-via-the-web-ui). 
+    [ADK web interface](../evaluate/index.md#1-adk-web-run-evaluations-via-the-web-ui). 
     If your ADK workflow uses Plugins, you must run your workflow without the 
     web interface.
 
@@ -46,7 +46,7 @@ Plugins in your agent application, see
 [Plugin callback hooks](#plugin-callback-hooks).
 
 Plugin functionality builds on
-[Callbacks](../callbacks/), which is a key design
+[Callbacks](../callbacks/index.md), which is a key design
 element of the ADK's extensible architecture. While a typical Agent Callback is
 configured on a *single agent, a single tool* for a *specific task*, a Plugin is
 registered *once* on the `Runner` and its callbacks apply *globally* to every
@@ -174,7 +174,7 @@ command line:
 ```
 
 Plugins are not supported by the
-[ADK web interface](../evaluate/#1-adk-web-run-evaluations-via-the-web-ui).
+[ADK web interface](../evaluate/index.md#1-adk-web-run-evaluations-via-the-web-ui).
 If your ADK workflow uses Plugins, you must run your workflow without the web
 interface.
 
@@ -193,7 +193,7 @@ Hello world: query is [hello world]
 
 
 For more information on running ADK agents, see the
-[Quickstart](/get-started/quickstart/#run-your-agent)
+[Quickstart](../get-started/quickstart.md#run-your-agent)
 guide.
 
 ## Build workflows with Plugins
@@ -373,7 +373,7 @@ callback is *not executed* (skipped).
 
 For more information about Agent callbacks defined as part of an Agent object,
 see
-[Types of Callbacks](../callbacks/types-of-callbacks/#agent-lifecycle-callbacks).
+[Types of Callbacks](../callbacks/types-of-callbacks.md#agent-lifecycle-callbacks).
 
 ### Model callbacks
 
@@ -511,4 +511,5 @@ The following code example shows the basic syntax of this callback:
 async def after_run_callback(
     self, *, invocation_context: InvocationContext
 ) -> Optional[None]:
+```
 ```

--- a/docs/safety/index.md
+++ b/docs/safety/index.md
@@ -288,7 +288,7 @@ Some examples include:
 
 * **Model Armor Plugin**: A plugin that queries the model armor API to check for potential content safety violations at specified points of agent execution. Similar to the _Gemini as a Judge_ plugin, if Model Armor finds matches of harmful content, it returns a predetermined response to the user.
 
-* **PII Redaction Plugin**: A specialized plugin with design for the [Before Tool Callback](/adk-docs/plugins/#tool-callbacks) and specifically created to redact personally identifiable information before it’s processed by a tool or sent to an external service.
+* **PII Redaction Plugin**: A specialized plugin with design for the [Before Tool Callback](../plugins/index.md#tool-callbacks) and specifically created to redact personally identifiable information before it’s processed by a tool or sent to an external service.
 
 ### Sandboxed Code Execution
 

--- a/docs/sessions/express-mode.md
+++ b/docs/sessions/express-mode.md
@@ -51,7 +51,7 @@ Next, we can create our Agent Engine instance. You can use the Gen AI SDK.
 
 ## Managing Sessions with a `VertexAiSessionService`
 
-[VertexAiSessionService](session.md###sessionservice-implementations) is compatible with Vertex AI Express mode API Keys. We can 
+[VertexAiSessionService](session.md#sessionservice-implementations) is compatible with Vertex AI Express mode API Keys. We can 
 instead initialize the session object without any project or location.
 
        ```py
@@ -78,7 +78,7 @@ instead initialize the session object without any project or location.
 
 ## Managing Memories with a `VertexAiMemoryBankService`
 
-[VertexAiMemoryBankService](memory.md###memoryservice-implementations) is compatible with Vertex AI Express mode API Keys. We can 
+[VertexAiMemoryBankService](memory.md#vertex-ai-memory-bank) is compatible with Vertex AI Express mode API Keys. We can 
 instead initialize the memory object without any project or location.
 
        ```py

--- a/docs/tools/function-tools.md
+++ b/docs/tools/function-tools.md
@@ -152,7 +152,7 @@ While you have considerable flexibility in defining your function, remember that
 * **Simple Data Types:** Favor primitive data types like `str` and `int` over custom classes whenever possible.  
 * **Meaningful Names:** The function's name and parameter names significantly influence how the LLM interprets and utilizes the tool. Choose names that clearly reflect the function's purpose and the meaning of its inputs. Avoid generic names like `do_stuff()` or `beAgent()`.
 * **Build for Parallel Execution:** Improve function calling performance when multiple tools are run by building for asynchronous operation. For information on enabling parallel execution for tools, see
-[Increase tool performance with parallel execution](/adk-docs/tools/performance/).
+[Increase tool performance with parallel execution](performance.md).
 
 ## Long Running Function Tools {#long-run-tool}
 
@@ -164,7 +164,7 @@ When using a `LongRunningFunctionTool`, your function can initiate the long-runn
     Depending on the type of tool you are building, designing for asychronous
     operation may be a better solution than creating a long running tool. For
     more information, see
-    [Increase tool performance with parallel execution](/adk-docs/tools/performance/).
+    [Increase tool performance with parallel execution](performance.md).
 
 ### How it Works
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -47,9 +47,9 @@ Think of the tools as a specialized toolkit that the agent's intelligent core (t
 ADK offers flexibility by supporting several types of tools:
 
 1. **[Function Tools](../tools/function-tools.md):** Tools created by you, tailored to your specific application's needs.
-    * **[Functions/Methods](../tools/function-tools.md#1-function-tool):** Define standard synchronous functions or methods in your code (e.g., Python def).
-    * **[Agents-as-Tools](../tools/function-tools.md#3-agent-as-a-tool):** Use another, potentially specialized, agent as a tool for a parent agent.
-    * **[Long Running Function Tools](../tools/function-tools.md#2-long-running-function-tool):** Support for tools that perform asynchronous operations or take significant time to complete.
+    * **[Functions/Methods](../tools/function-tools.md#function-tool):** Define standard synchronous functions or methods in your code (e.g., Python def).
+    * **[Agents-as-Tools](../tools/function-tools.md#agent-tool):** Use another, potentially specialized, agent as a tool for a parent agent.
+    * **[Long Running Function Tools](../tools/function-tools.md#long-run-tool):** Support for tools that perform asynchronous operations or take significant time to complete.
 2. **[Built-in Tools](../tools/built-in-tools.md):** Ready-to-use tools provided by the framework for common tasks.
         Examples: Google Search, Code Execution, Retrieval-Augmented Generation (RAG).
 3. **[Third-Party Tools](../tools/third-party-tools.md):** Integrate tools seamlessly from popular external libraries.

--- a/docs/tools/mcp-tools.md
+++ b/docs/tools/mcp-tools.md
@@ -17,7 +17,7 @@ This guide covers two primary integration patterns:
 
 Before you begin, ensure you have the following set up:
 
-* **Set up ADK:** Follow the standard ADK [setup instructions](../get-started/quickstart.md/#venv-install) in the quickstart.
+* **Set up ADK:** Follow the standard ADK [setup instructions](../get-started/quickstart.md/#set-up-environment-install-adk) in the quickstart.
 * **Install/update Python/Java:** MCP requires Python version of 3.9 or higher for Python or Java 17 or higher.
 * **Setup Node.js and npx:** **(Python only)** Many community MCP servers are distributed as Node.js packages and run using `npx`. Install Node.js (which includes npx) if you haven't already. For details, see [https://nodejs.org/en](https://nodejs.org/en).
 * **Verify Installations:** **(Python only)** Confirm `adk` and `npx` are in your PATH within the activated virtual environment:

--- a/docs/tools/performance.md
+++ b/docs/tools/performance.md
@@ -2,7 +2,7 @@
 
 Starting with Agent Development Kit (ADK) version 1.10.0, the framework
 attempts to run any agent-requested 
-[function tools](/adk-docs/tools/function-tools/) 
+[function tools](function-tools.md) 
 in parallel. This behavior can significantly improve the performance and
 responsiveness of your agents, particularly for agents that rely on multiple
 external APIs or long-running tasks. For example, if you have 3 tools that each


### PR DESCRIPTION
## What this Pull Request does

Corrects unreasonable path references in the documentation to ensure:

1. It does not affect the compilation and rendering of the documentation website, ensuring the documentation and anchor links work normally
2. The documentation links work normally when read locally via VSCode or a Markdown editor

## How to Verify

Verified through `mkdocs serve`, compared to the logs in #659, the number of documentation build errors will be significantly reduced, with the final result as follows:

```diff
➜  adk-docs git:(fix-relative-reference) ✗ mkdocs serve
INFO    -  Building documentation...
INFO    -  Cleaning site directory
+ INFO    -  Doc file 'agents/config.md' contains an unrecognized relative link '../api-reference/agentconfig', it was left as is.
+ INFO    -  Doc file 'agents/config.md' contains an unrecognized relative link '../api-reference/agentconfig', it was left as is.
+ INFO    -  Doc file 'agents/config.md' contains an unrecognized relative link '../api-reference/cli', it was left as is.
+ INFO    -  Doc file 'agents/config.md' contains an unrecognized relative link '../api-reference/agentconfig', it was left as is.
Building prefix dict from the default dictionary ...
Loading model from cache /var/folders/sq/4pvg07156sd37pvxbmnggmhw0000gn/T/jieba.cache
Loading model cost 1.049 seconds.
Prefix dict has been built successfully.
+ INFO    -  Doc file 'agents/config.md' contains a link '../get-started/installation.md#python', but the doc 'get-started/installation.md' does not contain
           an anchor '#python'.
INFO    -  Documentation built in 15.63 seconds
INFO    -  [23:42:51] Watching paths for changes: 'docs', 'mkdocs.yml'
INFO    -  [23:42:51] Serving on http://127.0.0.1:8000/adk-docs/
INFO    -  [23:44:26] Browser connected: http://127.0.0.1:8000/adk-docs/tools/performance/
```

> It is worth noting that the pages marked with `api-reference` by Diff are not written in Markdown, and the anchor `get-started/installation.md#python` is due to providing different document effects for Python and Java.
> 
> Therefore, it can be ignored.
