### PR TITLE
docs: Add MCP Toolbox for databases Go SDK Documentation

### DIFF
--- a/docs/tools/google-cloud/mcp-toolbox-for-databases.md
+++ b/docs/tools/google-cloud/mcp-toolbox-for-databases.md
@@ -1,7 +1,7 @@
 # MCP Toolbox for Databases
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span><span class="lst-go">Go</span>
 </div>
 
 [MCP Toolbox for Databases](https://github.com/googleapis/genai-toolbox) is an
@@ -81,98 +81,98 @@ documentation:
 
 ## Install Client SDK for ADK
 
-## Python SDK
+=== "Python"
 
-ADK relies on the `toolbox-core` python package to use Toolbox. Install the
-package before getting started:
+    ADK relies on the `toolbox-core` python package to use Toolbox. Install the
+    package before getting started:
 
-```shell
-pip install toolbox-core
-```
+    ```shell
+    pip install toolbox-core
+    ```
 
-### Loading Toolbox Tools
+    ### Loading Toolbox Tools
 
-Once you’re Toolbox server is configured and up and running, you can load tools
-from your server using ADK:
+    Once you’re Toolbox server is configured and up and running, you can load tools
+    from your server using ADK:
 
-```python
-from google.adk.agents import Agent
-from toolbox_core import ToolboxSyncClient
+    ```python
+    from google.adk.agents import Agent
+    from toolbox_core import ToolboxSyncClient
 
-toolbox = ToolboxSyncClient("https://127.0.0.1:5000")
+    toolbox = ToolboxSyncClient("https://127.0.0.1:5000")
 
-# Load a specific set of tools
-tools = toolbox.load_toolset('my-toolset-name'),
-# Load single tool
-tools = toolbox.load_tool('my-tool-name'),
+    # Load a specific set of tools
+    tools = toolbox.load_toolset('my-toolset-name'),
+    # Load single tool
+    tools = toolbox.load_tool('my-tool-name'),
 
-root_agent = Agent(
-    ...,
-    tools=tools # Provide the list of tools to the Agent
+    root_agent = Agent(
+        ...,
+        tools=tools # Provide the list of tools to the Agent
 
-)
-```
+    )
+    ```
 
-## Go SDK
+=== "Go"
 
-ADK relies on the `mcp-toolbox-sdk-go` go module to use Toolbox. Install the
-module before getting started:
+    ADK relies on the `mcp-toolbox-sdk-go` go module to use Toolbox. Install the
+    module before getting started:
 
-```shell
-go get github.com/googleapis/mcp-toolbox-sdk-go
-```
+    ```shell
+    go get github.com/googleapis/mcp-toolbox-sdk-go
+    ```
 
-### Loading Toolbox Tools
+    ### Loading Toolbox Tools
 
-Once you’re Toolbox server is configured and up and running, you can load tools
-from your server using ADK:
+    Once you’re Toolbox server is configured and up and running, you can load tools
+    from your server using ADK:
 
-```go
-package main
+    ```go
+    package main
 
-import (
-	"context"
-	"fmt"
+    import (
+    	"context"
+    	"fmt"
 
-	"github.com/googleapis/mcp-toolbox-sdk-go/tbadk"
-	"google.golang.org/adk/agent/llmagent"
-)
+    	"github.com/googleapis/mcp-toolbox-sdk-go/tbadk"
+    	"google.golang.org/adk/agent/llmagent"
+    )
 
-func main() {
+    func main() {
 
-  toolboxClient, err := tbadk.NewToolboxClient("https://127.0.0.1:5000")
-	if err != nil {
-		log.Fatalf("Failed to create MCP Toolbox client: %v", err)
-	}
+      toolboxClient, err := tbadk.NewToolboxClient("https://127.0.0.1:5000")
+    	if err != nil {
+    		log.Fatalf("Failed to create MCP Toolbox client: %v", err)
+    	}
 
-  // Load a specific set of tools
-  toolboxtools, err := toolboxClient.LoadToolset("my-toolset-name", ctx)
-  if err != nil {
-    return fmt.Sprintln("Could not load Toolbox Toolset", err)
-  }
+      // Load a specific set of tools
+      toolboxtools, err := toolboxClient.LoadToolset("my-toolset-name", ctx)
+      if err != nil {
+        return fmt.Sprintln("Could not load Toolbox Toolset", err)
+      }
 
-  toolsList := make([]tool.Tool, len(toolboxtools))
-    for i := range toolboxtools {
-      toolsList[i] = &toolboxtools[i]
+      toolsList := make([]tool.Tool, len(toolboxtools))
+        for i := range toolboxtools {
+          toolsList[i] = &toolboxtools[i]
+        }
+
+      llmagent, err := llmagent.New(llmagent.Config{
+        ...,
+        Tools:       toolsList,
+      })
+
+      // Load a single tool
+      tool, err := client.LoadTool("my-tool-name", ctx)
+      if err != nil {
+        return fmt.Sprintln("Could not load Toolbox Tool", err)
+      }
+
+      llmagent, err := llmagent.New(llmagent.Config{
+        ...,
+        Tools:       []tool.Tool{&toolboxtool},
+      })
     }
-
-  llmagent, err := llmagent.New(llmagent.Config{
-    ...,
-    Tools:       toolsList,
-  })
-
-  // Load a single tool
-  tool, err := client.LoadTool("my-tool-name", ctx)
-  if err != nil {
-    return fmt.Sprintln("Could not load Toolbox Tool", err)
-  }
-
-  llmagent, err := llmagent.New(llmagent.Config{
-    ...,
-    Tools:       []tool.Tool{&toolboxtool},
-  })
-}
-```
+    ```
 
 ## Advanced Toolbox Features
 


### PR DESCRIPTION
This PR adds a sample on how to use the [MCP Toolbox Go SDK](https://github.com/googleapis/mcp-toolbox-sdk-go) with ADK Go

Transferred from https://github.com/ivanmkc/adk-docs-private/pull/39