### PR TITLE
Fix: The model referenced in the get started tutorial is not available

### DIFF
--- a/examples/python/snippets/get-started/multi_tool_agent/agent.py
+++ b/examples/python/snippets/get-started/multi_tool_agent/agent.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import datetime
 from zoneinfo import ZoneInfo
 from google.adk.agents import Agent


### PR DESCRIPTION
The example code for "get started" uses a template that is no longer available.

The change involves referencing an available template.