### PR TITLE
docs: fix typos and spacing across docs

### DIFF
--- a/docs/agents/llm-agents.md
+++ b/docs/agents/llm-agents.md
@@ -1,7 +1,11 @@
 # LLM Agent
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span>
+  <span class="lst-supported">Supported in ADK</span>
+  <span class="lst-python">Python v0.1.0</span>
+  <span class="lst-typescript">Typescript v0.2.0</span>
+  <span class="lst-go">Go v0.1.0</span>
+  <span class="lst-java">Java v0.1.0</span>
 </div>
 
 The `LlmAgent` (often aliased simply as `Agent`) is a core component in ADK,
@@ -190,7 +194,7 @@ reasoning. They allow the agent to interact with the outside world, perform
 calculations, fetch real-time data, or execute specific actions.
 
 * **`tools` (Optional):** Provide a list of tools the agent can use. Each item in the list can be:
-    * A native function or method (wrapped as a `FunctionTool`). Python ADK automatically wraps the native function into a `FuntionTool` whereas, you must explicitly wrap your Java methods using `FunctionTool.create(...)`
+    * A native function or method (wrapped as a `FunctionTool`). Python ADK automatically wraps the native function into a `FunctionTool` whereas, you must explicitly wrap your Java methods using `FunctionTool.create(...)`
     * An instance of a class inheriting from `BaseTool`.
     * An instance of another agent (`AgentTool`, enabling agent-to-agent delegation - see [Multi-Agents](multi-agents.md)).
 

--- a/docs/observability/freeplay.md
+++ b/docs/observability/freeplay.md
@@ -80,7 +80,7 @@ Freeplay in the Observability section.
 ## Observability
 
 Freeplay's Observability feature gives you a clear view into how your agent is
-behaving in production. You can dig into to individual agent traces to
+behaving in production. You can dig into individual agent traces to
 understand each step and diagnose issues:
 
 ![Trace detail](https://228labs.com/freeplay-google-demo/images/trace_detail.png)

--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -59,7 +59,7 @@ The available log levels for the `--log_level` option are:
 - `ERROR`
 - `CRITICAL`
 
-> You can also use `-v` or `--verbose` as a a shortcut for `--log_level DEBUG`.
+> You can also use `-v` or `--verbose` as a shortcut for `--log_level DEBUG`.
 >
 > ```bash
 > adk web -v path/to/your/agents_dir

--- a/docs/streaming/configuration.md
+++ b/docs/streaming/configuration.md
@@ -1,4 +1,4 @@
-# Configurating streaming behaviour
+# Configuring streaming behaviour
 
 <div class="language-support-tag">
     <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.5.0</span><span class="lst-preview">Experimental</span>

--- a/docs/streaming/dev-guide/part4.md
+++ b/docs/streaming/dev-guide/part4.md
@@ -296,7 +296,7 @@ While this guide focuses on Bidi-streaming with Gemini 2.0 Live models, ADK also
 
 ## Understanding Live API Connections and Sessions
 
-When building ADK Bidi-streaming applications, it's essential to understand how ADK manages the communication layer between itself and the  Live API backend. This section explores the fundamental distinction between **connections** (the WebSocket transport links that ADK establishes to Live API) and **sessions** (the logical conversation contexts maintained by Live API). Unlike traditional request-response APIs, the Bidi-streaming architecture introduces unique constraints: connection timeouts, session duration limits that vary by modality (audio-only vs audio+video), finite context windows, and concurrent session quotas that differ between Gemini Live API and Vertex AI Live API.
+When building ADK Bidi-streaming applications, it's essential to understand how ADK manages the communication layer between itself and the Live API backend. This section explores the fundamental distinction between **connections** (the WebSocket transport links that ADK establishes to Live API) and **sessions** (the logical conversation contexts maintained by Live API). Unlike traditional request-response APIs, the Bidi-streaming architecture introduces unique constraints: connection timeouts, session duration limits that vary by modality (audio-only vs audio+video), finite context windows, and concurrent session quotas that differ between Gemini Live API and Vertex AI Live API.
 
 ### ADK `Session` vs Live API Session
 

--- a/docs/tools-custom/function-tools.md
+++ b/docs/tools-custom/function-tools.md
@@ -250,7 +250,7 @@ When using a `LongRunningFunctionTool`, your function can initiate the long-runn
     server to do the task.
 
 !!! tip "Tip: Parallel execution"
-    Depending on the type of tool you are building, designing for asychronous
+    Depending on the type of tool you are building, designing for asynchronous
     operation may be a better solution than creating a long running tool. For
     more information, see
     [Increase tool performance with parallel execution](/adk-docs/tools-custom/performance/).
@@ -262,7 +262,7 @@ In Python, you wrap a function with `LongRunningFunctionTool`. In Java, you pass
 
 1. **Initiation:** When the LLM calls the tool, your function starts the long-running operation.
 
-2. **Initial Updates:** Your function should optionally return an initial result (e.g. the long-running operaiton id). The ADK framework takes the result and sends it back to the LLM packaged within a `FunctionResponse`. This allows the LLM to inform the user (e.g., status, percentage complete, messages). And then the agent run is ended / paused.
+2. **Initial Updates:** Your function should optionally return an initial result (e.g. the long-running operation id). The ADK framework takes the result and sends it back to the LLM packaged within a `FunctionResponse`. This allows the LLM to inform the user (e.g., status, percentage complete, messages). And then the agent run is ended / paused.
 
 3. **Continue or Wait:** After each agent run is completed. Agent client can query the progress of the long-running operation and decide whether to continue the agent run with an intermediate response (to update the progress) or wait until a final response is retrieved. Agent client should send the intermediate or final response back to the agent for the next run.
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -83,7 +83,7 @@ Check out the following pre-built tools that you can use with ADK agents:
     </div>
     <div class="tool-card-content">
       <h3>Bigtable Tools</h3>
-      <p>Interact with Bigtable to retrieve data and and execute SQL</p>
+      <p>Interact with Bigtable to retrieve data and execute SQL</p>
     </div>
   </a>
 


### PR DESCRIPTION
- Correct typos and double-space issues across docs.
- Clean up repeated words to improve readability.