### PR TITLE
Add typescript deployment

### DIFF
--- a/docs/deploy/cloud-run.md
+++ b/docs/deploy/cloud-run.md
@@ -365,8 +365,7 @@ unless you specify it as deployment setting, such as the `--with_ui` option for
 
     #### Command usage
 
-    This deployment command should be run from the directory of your agent code:
-    where your `package.json` file is located.
+    This deployment command should be run from the directory of your agent code, where your `package.json` file is located.
 
     ##### Minimal command
 


### PR DESCRIPTION
I was able to get the TypeScript deployment working with `npx adk`, but I don't know what I'm missing for the Docker deployment.

Not in a position to merge, but thought I would share the draft since the `npx adk` is working.