### PR TITLE
Remove security advisory from index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,17 +34,6 @@ from simple tasks to complex workflows.
     Upgrade to ADK Java 1.0.0 to take advantage of these enhancements
     and ensure optimal performance in your applications.
 
-??? danger "ADK Python Security Advisory: LiteLLM supply chain compromise"
-
-    Unauthorized code was identified in LiteLLM versions 1.82.7 and 1.82.8 on
-    PyPI on March 24, 2026. If you use ADK Python with the `eval` or
-    `extensions` extras, update to the latest version of ADK Python immediately.
-    If you installed or upgraded LiteLLM during this period, rotate all secrets
-    and credentials. For details and required actions, refer to the [ADK
-    security advisory](https://github.com/google/adk-python/issues/5005) and
-    [LiteLLM's Security Update: Suspected Supply Chain
-    Incident](https://docs.litellm.ai/blog/security-update-march-2026).
-
 <div id="centered-install-tabs" class="install-command-container" markdown="1">
 
 <p class="get-started-text" style="text-align: center;">Get started:</p>


### PR DESCRIPTION
Remove security advisory announcement from docs index page.

- Advisory remains on LiteLLM page at https://adk.dev/agents/models/litellm/
- Parent issue remains in adk-python at https://github.com/google/adk-python/issues/5005
- For ongoing updates, refer to LiteLLM's security update: https://docs.litellm.ai/blog/security-update-march-2026