### PR TITLE
docs: Add analytics to the documentation site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,7 @@ extra:
   second_repo_icon: fontawesome/brands/github
   analytics:
     provider: google
-    property: G-Vxxxxxxxxxxxx
+    property: G-DKHZS27PHP
   consent:
     title: Cookie consent
     description: >- 


### PR DESCRIPTION
docs: Add analytics to the documentation site

- add Google analytics
- add Cookie consent interface
- launch approval: turbo/664312