### PR TITLE
Add "connectors" tag to n8n integration

### DIFF
--- a/docs/integrations/n8n.md
+++ b/docs/integrations/n8n.md
@@ -2,7 +2,7 @@
 catalog_title: n8n
 catalog_description: Trigger automated workflows, connect apps, and process data
 catalog_icon: /adk-docs/integrations/assets/n8n.png
-catalog_tags: ["mcp"]
+catalog_tags: ["mcp", "connectors"]
 ---
 
 # n8n MCP tool for ADK


### PR DESCRIPTION
Add "connectors" tag to the n8n integration page to categorize it alongside other connector/integration platform tools in the catalog. This "connectors" category will also include #1319 as another third-party integration.