### PR TITLE
doc: update ADK Java to 0.6.0

### DIFF
--- a/docs/deploy/cloud-run.md
+++ b/docs/deploy/cloud-run.md
@@ -532,12 +532,12 @@ unless you specify it as deployment setting, such as the `--with_ui` option for
           <dependency>
              <groupId>com.google.adk</groupId>
              <artifactId>google-adk</artifactId>
-             <version>0.5.0</version>
+             <version>0.6.0</version>
           </dependency>
           <dependency>
              <groupId>com.google.adk</groupId>
              <artifactId>google-adk-dev</artifactId>
-             <version>0.5.0</version>
+             <version>0.6.0</version>
           </dependency>
         </dependencies>
 

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -99,13 +99,13 @@
             <dependency>
                 <groupId>com.google.adk</groupId>
                 <artifactId>google-adk</artifactId>
-                <version>0.5.0</version>
+                <version>0.6.0</version>
             </dependency>
             <!-- The ADK dev web UI to debug your agent -->
             <dependency>
                 <groupId>com.google.adk</groupId>
                 <artifactId>google-adk-dev</artifactId>
-                <version>0.5.0</version>
+                <version>0.6.0</version>
             </dependency>
         </dependencies>
 
@@ -118,8 +118,8 @@
 
     ```title="build.gradle"
     dependencies {
-        implementation 'com.google.adk:google-adk:0.5.0'
-        implementation 'com.google.adk:google-adk-dev:0.5.0'
+        implementation 'com.google.adk:google-adk:0.6.0'
+        implementation 'com.google.adk:google-adk-dev:0.6.0'
     }
     ```
 

--- a/docs/get-started/java.md
+++ b/docs/get-started/java.md
@@ -103,7 +103,7 @@ An ADK agent project requires this dependency in your
     <dependency>
         <groupId>com.google.adk</groupId>
         <artifactId>google-adk</artifactId>
-        <version>0.5.0</version>
+        <version>0.6.0</version>
     </dependency>
 </dependencies>
 ```
@@ -138,13 +138,13 @@ additional settings with the following configuration code:
             <dependency>
                 <groupId>com.google.adk</groupId>
                 <artifactId>google-adk</artifactId>
-                <version>0.3.0</version>
+                <version>0.6.0</version>
             </dependency>
             <!-- The ADK dev web UI to debug your agent -->
             <dependency>
                 <groupId>com.google.adk</groupId>
                 <artifactId>google-adk-dev</artifactId>
-                <version>0.3.0</version>
+                <version>0.6.0</version>
             </dependency>
         </dependencies>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,13 +46,13 @@ from simple tasks to complex workflows.
     <dependency>
         <groupId>com.google.adk</groupId>
         <artifactId>google-adk</artifactId>
-        <version>0.5.0</version>
+        <version>0.6.0</version>
     </dependency>
     ```
 
     ```gradle title="build.gradle"
     dependencies {
-        implementation 'com.google.adk:google-adk:0.5.0'
+        implementation 'com.google.adk:google-adk:0.6.0'
     }
     ```
 


### PR DESCRIPTION
ADK Java 0.6.0 was released a few days ago.
This PR updates all the version references (in particular Maven and Gradle dependency coordinates)