### PR TITLE
fix: avoid assigning result of delete_session which returns None

### DIFF
--- a/docs/sessions/session/index.md
+++ b/docs/sessions/session/index.md
@@ -58,7 +58,7 @@ are its key properties:
         print(f"---------------------------------")
 
         # Clean up (optional for this example)
-        temp_service = await temp_service.delete_session(app_name=example_session.app_name,
+        await temp_service.delete_session(app_name=example_session.app_name,
                                     user_id=example_session.user_id, session_id=example_session.id)
         print("The final status of temp_service - ", temp_service)
        ```


### PR DESCRIPTION
The delete_session method does not return the session service instance, but None instead. Assigning its result back to temp_service leads to unexpected behavior where temp_service becomes None.

This change removes the incorrect assignment and calls delete_session without reassigning, ensuring temp_service remains a valid service instance.

This aligns with the intended usage of delete_session as a side-effect-only method.