### PR TITLE
ci: Add site to markdown link checker ignore list

### DIFF
--- a/.link-checker-config.json
+++ b/.link-checker-config.json
@@ -11,6 +11,9 @@
     },
     {
       "pattern": "^https://a2aprotocol.ai/"
+    },
+    {
+      "pattern": "^https://www.gnu.org/"
     }
   ],
   "aliveStatusCodes": [


### PR DESCRIPTION
This PR adds `^https://www.gnu.org/` to the markdown-link-check ignore list. Links to this site are causing the link checker CI job to timeout or fail due to server flakiness. After this is merged, the [link checker GH action](https://github.com/google/adk-docs/actions/workflows/link-checker.yaml) should resume working as expected.