### PR TITLE
feat: Add Go quickstart guide and code snippet

### DIFF
--- a/docs/get-started/quickstart.md
+++ b/docs/get-started/quickstart.md
@@ -5,8 +5,8 @@ setting up a basic agent with multiple tools, and running it locally either in t
 
 <!-- <img src="../../assets/quickstart.png" alt="Quickstart setup"> -->
 
-This quickstart assumes a local IDE (VS Code, PyCharm, IntelliJ IDEA, etc.)
-with Python 3.9+ or Java 17+ and terminal access. This method runs the
+This quickstart assumes a local IDE (VS Code, PyCharm, IntelliJ IDEA, GoLand etc.)
+with Python 3.9+, Java 17+, or Go 1.21+ and terminal access. This method runs the
 application entirely on your machine and is recommended for internal development.
 
 ## 1. Set up Environment & Install ADK { #set-up-environment-install-adk }
@@ -33,6 +33,14 @@ application entirely on your machine and is recommended for internal development
 === "Java"
 
     To install ADK and setup the environment, proceed to the following steps.
+
+=== "Go"
+
+    Install Go 1.21+ and then run the following command to install the ADK for Go:
+
+    ```bash
+    go get google.com/adk
+    ```
 
 ## 2. Create Agent Project { #create-agent-project }
 
@@ -139,6 +147,37 @@ application entirely on your machine and is recommended for internal development
     --8<-- "examples/java/cloud-run/src/main/java/agents/multitool/MultiToolAgent.java:full_code"
     ```
 
+=== "Go"
+
+    Go projects generally feature the following project structure:
+
+    ```console
+    project_folder/
+    ├── go.mod
+    ├── go.sum
+    └── main.go
+    ```
+
+    ### Create `agent.go`
+
+    Create a `agent.go` source file in your project folder.
+
+    ```bash
+    touch agent.go
+    ```
+
+    Initialize a new Go module:
+
+    ```bash
+    go mod init multi_tool_agent
+    ```
+
+    Copy and paste the following code into `agent.go`:
+
+    ```go title="agent.go"
+    --8<-- "examples/go/snippets/get-started/multi_tool_agent/agent.go"
+    ```
+
 ![intro_components.png](../assets/quickstart-flow-tool.png)
 
 ## 3. Set up the model { #set-up-the-model }
@@ -163,7 +202,7 @@ agent will be unable to function.
         GOOGLE_API_KEY=PASTE_YOUR_ACTUAL_API_KEY_HERE
         ```
 
-        When using Java, define environment variables:
+        When using Java or Go, define environment variables:
 
         ```console title="terminal"
         export GOOGLE_GENAI_USE_VERTEXAI=FALSE
@@ -185,7 +224,7 @@ agent will be unable to function.
         GOOGLE_CLOUD_LOCATION=LOCATION
         ```
 
-        When using Java, define environment variables:
+        When using Java or Go, define environment variables:
 
         ```console title="terminal"
         export GOOGLE_GENAI_USE_VERTEXAI=TRUE
@@ -206,7 +245,7 @@ agent will be unable to function.
         GOOGLE_API_KEY=PASTE_YOUR_ACTUAL_EXPRESS_MODE_API_KEY_HERE
         ```
 
-        When using Java, define environment variables:
+        When using Java or Go, define environment variables:
 
         ```console title="terminal"
         export GOOGLE_GENAI_USE_VERTEXAI=TRUE
@@ -420,7 +459,24 @@ agent will be unable to function.
         gradle runAgent
         ```
 
+=== "Go"
 
+    Using the terminal, navigate to your agent project directory:
+
+    ```console
+    project_folder/      <-- navigate to this directory
+        go.mod
+        go.sum
+        agent.go
+    ```
+
+    Run the following command to chat with your agent.
+
+    ```
+    go run .
+    ```
+
+    To exit, use Cmd/Ctrl+C.
 
 ### 📝 Example prompts to try
 

--- a/examples/go/snippets/get-started/multi_tool_agent/agent.go
+++ b/examples/go/snippets/get-started/multi_tool_agent/agent.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"google.com/adk/agent"
+	"google.com/adk/session"
+	"google.com/adk/tool"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	a, err := agent.New(
+		agent.WithName("weather_time_agent"),
+		agent.WithModel("gemini-2.0-flash"),
+		agent.WithDescription("Agent to answer questions about the time and weather in a city."),
+		agent.WithInstruction("You are a helpful agent who can answer user questions about the time and weather in a city."),
+		agent.WithTools(
+			tool.MustNew(getWeather),
+			tool.MustNew(getCurrentTime),
+		),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create agent: %w", err)
+	}
+
+	s, err := session.New(a)
+	if err != nil {
+		return fmt.Errorf("failed to create session: %w", err)
+	}
+	defer s.Close()
+
+	scanner := bufio.NewScanner(os.Stdin)
+	fmt.Println("Chat with the agent (type 'quit' to exit).")
+	for {
+		fmt.Print("> ")
+		if !scanner.Scan() {
+			break
+		}
+		input := scanner.Text()
+		if strings.ToLower(input) == "quit" {
+			break
+		}
+
+		output, err := s.Send(input)
+		if err != nil {
+			fmt.Printf("Error: %v\n", err)
+			continue
+		}
+		fmt.Println(output)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scanner error: %w", err)
+	}
+
+	return nil
+}
+
+// getWeather retrieves the current weather report for a specified city.
+//
+// city: The name of the city for which to retrieve the weather report.
+func getWeather(city string) map[string]string {
+	if strings.ToLower(city) == "new york" {
+		return map[string]string{
+			"status": "success",
+			"report": "The weather in New York is sunny with a temperature of 25 degrees Celsius (77 degrees Fahrenheit).",
+		}
+	}
+	return map[string]string{
+		"status":        "error",
+		"error_message": fmt.Sprintf("Weather information for '%s' is not available.", city),
+	}
+}
+
+// getCurrentTime returns the current time in a specified city.
+//
+// city: The name of the city for which to retrieve the current time.
+func getCurrentTime(city string) map[string]string {
+	loc, err := time.LoadLocation(strings.ReplaceAll(city, " ", "_"))
+	if err != nil {
+		// Fallback for "New York"
+		if strings.ToLower(city) == "new york" {
+			loc, err = time.LoadLocation("America/New_York")
+			if err != nil {
+				return map[string]string{
+					"status":        "error",
+					"error_message": fmt.Sprintf("Could not load timezone information for %s.", city),
+				}
+			}
+		} else {
+			return map[string]string{
+				"status":        "error",
+				"error_message": fmt.Sprintf("Sorry, I don't have timezone information for %s.", city),
+			}
+		}
+	}
+
+	report := fmt.Sprintf("The current time in %s is %s", city, time.Now().In(loc).Format("2006-01-02 15:04:05 MST"))
+	return map[string]string{
+		"status": "success",
+		"report": report,
+	}
+}


### PR DESCRIPTION
This commit introduces a Go version of the quickstart guide to the documentation.

Key changes:
- A new Go code snippet for a multi-tool agent has been added in `examples/go/snippets/get-started/multi_tool_agent/agent.go`.
- The quickstart documentation (`docs/get-started/quickstart.md`) has been updated to include a "Go" tab with instructions for setting up the environment, creating a project, and running the agent.
- The Go code is functionally equivalent to the existing Python and Java examples.

These changes address the request in Buganizer issue b/440665919.