### PR TITLE
fix(docs): Add missing imports/constants to sequential example

### DIFF
--- a/examples/python/snippets/agents/workflow-agents/sequential_agent_code_development_agent.py
+++ b/examples/python/snippets/agents/workflow-agents/sequential_agent_code_development_agent.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# --8<-- [start:init]
+# Part of agent.py --> Follow https://google.github.io/adk-docs/get-started/quickstart/ to learn the setup
+
 import asyncio
 import os
 from google.adk.agents.sequential_agent import SequentialAgent
 from google.adk.agents.llm_agent import LlmAgent
 from google.genai import types
-# Change 1: Import InMemoryRunner instead of Runner/InMemorySessionService
 from google.adk.runners import InMemoryRunner
 from typing import Optional # For type hints
 
@@ -26,10 +28,6 @@ APP_NAME = "code_pipeline_app"
 USER_ID = "dev_user_01"
 SESSION_ID = "pipeline_session_02" # Use a unique session ID for each run if desired
 GEMINI_MODEL = "gemini-2.0-flash"
-
-
-# --8<-- [start:init]
-# Part of agent.py --> Follow https://google.github.io/adk-docs/get-started/quickstart/ to learn the setup
 
 # --- 1. Define Sub-Agents for Each Pipeline Stage ---
 


### PR DESCRIPTION
The sequential agents example snippet did not include the necessary imports and constants, which could cause the code to break when copied and executed as-is.