### PR TITLE
Integrations: Fix tool card icon sizing and missing metadata

### DIFF
--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -326,8 +326,11 @@ nav.md-nav--primary .md-nav__item--section>.md-nav__link {
 }
 
 .tool-card-image-wrapper {
-  width: 70px;
-  height: auto;
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background-color: transparent;
   padding: 0.5rem;
   box-sizing: border-box;
@@ -335,7 +338,9 @@ nav.md-nav--primary .md-nav__item--section>.md-nav__link {
 }
 
 .tool-card-image-wrapper img {
-  width: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
   height: auto;
   object-fit: contain;
 }

--- a/docs/tools/third-party/ag-ui.md
+++ b/docs/tools/third-party/ag-ui.md
@@ -1,6 +1,7 @@
 ---
 catalog_title: AG-UI
-catalog_description: Build rich user experiences with CopilotKit and other clients
+catalog_description: Build interactive chat UIs with streaming, state sync, and agentic actions
+catalog_icon: /adk-docs/assets/tools-ag-ui.png
 ---
 
 # Build chat experiences with AG-UI and CopilotKit

--- a/docs/tools/third-party/mongodb.md
+++ b/docs/tools/third-party/mongodb.md
@@ -1,3 +1,9 @@
+---
+catalog_title: MongoDB
+catalog_description: Query collections, manage databases, and analyze schemas
+catalog_icon: /adk-docs/assets/tools-mongodb.png
+---
+
 # MongoDB
 
 <div class="language-support-tag">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,7 +139,7 @@ plugins:
       j2_variable_end_string: '$}}'
       # alternative to {# #}
       j2_comment_start_string: '{{#'
-      j2_comment_end_string: '#}}'   
+      j2_comment_end_string: '#}}'
   - redirects:
       redirect_maps:
         'get-started/local-testing.md': 'runtime/api-server.md'
@@ -266,6 +266,7 @@ nav:
         - Vertex AI express mode: tools/google-cloud/express-mode.md
       - Third-party tools:
         - tools/third-party/index.md
+        - Agentic UI (AG-UI): tools/third-party/ag-ui.md
         - Asana: tools/third-party/asana.md
         - Atlassian: tools/third-party/atlassian.md
         - Cartesia: tools/third-party/cartesia.md
@@ -283,7 +284,6 @@ nav:
         - PayPal: tools/third-party/paypal.md
         - Qdrant: tools/third-party/qdrant.md
         - Stripe: tools/third-party/stripe.md
-        - Agentic UI (AG-UI): tools/third-party/ag-ui.md
       - Tool limitations: tools/limitations.md
     - Custom Tools:
       - tools-custom/index.md


### PR DESCRIPTION
Followup to #1210 with a couple of small fixes:

- Fixes tool card icon sizes to be consistent
- Adds frontmatter for AG-UI and MongoDB