### PR TITLE
Add link to ADK skills source on GitHub

### DIFF
--- a/docs/tutorials/coding-with-ai.md
+++ b/docs/tutorials/coding-with-ai.md
@@ -25,13 +25,14 @@ directory:
 npx skills add google/adk-docs/skills -y
 ```
 
-The ADK skills package includes:
+Browse the [ADK skills on
+GitHub](https://github.com/google/adk-docs/tree/main/skills), which include:
 
 | Skill | Description |
 |-------|-------------|
 | `adk-cheatsheet` | Python API quick reference and docs index |
-| `adk-dev-guide` | Development lifecycle and coding guidelines |
 | `adk-deploy-guide` | Agent Engine, Cloud Run, and GKE deployment |
+| `adk-dev-guide` | Development lifecycle and coding guidelines |
 | `adk-eval-guide` | Evaluation methodology and scoring |
 | `adk-observability-guide` | Tracing, logging, and integrations |
 | `adk-scaffold` | Project scaffolding |


### PR DESCRIPTION
Adds a link to the skills source on GitHub so users can review skills before installing.