### PR TITLE
fix: Fix relative links on tutorials page

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -19,16 +19,16 @@ applications with ADK. Explore our collection below and happy building:
 
     Create a workflow that uses multiple tools.
 
-    [:octicons-arrow-right-24: Build a multi-tool agent](/adk-docs/get-started/index.md)
+    [:octicons-arrow-right-24: Build a multi-tool agent](../get-started/quickstart.md)
 
 -   :material-console-line: **Agent team**
 
     ---
 
     Build an multi-agent workflow including agent delegation,
-    session management, and safety callbacks. 
+    session management, and safety callbacks.
 
-    [:octicons-arrow-right-24: Build an agent team](/adk-docs/tutorials/agent-team.md)
+    [:octicons-arrow-right-24: Build an agent team](../tutorials/agent-team.md)
 
 -   :material-console-line: **Streaming agent**
 
@@ -36,7 +36,7 @@ applications with ADK. Explore our collection below and happy building:
 
     Create an agent for handling streamed content.
 
-    [:octicons-arrow-right-24: Build a streaming agent](/adk-docs/get-started/streaming/)
+    [:octicons-arrow-right-24: Build a streaming agent](../get-started/streaming/index.md)
 
 -   :material-rocket-launch-outline: **Discover sample agents**
 


### PR DESCRIPTION
Uses relative links to the MD files on the updated tutorial page, which mkdocs will resolve to the correct URL path.

Followup PR to #739.