### PR TITLE
Added a section for open models on VertexAI MaaS

### DIFF
--- a/docs/agents/models/vertex.md
+++ b/docs/agents/models/vertex.md
@@ -168,7 +168,7 @@ Vertex AI.
 
     1.  **Vertex AI Environment:**
         *   Ensure your Google Cloud project and region are correctly set up.
-        *   **Application Default Credentials (ADC):** Make sure ADC is configured correctly in your environment. This is typically done by running `gcloud auth application-default login`. The Java client libraries will use these credentials to authenticate with Vertex AI. Follow the [Google Cloud Java documentation on ADC](https://cloud.google.com/java/docs/reference/google-auth-library/latest/com.google.auth.oauth2.GoogleCredentials#com_google_auth_oauth2_GoogleCredentials_getApplicationDefault__) for detailed setup.
+        *   **Application Default Credentials (ADC):** Make sure ADC is configured correctly in your environment. This is typically done by running `gcloud auth application-default login`. The Java client libraries use these credentials to authenticate with Vertex AI. Follow the [Google Cloud Java documentation on ADC](https://cloud.google.com/java/docs/reference/google-auth-library/latest/com.google.auth.oauth2.GoogleCredentials#com_google_auth_oauth2_GoogleCredentials_getApplicationDefault__) for detailed setup.
 
     2.  **Provider Library Dependencies:**
         *   **Third-Party Client Libraries (Often Transitive):** The ADK core library often includes the necessary client libraries for common third-party models on Vertex AI (like Anthropic's required classes) as **transitive dependencies**. This means you might not need to explicitly add a separate dependency for the Anthropic Vertex SDK in your `pom.xml` or `build.gradle`.
@@ -230,14 +230,13 @@ Vertex AI.
     }
     ```
 
-## Open Models on Vertex AI {#third-party-open-models-on-vertex-ai-eg-meta-llama}
+## Open Models on Vertex AI {#open-models}
 
 <div class="language-support-tag">
     <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span>
 </div>
 
-
-Vertex AI offers a curated selection of open-source models, such as Meta Llama, through Model-as-a-Service (MaaS). These models are accessible via managed APIs, allowing you to deploy and scale without managing the underlying infrastructure. For a full list of available options, please refer to the [Vertex AI open models for MaaS](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/use-open-models#open-models) documentation.
+Vertex AI offers a curated selection of open-source models, such as Meta Llama, through Model-as-a-Service (MaaS). These models are accessible via managed APIs, allowing you to deploy and scale without managing the underlying infrastructure. For a full list of available options, see the [Vertex AI open models for MaaS](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/maas/use-open-models#open-models) documentation.
 
 === "Python"
 


### PR DESCRIPTION
The current ADK documentation for [Vertex AI hosted models](https://google.github.io/adk-docs/agents/models/vertex/#vertex-ai-hosted-models-for-adk-agents) only talks about "Model Garden Deployments",  "Fine-tuned Model Endpoints" and "Anthropic Claude on Vertex AI MaaS".

It doesn't talk about Open models on Vertex AI MaaS that requires LiteLLM wrapper. 

Although the documentation has a separate section for [LiteLLM model connector for ADK agents](https://google.github.io/adk-docs/agents/models/litellm/#litellm-model-connector-for-adk-agents), it doesn't talk about remote hosted models in the context of VertexAI MaaS. 

This is causing some confusion with our developers and hence adding a new section for open models in the "Vertex AI hosted" section.