### PR TITLE
chore: update deploy preview config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,11 @@
 [build]
 publish = "site"
-command = "pip install -r requirements.txt && mkdocs build"
 
 [build.environment]
 PYTHON_VERSION = "3.12"
+
+[context.production]
+  command = "echo 'Skipping — production is deployed via GitHub Pages' && mkdir -p site && echo '<html><body>Production is on GitHub Pages</body></html>' > site/index.html"
+
+[context.deploy-preview]
+  command = "pip install -r requirements.txt && mkdocs build"


### PR DESCRIPTION
Override deploy and preview deploy config.

For deploy - build a placeholder site indicating the production deployment is done via Github pages.
Preview deploy - allow site to be built for previews.