### PR TITLE
docs: Align BigQuery Agent Analytics doc with v1.25.0 plugin code

### DIFF
--- a/docs/integrations/bigquery-agent-analytics.md
+++ b/docs/integrations/bigquery-agent-analytics.md
@@ -8,16 +8,16 @@ catalog_tags: ["observability", "google"]
 # BigQuery Agent Analytics plugin for ADK
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v1.21.0</span><span class="lst-preview">Preview</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v1.25.0</span><span class="lst-preview">Preview</span>
 </div>
 
 !!! important "Version Requirement"
 
-    Use ADK Python version 1.21.0 or higher to make full use of the features described in this document.
+    Use ADK Python version 1.25.0 or higher to make full use of the features described in this document, including auto-schema-upgrade, tool provenance tracking, and HITL event tracing.
 
 The BigQuery Agent Analytics Plugin significantly enhances the Agent Development Kit (ADK) by providing a robust solution for in-depth agent behavior analysis. Using the ADK Plugin architecture and the **BigQuery Storage Write API**, it captures and logs critical operational events directly into a Google BigQuery table, empowering you with advanced capabilities for debugging, real-time monitoring, and comprehensive offline performance evaluation.
 
-Version 1.21.0 introduces **Hybrid Multimodal Logging**, allowing you to log large payloads (images, audio, blobs) by offloading them to Google Cloud Storage (GCS) while keeping a structured reference (`ObjectRef`) in BigQuery.
+Version 1.25.0 adds **Auto Schema Upgrade** (safely add new columns to existing tables), **Tool Provenance** tracking (LOCAL, MCP, SUB_AGENT, A2A, TRANSFER_AGENT), and **HITL Event Tracing** for human-in-the-loop interactions.
 
 !!! example "Preview release"
 
@@ -40,6 +40,8 @@ Version 1.21.0 introduces **Hybrid Multimodal Logging**, allowing you to log lar
     asynchronously using the Storage Write API to allow high throughput and low latency.
 -   **Multimodal Analysis**: Log and analyze text, images, and other modalities. Large files are offloaded to GCS, making them accessible to BigQuery ML via Object Tables.
 -   **Distributed Tracing**: Built-in support for OpenTelemetry-style tracing (`trace_id`, `span_id`) to visualize agent execution flows.
