### PR TITLE
Open link to Go API docs (external site) in a new tab

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -254,7 +254,7 @@ nav:
     - API Reference:
       - api-reference/index.md
       - Python ADK: api-reference/python/index.html
-      - Go ADK: https://pkg.go.dev/google.golang.org/adk
+      - Go ADK: https://pkg.go.dev/google.golang.org/adk" target="_blank
       - Java ADK: api-reference/java/index.html
       - CLI Reference: api-reference/cli/index.html
       - Agent Config reference: api-reference/agentconfig/index.html


### PR DESCRIPTION
The formatting of the double quotes is intentional for this to work in `mkdocs.yml`.