### PR TITLE
doc: fix missing object reference due name conflict (Google Cloud Tools)

### DIFF
--- a/docs/tools/google-cloud-tools.md
+++ b/docs/tools/google-cloud-tools.md
@@ -80,7 +80,7 @@ you only need to follow a subset of these steps.
         "apikey", "query", "apikey", apikey_credential_str
     )
 
-    sample_toolset_with_auth = APIHubToolset(
+    sample_toolset = APIHubToolset(
         name="apihub-sample-tool",
         description="Sample Tool",
         access_token="...",  # Copy your access token generated in step 1


### PR DESCRIPTION
Section: [Google Cloud Tools](https://google.github.io/adk-docs/tools/google-cloud-tools/)

It is defined as `sample_toolset_with_auth`, but used as `sample_toolset`