### PR TITLE
Working example for caching an OAuth credential in the session state

### DIFF
--- a/docs/tools/authentication.md
+++ b/docs/tools/authentication.md
@@ -447,6 +447,8 @@ else:
 * This returns the updated `exchanged_credential` object sent back by the client (containing the callback URL in `auth_response_uri`).
 
 ```py
+from datetime import datetime, timedelta
+
 # Use auth_scheme and auth_credential configured in the tool.
 # exchanged_credential: AuthCredential | None
 
@@ -459,9 +461,11 @@ if exchanged_credential:
    # ADK exchanged the access token already for us
         access_token = exchanged_credential.oauth2.access_token
         refresh_token = exchanged_credential.oauth2.refresh_token
+        expiry = datetime.utcnow() + timedelta(seconds=exchanged_credential.oauth2.expires_in)
         creds = Credentials(
             token=access_token,
             refresh_token=refresh_token,
+            expiry=expiry,
             token_uri=auth_scheme.flows.authorizationCode.tokenUrl,
             client_id=auth_credential.oauth2.client_id,
             client_secret=auth_credential.oauth2.client_secret,


### PR DESCRIPTION
If the expiry is not saved in credentials, we are not able to rebuild a valid token from the state of the session.

**No expiry in credentials:**

```py
cached = json.loads(creds.to_json())
creds = Credentials.from_authorized_user_info(cached_token_info, SCOPES)
assert creds.valid == False
assert creds.expired == True
````


**Expiry in credentials:**

```py
cached = json.loads(creds.to_json())
creds = Credentials.from_authorized_user_info(cached_token_info, SCOPES)
assert creds.valid == True
assert creds.expired == False
````
