### PR TITLE
gitignore: ignore content of `site` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,7 @@ docs/site
 
 # Bash files
 ***/*.sh
+
+# Ignore a local build but keep the directory
+/site/*
+!/site/.gitkeep


### PR DESCRIPTION
The `site` directory used for a local build is not included in `.gitignore`. This produces large Git diffs after running `mkdocs serve` locally.

I've added a pattern to `.gitignore` to ignore anything but an already existing `.gitkeep` file in the `site` directory.

This should keep the directory as is in Git and prevent any accidental commits of generated site builds.