### PR TITLE
Integrations: Remove evaluation tag, use observability tag

### DIFF
--- a/docs/integrations/langwatch.md
+++ b/docs/integrations/langwatch.md
@@ -2,7 +2,7 @@
 catalog_title: LangWatch
 catalog_description: Observability, tracing, evaluation, and prompt optimization for ADK agents
 catalog_icon: /integrations/assets/langwatch.png
-catalog_tags: ["observability", "evaluation"]
+catalog_tags: ["observability"]
 ---
 
 # LangWatch observability for ADK


### PR DESCRIPTION
Cleaning up category tags for observability integration. Remove evaluation tag, use observability tag.