### PR TITLE
docs: fix typo in BigQuery DDL (missing space before OPTIONS)

### DIFF
--- a/docs/observability/bigquery-agent-analytics.md
+++ b/docs/observability/bigquery-agent-analytics.md
@@ -213,7 +213,7 @@ production, we recommend creating the table manually using the following DDL, wh
 ```sql
 CREATE TABLE `your-gcp-project-id.adk_agent_logs.agent_events_v2`
 (
-  timestamp TIMESTAMP NOT NULLOPTIONS(description="The UTC time at which the event was logged."),
+  timestamp TIMESTAMP NOT NULL OPTIONS(description="The UTC time at which the event was logged."),
   event_type STRING OPTIONS(description="Indicates the type of event being logged (e.g., 'LLM_REQUEST', 'TOOL_COMPLETED')."),
   agent STRING OPTIONS(description="The name of the ADK agent or author associated with the event."),
   session_id STRING OPTIONS(description="A unique identifier to group events within a single conversation or user session."),


### PR DESCRIPTION
Thank you for creating and maintaining this amazing project! 
I found a small typo while reading the documentation and would like to contribute a fix.

## Summary
Fixed a typo in the BigQuery DDL example in the agent analytics documentation.

## Changes
- Added missing space between `NOT NULL` and `OPTIONS` in the DDL statement

## Before
timestamp TIMESTAMP NOT NULLOPTIONS(description="...")## After
timestamp TIMESTAMP NOT NULL OPTIONS(description="...")## Related Files
- `docs/observability/bigquery-agent-analytics.md`