### PR TITLE
fix(docs): fix url link to "Java Quickstart for ADK" page

### DIFF
--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -11,13 +11,13 @@ set up and running a simple agent in less than 20 minutes.
     ---
     Create your first Python ADK agent in minutes.
 
-    [:octicons-arrow-right-24: Start with Python](/adk-docs/get-started/python) <br>
+    [:octicons-arrow-right-24: Start with Python](python.md) <br>
 
 -   :fontawesome-brands-java:{ .lg .middle } **Java Quickstart**
 
     ---
     Create your first Java ADK agent in minutes.
 
-    [:octicons-arrow-right-24: Start with Java](/adk-docs/get-started/java) <br>
+    [:octicons-arrow-right-24: Start with Java](java.md) <br>
 
 </div>


### PR DESCRIPTION
The link should be https://google.github.io/adk-docs/get-started/java/ instead of https://google.github.io/adk-docs/get-started/java.md