+-   **Tool Provenance**: Track the origin of each tool call (local function, MCP server, sub-agent, A2A remote agent, or transfer agent).
+-   **Human-in-the-Loop (HITL) Tracing**: Dedicated event types for credential requests, confirmation prompts, and user input requests.
 
 The agent event data recorded varies based on the ADK event type. For more
 information, see [Event types and payloads](#event-types).
@@ -189,8 +191,9 @@ You can customize the plugin using `BigQueryLoggerConfig`.
 -   **`log_multi_modal_content`** (`bool`, default: `True`): Whether to log detailed content parts (including GCS references).
 -   **`queue_max_size`** (`int`, default: `10000`): The maximum number of events to hold in the in-memory queue before dropping new events.
 -   **`retry_config`** (`RetryConfig`, default: `RetryConfig()`): Configuration for retrying failed BigQuery writes (attributes: `max_retries`, `initial_delay`, `multiplier`, `max_delay`).
--   **`log_session_metadata`** (`bool`, default: `True`): If True, logs metadata from the `session` object (e.g., `session.metadata`) into the `attributes` column.
+-   **`log_session_metadata`** (`bool`, default: `True`): If True, logs session information into the `attributes` column, including `session_id`, `app_name`, `user_id`, and the session `state` dictionary (e.g., custom state like gchat thread-id, customer_id).
 -   **`custom_tags`** (`Dict[str, Any]`, default: `{}`): A dictionary of static tags (e.g., `{"env": "prod", "version": "1.0"}`) to be included in the `attributes` column for every event.
+-   **`auto_schema_upgrade`** (`bool`, default: `True`): When enabled, the plugin automatically adds new columns to an existing table when the plugin schema evolves. Only additive changes are made (columns are never dropped or altered). A version label (`adk_schema_version`) on the table ensures the diff runs at most once per schema version. Safe to leave enabled.
 
 
 The following code sample shows how to define a configuration for the
@@ -231,6 +234,7 @@ config = BigQueryLoggerConfig(
     max_content_length=500, # Truncate content to 500 chars
     content_formatter=redact_dollar_amounts, # Redact the dollar amounts in the logging content
     queue_max_size=10000, # Max events to hold in memory
+    auto_schema_upgrade=True, # Automatically add new columns to existing tables
     # retry_config=RetryConfig(max_retries=3), # Optional: Configure retries
 )
 
@@ -246,8 +250,8 @@ The events table (`agent_events_v2`) uses a flexible schema. The following table
 
 | Field Name | Type | Mode | Description | Example Value |
 |:---|:---|:---|:---|:---|
-| **timestamp** | `TIMESTAMP` | `REQUIRED` | UTC timestamp of event creation. Acts as the primary ordering key and often the daily partitioning key. Precision is microsecond. | `2026-02-03 20:52:17 UTC` |
-| **event_type** | `STRING` | `NULLABLE` | The canonical event category. Standard values include `LLM_REQUEST`, `LLM_RESPONSE`, `LLM_ERROR`, `TOOL_STARTING`, `TOOL_COMPLETED`, `TOOL_ERROR`, `AGENT_STARTING`, `AGENT_COMPLETED`, `STATE_DELTA`. Used for high-level filtering. | `LLM_REQUEST` |
+| **timestamp** | `TIMESTAMP` | `REQUIRED` | UTC timestamp of event creation. Acts as the primary ordering key and the daily partitioning key. Precision is microsecond. | `2026-02-03 20:52:17 UTC` |
+| **event_type** | `STRING` | `NULLABLE` | The canonical event category. Standard values include `LLM_REQUEST`, `LLM_RESPONSE`, `LLM_ERROR`, `TOOL_STARTING`, `TOOL_COMPLETED`, `TOOL_ERROR`, `AGENT_STARTING`, `AGENT_COMPLETED`, `STATE_DELTA`, `INVOCATION_STARTING`, `INVOCATION_COMPLETED`, `USER_MESSAGE_RECEIVED`, and HITL events (see [HITL events](#hitl-events)). Used for high-level filtering. | `LLM_REQUEST` |
 | **agent** | `STRING` | `NULLABLE` | The name of the agent responsible for this event. Defined during agent initialization or via the `root_agent_name` context. | `my_bq_agent` |
 | **session_id** | `STRING` | `NULLABLE` | A persistent identifier for the entire conversation thread. Stays constant across multiple turns and sub-agent calls. | `04275a01-1649-4a30-b6a7-5b443c69a7bc` |
 | **invocation_id** | `STRING` | `NULLABLE` | The unique identifier for a single execution turn or request cycle. Corresponds to `trace_id` in many contexts. | `e-b55b2000-68c6-4e8b-b3b3-ffb454a92e40` |
@@ -256,7 +260,7 @@ The events table (`agent_events_v2`) uses a flexible schema. The following table
 | **span_id** | `STRING` | `NULLABLE` | The **OpenTelemetry** Span ID (16-char hex). Uniquely identifies this specific atomic operation. | `69867a836cd94798be2759d8e0d70215` |
 | **parent_span_id** | `STRING` | `NULLABLE` | The Span ID of the immediate caller. Used to reconstruct the parent-child execution tree (DAG). | `ef5843fe40764b4b8afec44e78044205` |
 | **content** | `JSON` | `NULLABLE` | The primary event payload. Structure is polymorphic based on `event_type`. | `{"system_prompt": "You are...", "prompt": [{"role": "user", "content": "hello"}], "response": "Hi", "usage": {"total": 15}}` |
-| **attributes** | `JSON` | `NULLABLE` | Metadata/Enrichment (usage stats, model info, custom tags). | `{"model": "gemini-2.5-flash", "usage_metadata": {"total_token_count": 15}, "state_delta": {"key": "val"}, "session_metadata": {"key": "val"}}` |
+| **attributes** | `JSON` | `NULLABLE` | Metadata/Enrichment (usage stats, model info, tool provenance, custom tags). | `{"model": "gemini-2.5-flash", "usage_metadata": {"total_token_count": 15}, "session_metadata": {"session_id": "...", "app_name": "...", "user_id": "...", "state": {}}, "custom_tags": {"env": "prod"}}` |
 | **latency_ms** | `JSON` | `NULLABLE` | Performance metrics. Standard keys are `total_ms` (wall-clock duration) and `time_to_first_token_ms` (streaming latency). | `{"total_ms": 1250, "time_to_first_token_ms": 450}` |
 | **status** | `STRING` | `NULLABLE` | High-level outcome. Values: `OK` (success) or `ERROR` (failure). | `OK` |
 | **error_message** | `STRING` | `NULLABLE` | Human-readable exception message or stack trace fragment. Populated only when `status` is `ERROR`. | `Error 404: Dataset not found` |
@@ -338,6 +342,7 @@ Captures the prompt sent to the model, including conversation history and system
   "attributes": {
     "root_agent_name": "my_bq_agent",
     "model": "gemini-2.5-flash",
+    "tools": ["list_dataset_ids", "execute_sql"],
     "llm_config": {
       "temperature": 0.5,
       "top_p": 0.9
@@ -397,7 +402,16 @@ Logged when an LLM call fails with an exception. The error message is captured a
 
 #### Tool usage (plugin lifecycle)
 
-These events track the execution of tools by the agent.
+These events track the execution of tools by the agent. Each tool event includes a `tool_origin` field that classifies the tool's provenance:
+
+| Tool Origin | Description |
+|:---|:---|
+| `LOCAL` | `FunctionTool` instances (local Python functions) |
+| `MCP` | Model Context Protocol tools (`McpTool` instances) |
+| `SUB_AGENT` | `AgentTool` instances (sub-agents) |
+| `A2A` | Remote Agent-to-Agent instances (`RemoteA2aAgent`) |
+| `TRANSFER_AGENT` | `TransferToAgentTool` instances |
+| `UNKNOWN` | Unclassified tools |
 
 **4. TOOL_STARTING**
 
@@ -410,7 +424,8 @@ Logged when an agent begins executing a tool.
     "tool": "list_dataset_ids",
     "args": {
       "project_id": "bigquery-public-data"
-    }
+    },
+    "tool_origin": "LOCAL"
   }
 }
 ```
@@ -427,7 +442,8 @@ Logged when a tool execution finishes.
     "result": [
       "austin_311",
       "austin_bikeshare"
-    ]
+    ],
+    "tool_origin": "LOCAL"
   },
   "latency_ms": {
     "total_ms": 467
@@ -437,7 +453,7 @@ Logged when a tool execution finishes.
 
 **6. TOOL_ERROR**
 
-Logged when a tool execution fails with an exception. Captures the tool name, arguments, and error message.
+Logged when a tool execution fails with an exception. Captures the tool name, arguments, tool origin, and error message.
 
 ```json
 {
@@ -446,7 +462,8 @@ Logged when a tool execution fails with an exception. Captures the tool name, ar
     "tool": "list_dataset_ids",
     "args": {
       "project_id": "nonexistent-project"
-    }
+    },
+    "tool_origin": "LOCAL"
   },
   "error_message": "Error 404: Dataset not found",
   "latency_ms": {
@@ -507,6 +524,60 @@ Tracks changes to the agent's internal state (e.g., token cache updates).
 
   </tbody>
 </table>
+
+#### Human-in-the-Loop (HITL) Events {#hitl-events}
+
+The plugin automatically detects calls to ADK's synthetic HITL tools and emits dedicated event types for them. These events are logged **in addition to** the normal `TOOL_STARTING` / `TOOL_COMPLETED` events.
+
+The following HITL tool names are recognized:
+
+- `adk_request_credential` — Request for user credentials (e.g., OAuth tokens)
+- `adk_request_confirmation` — Request for user confirmation before proceeding
+- `adk_request_input` — Request for free-form user input
+
+<table>
+  <thead>
+    <tr>
+      <th><strong>Event Type</strong></th>
+      <th><strong>Trigger</strong></th>
+      <th><strong>Content (JSON) Structure</strong></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><p><pre>HITL_CREDENTIAL_REQUEST</pre></p></td>
+      <td>Agent calls <code>adk_request_credential</code></td>
+      <td><p><pre>{"tool": "adk_request_credential", "args": {...}}</pre></p></td>
+    </tr>
+    <tr>
+      <td><p><pre>HITL_CREDENTIAL_REQUEST_COMPLETED</pre></p></td>
+      <td>User provides credential response</td>
+      <td><p><pre>{"tool": "adk_request_credential", "result": {...}}</pre></p></td>
+    </tr>
+    <tr>
+      <td><p><pre>HITL_CONFIRMATION_REQUEST</pre></p></td>
+      <td>Agent calls <code>adk_request_confirmation</code></td>
+      <td><p><pre>{"tool": "adk_request_confirmation", "args": {...}}</pre></p></td>
+    </tr>
+    <tr>
+      <td><p><pre>HITL_CONFIRMATION_REQUEST_COMPLETED</pre></p></td>
+      <td>User provides confirmation response</td>
+      <td><p><pre>{"tool": "adk_request_confirmation", "result": {...}}</pre></p></td>
+    </tr>
+    <tr>
+      <td><p><pre>HITL_INPUT_REQUEST</pre></p></td>
+      <td>Agent calls <code>adk_request_input</code></td>
+      <td><p><pre>{"tool": "adk_request_input", "args": {...}}</pre></p></td>
+    </tr>
+    <tr>
+      <td><p><pre>HITL_INPUT_REQUEST_COMPLETED</pre></p></td>
+      <td>User provides input response</td>
+      <td><p><pre>{"tool": "adk_request_input", "result": {...}}</pre></p></td>
+    </tr>
+  </tbody>
+</table>
+
+HITL request events are detected from `function_call` parts in `on_event_callback`. HITL completion events are detected from `function_response` parts in both `on_event_callback` and `on_user_message_callback`.
 
 #### GCS Offloading Examples (Multimodal & Large Text)
 
@@ -669,6 +740,35 @@ SELECT
   CAST(JSON_VALUE(latency_ms, '$.total_ms') AS INT64) as latency_ms
 FROM `your-gcp-project-id.your-dataset-id.agent_events_v2`
 WHERE event_type IN ('LLM_ERROR', 'TOOL_ERROR')
+ORDER BY timestamp DESC
+LIMIT 20;
+```
+
+**Tool Provenance Analysis**
+
+```sql
+SELECT
+  JSON_VALUE(content, '$.tool_origin') as tool_origin,
+  JSON_VALUE(content, '$.tool') as tool_name,
+  COUNT(*) as call_count,
+  AVG(CAST(JSON_VALUE(latency_ms, '$.total_ms') AS INT64)) as avg_latency_ms
+FROM `your-gcp-project-id.your-dataset-id.agent_events_v2`
+WHERE event_type = 'TOOL_COMPLETED'
+GROUP BY tool_origin, tool_name
+ORDER BY call_count DESC;
+```
+
+**HITL Interaction Analysis**
+
+```sql
+SELECT
+  timestamp,
+  event_type,
+  session_id,
+  JSON_VALUE(content, '$.tool') as hitl_tool,
+  content
+FROM `your-gcp-project-id.your-dataset-id.agent_events_v2`
+WHERE event_type LIKE 'HITL_%'
 ORDER BY timestamp DESC
 LIMIT 20;
 ```


### PR DESCRIPTION
## Summary
- **Version bump**: Update version requirement from v1.21.0 to v1.25.0
- **Missing config**: Add `auto_schema_upgrade` option to Configuration section
- **Tool provenance**: Add `tool_origin` field to all TOOL_* event content examples (LOCAL, MCP, SUB_AGENT, A2A, TRANSFER_AGENT, UNKNOWN) with classification table
- **HITL events**: Add new section documenting all 6 HITL event types (HITL_CREDENTIAL_REQUEST, HITL_CONFIRMATION_REQUEST, HITL_INPUT_REQUEST, and _COMPLETED counterparts)
- **Fix `log_session_metadata`**: Correct description to reference actual fields (`session.state`, `session.id`, `session.app_name`, `session.user_id`) instead of `session.metadata`
- **LLM_REQUEST attributes**: Add `tools` attribute (list of tool names available to the model)
- **Schema table**: Add missing event types (INVOCATION_STARTING/COMPLETED, USER_MESSAGE_RECEIVED, HITL_*) to event_type description
- **New queries**: Add Tool Provenance Analysis and HITL Interaction Analysis SQL examples

All changes verified against the latest plugin source code at commit `4260ef0c`.

## Test plan
- [ ] Verify doc renders correctly in MkDocs
- [ ] Cross-reference all event type names, content structures, and config options against plugin source

🤖 Generated with [Claude Code](https://claude.com/claude-code)