### PR TITLE
docs: update MCP Toolbox guide to `toolbox-adk`

### DIFF
--- a/docs/tools/google-cloud/mcp-toolbox-for-databases.md
+++ b/docs/tools/google-cloud/mcp-toolbox-for-databases.md
@@ -92,7 +92,7 @@ documentation:
 
     ### Loading Toolbox Tools
 
-    Once you’re Toolbox server is configured and up and running, you can load tools
+    Once your Toolbox server is configured, up and running, you can load tools
     from your server using ADK:
 
     ```python
@@ -106,6 +106,59 @@ documentation:
     root_agent = Agent(
         ...,
         tools=[toolset] # Provide the toolset to the Agent
+    )
+    ```
+
+    ### Authentication
+
+    The `ToolboxToolset` supports various authentication strategies including Workload Identity (ADC), User Identity (OAuth2), and API Keys. For full documentation, see the [Toolbox ADK Authentication Guide](https://github.com/googleapis/mcp-toolbox-sdk-python/tree/main/packages/toolbox-adk#authentication).
+
+    **Example: Workload Identity (ADC)**
+
+    Recommended for Cloud Run, GKE, or local development with `gcloud auth login`.
+
+    ```python
+    from google.adk.tools.toolbox_toolset import ToolboxToolset
+    from toolbox_adk import CredentialStrategy
+
+    # target_audience: The URL of your Toolbox server
+    creds = CredentialStrategy.workload_identity(target_audience="<TOOLBOX_URL>")
+
+    toolset = ToolboxToolset(
+        server_url="<TOOLBOX_URL>",
+        credentials=creds
+    )
+    ```
+
+    ### Advanced Configuration
+
+    You can configure parameter binding, request hooks, and additional headers. See the [Toolbox ADK documentation](https://github.com/googleapis/mcp-toolbox-sdk-python/tree/main/packages/toolbox-adk) for details.
+
+    #### Parameter Binding
+
+    Bind values to tool parameters globally. These values are hidden from the model.
+
+    ```python
+    toolset = ToolboxToolset(
+        server_url="...",
+        bound_params={
+            "region": "us-central1",
+            "api_key": lambda: get_api_key() # Can be a callable
+        }
+    )
+    ```
+
+    #### Usage with Hooks
+
+    Attach `pre_hook` and `post_hook` functions to execute logic before and after tool invocation.
+
+    ```python
+    async def log_start(context, args):
+        print(f"Starting tool with args: {args}")
+
+    toolset = ToolboxToolset(
+        server_url="...",
+        pre_hook=log_start
     )
     ```
 


### PR DESCRIPTION
Updates the MCP Toolbox guide to reference the new `toolbox-adk` package and demonstrates the simplified `ToolboxToolset` usage pattern. This aligns the documentation with the latest SDK changes.