### PR TITLE
docs: add Aegis governance integration

### DIFF
--- a/docs/integrations/aegis.md
+++ b/docs/integrations/aegis.md
@@ -1,0 +1,118 @@
+---
+catalog_title: Aegis
+catalog_description: Governance runtime with prompt injection detection, PII masking, and policy-as-code for ADK agents
+catalog_icon: /adk-docs/integrations/assets/aegis.svg
+catalog_tags: ["safety"]
+---
+
+# Aegis governance for ADK
+
+<div class="language-support-tag">
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
+</div>
+
+[Aegis](https://github.com/Acacian/aegis) is an open-source governance runtime
+that auto-instruments Google ADK agents with security guardrails. With a single
+function call, Aegis adds prompt injection detection, PII masking, and
+policy-as-code enforcement to your agents — no code changes required.
+
+## Use cases
+
+- **Prompt Injection Detection**: Detect and block prompt injection attacks with
+  107 detection patterns across 13 categories.
+
+- **PII Masking**: Automatically redact sensitive data such as emails, phone
+  numbers, and SSNs from agent inputs and outputs.
+
+- **Policy-as-Code**: Define governance rules in YAML and enforce them with
+  `aegis plan` and `aegis test` CLI commands.
+
+- **Audit Trail**: Maintain a complete log of all LLM interactions for
+  compliance and debugging.
+
+## Prerequisites
+
+- Python 3.10 or later
+- Google ADK installed (`google-adk`)
+
+## Installation
+
+Install Aegis alongside ADK:
+
+```bash
+pip install agent-aegis google-adk
+```
+
+## Use with agent
+
+```python
+import aegis
+from google.adk.agents import Agent
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+
+# Auto-instrument all supported frameworks including Google ADK
+aegis.auto_instrument()
+
+agent = Agent(
+    model="gemini-2.0-flash",
+    name="assistant",
+    instruction="You are a helpful assistant.",
+)
+
+runner = Runner(
+    agent=agent,
+    app_name="my_app",
+    session_service=InMemorySessionService(),
+)
+```
+
+All agent interactions are now governed by Aegis guardrails automatically.
+
+## Policy configuration
+
+Define governance policies in a YAML file:
+
+```yaml
+# policy.yaml
+version: "1.0"
+guardrails:
+  injection_detection:
+    enabled: true
+    action: block
+  pii_masking:
+    enabled: true
+    mask_types: [email, phone, ssn]
+```
+
+Load the policy when initializing Aegis:
+
+```python
+import aegis
+
+aegis.auto_instrument()
+aegis.init(policy_path="policy.yaml")
+```
+
+Validate and test policies with the Aegis CLI:
+
+```bash
+aegis plan   # Preview policy changes
+aegis test   # Run policy test suite
+```
+
+## Key features
+
+Feature | Description
+---- | -----------
+Auto-instrumentation | One-line setup with `aegis.auto_instrument()`, no code changes needed
+Prompt injection detection | 107 detection patterns across 13 categories
+PII masking | Automatic redaction of emails, phone numbers, SSNs, and other sensitive data
+Policy-as-code | YAML-based governance rules with `aegis plan` and `aegis test` CLI
+Audit trail | Complete log of all LLM interactions for compliance
+
+## Resources
+
+- [Aegis Documentation](https://acacian.github.io/aegis/)
+- [Aegis on PyPI](https://pypi.org/project/agent-aegis/)
+- [Aegis GitHub Repository](https://github.com/Acacian/aegis)

--- a/docs/integrations/assets/aegis.svg
+++ b/docs/integrations/assets/aegis.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="400" height="400">
+  <defs>
+    <clipPath id="shield-clip">
+      <path d="M200 40 L340 100 C340 100 330 300 200 370 C70 300 60 100 60 100 Z"/>
+    </clipPath>
+  </defs>
+
+  <!-- Shield body -->
+  <path
+    d="M200 40 L340 100 C340 100 330 300 200 370 C70 300 60 100 60 100 Z"
+    fill="#2563eb"
+  />
+
+  <!-- Inner shield highlight -->
+  <path
+    d="M200 65 L320 115 C320 115 311 290 200 350 C89 290 80 115 80 115 Z"
+    fill="none"
+    stroke="rgba(255,255,255,0.25)"
+    stroke-width="2"
+  />
+
+  <!-- Central chevron / check mark -->
+  <polyline
+    points="150,200 190,245 260,165"
+    fill="none"
+    stroke="#ffffff"
+    stroke-width="22"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>


### PR DESCRIPTION
## Summary
Add integration page for [Aegis](https://github.com/Acacian/aegis), an open-source governance runtime for ADK agents.

## What is Aegis?
Aegis auto-instruments Google ADK with security guardrails via a single `aegis.auto_instrument()` call:

- **Prompt injection detection** — 107 detection patterns across 13 categories
- **PII masking** — automatic redaction of emails, phone numbers, SSNs
- **Policy-as-code** — YAML-based governance rules with `aegis plan` / `aegis test` CLI
- **Audit trail** — complete log of all LLM interactions

Zero code changes required.

## Changes
- `docs/integrations/aegis.md` — new integration page following the standard template
- `docs/integrations/assets/aegis.svg` — logo asset

## References
- PyPI: https://pypi.org/project/agent-aegis/
- Docs: https://acacian.github.io/aegis/
- GitHub: https://github.com/Acacian/aegis