### PR TITLE
docs: align BQ AA plugin doc with latest main code

### DIFF
--- a/docs/integrations/bigquery-agent-analytics.md
+++ b/docs/integrations/bigquery-agent-analytics.md
@@ -1221,9 +1221,11 @@ OAuth tokens cached by `SessionStateCredentialService` or
 
 !!! info "No configuration required"
 
-    Built-in redaction is always active and cannot be disabled. It runs
-    before any custom `content_formatter` and applies recursively to
-    nested dictionaries and JSON-encoded strings within attribute values.
+    Built-in redaction is always active for structured attributes and
+    state logging, and applies recursively to nested dictionaries and
+    JSON-encoded strings within attribute values. Custom
+    `content_formatter` runs **first** on raw content, so use it to add
+    masking for secrets that may appear in free-form payloads.
 
 ### Use `content_formatter` to redact additional secrets
 

--- a/docs/integrations/bigquery-agent-analytics.md
+++ b/docs/integrations/bigquery-agent-analytics.md
@@ -471,7 +471,7 @@ plugin = BigQueryAgentAnalyticsPlugin(
 -   **`log_multi_modal_content`** (`bool`, default: `True`): Whether to log detailed content parts (including GCS references).
 -   **`queue_max_size`** (`int`, default: `10000`): The maximum number of events to hold in the in-memory queue before dropping new events.
 -   **`retry_config`** (`RetryConfig`, default: `RetryConfig()`): Configuration for retrying failed BigQuery writes. Sub-fields: `max_retries` (default `3`), `initial_delay` (default `1.0` seconds), `multiplier` (default `2.0`), `max_delay` (default `10.0` seconds).
--   **`log_session_metadata`** (`bool`, default: `True`): If True, logs session information into the `attributes` column, including `session_id`, `app_name`, `user_id`, and the session `state` dictionary (e.g., custom state like gchat thread-id, customer_id). State keys prefixed with `secret:` or `temp:` are automatically redacted. See [Built-in redaction](#built-in-redaction).
+-   **`log_session_metadata`** (`bool`, default: `True`): If True, logs session information into the `attributes` column, including `session_id`, `app_name`, `user_id`, and the session `state` dictionary (e.g., custom state like gchat thread-id, customer_id). State keys prefixed with `temp:` are automatically redacted. See [Built-in redaction](#built-in-redaction).
 -   **`custom_tags`** (`Dict[str, Any]`, default: `{}`): A dictionary of static tags (e.g., `{"env": "prod", "version": "1.0"}`) to be included in the `attributes` column for every event.
 -   **`auto_schema_upgrade`** (`bool`, default: `True`): When enabled, the plugin automatically adds new columns to an existing table when the plugin schema evolves. Only additive changes are made (columns are never dropped or altered). A version label (`adk_schema_version`) on the table ensures the diff runs at most once per schema version. Safe to leave enabled.
 -   **`create_views`** (`bool`, default: `True`): Added in 1.27.0. When enabled, automatically generates per-event-type BigQuery views that unnest structured JSON data (such as `content` or `attributes`) into flat, typed columns, significantly simplifying SQL queries.
@@ -524,6 +524,23 @@ config = BigQueryLoggerConfig(
 plugin = BigQueryAgentAnalyticsPlugin(..., config=config)
 ```
 
+### Public methods
+
+The plugin exposes several public methods for lifecycle management:
+
+-   **`await plugin.flush()`**: Flush all pending events to BigQuery. Call this before shutdown to avoid data loss.
+-   **`await plugin.shutdown(timeout=None)`**: Gracefully shut down the plugin, flushing pending events and releasing resources. The optional `timeout` parameter overrides `shutdown_timeout` from the config.
+-   **`await plugin.create_analytics_views()`**: Manually (re-)create all per-event-type analytics views. Useful after a schema upgrade or when views need to be refreshed.
+-   **Async context manager**: The plugin supports `async with` for automatic startup and shutdown:
+
+    ```python
+    async with BigQueryAgentAnalyticsPlugin(
+        project_id=PROJECT_ID, dataset_id=DATASET_ID
+    ) as plugin:
+        # plugin is initialized and ready to use
+        ...
+    # plugin.shutdown() is called automatically on exit
+    ```
 
 ## Schema and production setup
 
@@ -812,7 +829,7 @@ Tracks changes to the agent's internal state (e.g., custom application state upd
 
 !!! note "Built-in redaction"
 
-    State keys prefixed with `secret:` or `temp:` are automatically redacted
+    State keys prefixed with `temp:` are automatically redacted
     to `[REDACTED]` in the logged `state_delta`. See
     [Built-in redaction](#built-in-redaction) for details.
 
@@ -1233,11 +1250,8 @@ JSON:
 `client_secret`, `access_token`, `refresh_token`, `id_token`, `api_key`,
 `password`
 
-In addition, any state key prefixed with **`temp:`** or **`secret:`** is
-automatically replaced with `[REDACTED]` in the logged `state_delta`.
-This means ADK session state stored under the `secret:` scope (such as
-OAuth tokens cached by `SessionStateCredentialService` or
-`BigQueryCredentialsConfig`) is never persisted in BigQuery.
+In addition, any state key prefixed with **`temp:`** is automatically
+replaced with `[REDACTED]` in the logged `state_delta`.
 
 !!! info "No configuration required"
 

--- a/docs/integrations/bigquery-agent-analytics.md
+++ b/docs/integrations/bigquery-agent-analytics.md
@@ -440,7 +440,16 @@ The plugin supports **OpenTelemetry** for distributed tracing. OpenTelemetry is 
 
 ## Configuration options
 
-You can customize the plugin using `BigQueryLoggerConfig`.
+You can customize the plugin using `BigQueryLoggerConfig`. The `BigQueryAgentAnalyticsPlugin` constructor also accepts `**kwargs`, which are forwarded directly to `BigQueryLoggerConfig`. This lets you pass config fields (like `batch_size` or `enabled`) without creating a separate config object:
+
+```python
+plugin = BigQueryAgentAnalyticsPlugin(
+    project_id="my-project",
+    dataset_id="my_dataset",
+    batch_size=10,           # forwarded to BigQueryLoggerConfig
+    shutdown_timeout=5.0,    # forwarded to BigQueryLoggerConfig
+)
+```
 
 -   **`enabled`** (`bool`, default: `True`): To disable the plugin from logging agent data to the BigQuery table, set this parameter to False.
 -   **`table_id`** (`str`, default: `"agent_events"`): The BigQuery table ID within the dataset. Can also be overridden by the `table_id` parameter on the `BigQueryAgentAnalyticsPlugin` constructor, which takes precedence.
@@ -461,8 +470,8 @@ You can customize the plugin using `BigQueryLoggerConfig`.
 -   **`content_formatter`** (`Optional[Callable[[Any, str], Any]]`, default: `None`): An optional function to format event content before logging. The function receives two arguments: the raw content and the event type string (e.g., `"LLM_REQUEST"`).
 -   **`log_multi_modal_content`** (`bool`, default: `True`): Whether to log detailed content parts (including GCS references).
 -   **`queue_max_size`** (`int`, default: `10000`): The maximum number of events to hold in the in-memory queue before dropping new events.
--   **`retry_config`** (`RetryConfig`, default: `RetryConfig()`): Configuration for retrying failed BigQuery writes (attributes: `max_retries`, `initial_delay`, `multiplier`, `max_delay`).
--   **`log_session_metadata`** (`bool`, default: `True`): If True, logs session information into the `attributes` column, including `session_id`, `app_name`, `user_id`, and the session `state` dictionary (e.g., custom state like gchat thread-id, customer_id).
+-   **`retry_config`** (`RetryConfig`, default: `RetryConfig()`): Configuration for retrying failed BigQuery writes. Sub-fields: `max_retries` (default `3`), `initial_delay` (default `1.0` seconds), `multiplier` (default `2.0`), `max_delay` (default `10.0` seconds).
+-   **`log_session_metadata`** (`bool`, default: `True`): If True, logs session information into the `attributes` column, including `session_id`, `app_name`, `user_id`, and the session `state` dictionary (e.g., custom state like gchat thread-id, customer_id). State keys prefixed with `secret:` or `temp:` are automatically redacted. See [Built-in redaction](#built-in-redaction).
 -   **`custom_tags`** (`Dict[str, Any]`, default: `{}`): A dictionary of static tags (e.g., `{"env": "prod", "version": "1.0"}`) to be included in the `attributes` column for every event.
 -   **`auto_schema_upgrade`** (`bool`, default: `True`): When enabled, the plugin automatically adds new columns to an existing table when the plugin schema evolves. Only additive changes are made (columns are never dropped or altered). A version label (`adk_schema_version`) on the table ensures the diff runs at most once per schema version. Safe to leave enabled.
 -   **`create_views`** (`bool`, default: `True`): Added in 1.27.0. When enabled, automatically generates per-event-type BigQuery views that unnest structured JSON data (such as `content` or `attributes`) into flat, typed columns, significantly simplifying SQL queries.
@@ -586,15 +595,29 @@ CLUSTER BY event_type, agent, user_id;
 
 When `create_views=True` (the default in 1.27.0 and higher), the plugin automatically generates views for each event type that unnest common JSON structures into flat, typed columns. This significantly simplifies SQL, eliminating the need to write complex `JSON_VALUE` or `JSON_QUERY` functions explicitly.
 
-For example, the view `v_llm_request` includes the following schema:
+View names follow the convention `v_{event_type_lowercase}` (for example, `LLM_REQUEST` becomes `v_llm_request`). You can also call the public async method `await plugin.create_analytics_views()` to manually refresh views, for example after a schema upgrade.
 
-| Field Name | Type | Description |
-|:---|:---|:---|
-| **(Common Columns)** | `VARIES` | Includes standard metadata: `timestamp`, `event_type`, `agent`, `session_id`, `invocation_id`, `user_id`, `trace_id`, `span_id`, `parent_span_id`, `status`, `error_message`, `is_truncated`. |
-| **model** | `STRING` | The name of the LLM model used for the request. |
-| **request_content** | `JSON` | The raw LLM request payload. |
-| **llm_config** | `JSON` | The configuration parameters passed to the LLM (temperature, top_p, etc.). |
-| **tools** | `JSON` | Array of tools available during the request. |
+Every view includes these **common columns**: `timestamp`, `event_type`, `agent`, `session_id`, `invocation_id`, `user_id`, `trace_id`, `span_id`, `parent_span_id`, `status`, `error_message`, `is_truncated`.
+
+The following table lists all 15 auto-created views and their event-specific columns:
+
+| View Name | Event-Specific Columns |
+|:---|:---|
+| **`v_user_message_received`** | *(common columns only)* |
+| **`v_llm_request`** | `model` (STRING), `request_content` (JSON), `llm_config` (JSON), `tools` (JSON) |
+| **`v_llm_response`** | `response` (JSON), `usage_prompt_tokens` (INT64), `usage_completion_tokens` (INT64), `usage_total_tokens` (INT64), `total_ms` (INT64), `ttft_ms` (INT64), `model_version` (STRING), `usage_metadata` (JSON) |
+| **`v_llm_error`** | `total_ms` (INT64) |
+| **`v_tool_starting`** | `tool_name` (STRING), `tool_args` (JSON), `tool_origin` (STRING) |
+| **`v_tool_completed`** | `tool_name` (STRING), `tool_result` (JSON), `tool_origin` (STRING), `total_ms` (INT64) |
+| **`v_tool_error`** | `tool_name` (STRING), `tool_args` (JSON), `tool_origin` (STRING), `total_ms` (INT64) |
+| **`v_agent_starting`** | `agent_instruction` (STRING) |
+| **`v_agent_completed`** | `total_ms` (INT64) |
+| **`v_invocation_starting`** | *(common columns only)* |
+| **`v_invocation_completed`** | *(common columns only)* |
+| **`v_state_delta`** | `state_delta` (JSON) |
+| **`v_hitl_credential_request`** | `tool_name` (STRING), `tool_args` (JSON) |
+| **`v_hitl_confirmation_request`** | `tool_name` (STRING), `tool_args` (JSON) |
+| **`v_hitl_input_request`** | `tool_name` (STRING), `tool_args` (JSON) |
 
 ### Event types and payloads {#event-types}
 
@@ -765,14 +788,21 @@ These events track changes to the agent's state, typically triggered by tools.
 
 **7. STATE_DELTA**
 
-Tracks changes to the agent's internal state (e.g., token cache updates).
+Tracks changes to the agent's internal state (e.g., custom application state updated by tools).
+
+!!! note "Built-in redaction"
+
+    State keys prefixed with `secret:` or `temp:` are automatically redacted
+    to `[REDACTED]` in the logged `state_delta`. See
+    [Built-in redaction](#built-in-redaction) for details.
 
 ```json
 {
   "event_type": "STATE_DELTA",
   "attributes": {
     "state_delta": {
-      "bigquery_token_cache": "{\"token\": \"ya29...\", \"expiry\": \"...\"}"
+      "customer_tier": "enterprise",
+      "last_query_dataset": "bigquery-public-data.samples"
     }
   }
 }
@@ -866,6 +896,15 @@ The following HITL tool names are recognized:
 
 HITL request events are detected from `function_call` parts in `on_event_callback`. HITL completion events are detected from `function_response` parts in both `on_event_callback` and `on_user_message_callback`.
 
+!!! note "Views for HITL events"
+
+    Auto-created views exist only for the three **request** event types
+    (`v_hitl_credential_request`, `v_hitl_confirmation_request`,
+    `v_hitl_input_request`). The three `*_COMPLETED` event types are logged
+    to the base table but do not have dedicated views. Query them directly
+    from the `agent_events` table using
+    `WHERE event_type LIKE 'HITL_%_COMPLETED'`.
+
 #### GCS Offloading Examples (Multimodal & Large Text)
 
 When `gcs_bucket_name` is configured, large text and multimodal content (images, audio, etc.) are automatically offloaded to GCS. The `content` column will contain a summary or placeholder, while `content_parts` contains the `object_ref` pointing to the GCS URI.
@@ -941,7 +980,19 @@ WHERE trace_id = 'your-trace-id'
 ORDER BY timestamp ASC;
 ```
 
-### Token usage analysis (accessing JSON fields)
+### Token usage analysis
+
+Using the `v_llm_response` view (recommended):
+
+```sql
+SELECT
+  AVG(usage_total_tokens) as avg_tokens,
+  AVG(usage_prompt_tokens) as avg_prompt_tokens,
+  AVG(usage_completion_tokens) as avg_completion_tokens
+FROM `your-gcp-project-id.your-dataset-id.v_llm_response`;
+```
+
+Or using the base table with JSON extraction:
 
 ```sql
 SELECT
@@ -985,6 +1036,22 @@ LIMIT 1;
 
 ### Latency Analysis (LLM & Tools)
 
+Using views (recommended):
+
+```sql
+-- LLM latency
+SELECT AVG(total_ms) as avg_llm_ms, AVG(ttft_ms) as avg_ttft_ms
+FROM `your-gcp-project-id.your-dataset-id.v_llm_response`;
+
+-- Tool latency by tool name
+SELECT tool_name, tool_origin, AVG(total_ms) as avg_tool_ms
+FROM `your-gcp-project-id.your-dataset-id.v_tool_completed`
+GROUP BY tool_name, tool_origin
+ORDER BY avg_tool_ms DESC;
+```
+
+Or using the base table:
+
 ```sql
 SELECT
   event_type,
@@ -1017,30 +1084,33 @@ ORDER BY timestamp ASC;
 
 ### Error Analysis (LLM & Tool Errors)
 
+Using views (recommended):
+
 ```sql
-SELECT
-  timestamp,
-  event_type,
-  agent,
-  error_message,
-  JSON_VALUE(content, '$.tool') as tool_name,
-  CAST(JSON_VALUE(latency_ms, '$.total_ms') AS INT64) as latency_ms
-FROM `your-gcp-project-id.your-dataset-id.agent_events`
-WHERE event_type IN ('LLM_ERROR', 'TOOL_ERROR')
+-- Tool errors with provenance
+SELECT timestamp, agent, tool_name, tool_origin, error_message, total_ms
+FROM `your-gcp-project-id.your-dataset-id.v_tool_error`
+ORDER BY timestamp DESC
+LIMIT 20;
+
+-- LLM errors
+SELECT timestamp, agent, error_message, total_ms
+FROM `your-gcp-project-id.your-dataset-id.v_llm_error`
 ORDER BY timestamp DESC
 LIMIT 20;
 ```
 
 ### Tool Provenance Analysis
 
+Using the `v_tool_completed` view (recommended):
+
 ```sql
 SELECT
-  JSON_VALUE(content, '$.tool_origin') as tool_origin,
-  JSON_VALUE(content, '$.tool') as tool_name,
+  tool_origin,
+  tool_name,
   COUNT(*) as call_count,
-  AVG(CAST(JSON_VALUE(latency_ms, '$.total_ms') AS INT64)) as avg_latency_ms
-FROM `your-gcp-project-id.your-dataset-id.agent_events`
-WHERE event_type = 'TOOL_COMPLETED'
+  AVG(total_ms) as avg_latency_ms
+FROM `your-gcp-project-id.your-dataset-id.v_tool_completed`
 GROUP BY tool_origin, tool_name
 ORDER BY call_count DESC;
 ```
@@ -1131,10 +1201,31 @@ https://lookerstudio.google.com/reporting/create?c.reportId=f1c5b513-3095-44f8-9
     ([google/adk-python#3845](https://github.com/google/adk-python/issues/3845))
     and can lead to credential exposure in your analytics data.
 
-To prevent sensitive credentials from being persisted in BigQuery, use one or
-more of the following approaches:
+The plugin includes **built-in redaction** that automatically protects
+common secrets. For additional control, you can layer custom redaction on top.
 
-### Use `content_formatter` to redact secrets
+### Built-in redaction {#built-in-redaction}
+
+The plugin automatically redacts values for the following well-known key
+names (case-insensitive) wherever they appear in `content` or `attributes`
+JSON:
+
+`client_secret`, `access_token`, `refresh_token`, `id_token`, `api_key`,
+`password`
+
+In addition, any state key prefixed with **`temp:`** or **`secret:`** is
+automatically replaced with `[REDACTED]` in the logged `state_delta`.
+This means ADK session state stored under the `secret:` scope (such as
+OAuth tokens cached by `SessionStateCredentialService` or
+`BigQueryCredentialsConfig`) is never persisted in BigQuery.
+
+!!! info "No configuration required"
+
+    Built-in redaction is always active and cannot be disabled. It runs
+    before any custom `content_formatter` and applies recursively to
+    nested dictionaries and JSON-encoded strings within attribute values.
+
+### Use `content_formatter` to redact additional secrets
 
 Provide a custom `content_formatter` function in `BigQueryLoggerConfig` to
 strip or mask sensitive fields before they are written:

--- a/docs/integrations/bigquery-agent-analytics.md
+++ b/docs/integrations/bigquery-agent-analytics.md
@@ -471,7 +471,7 @@ plugin = BigQueryAgentAnalyticsPlugin(
 -   **`log_multi_modal_content`** (`bool`, default: `True`): Whether to log detailed content parts (including GCS references).
 -   **`queue_max_size`** (`int`, default: `10000`): The maximum number of events to hold in the in-memory queue before dropping new events.
 -   **`retry_config`** (`RetryConfig`, default: `RetryConfig()`): Configuration for retrying failed BigQuery writes. Sub-fields: `max_retries` (default `3`), `initial_delay` (default `1.0` seconds), `multiplier` (default `2.0`), `max_delay` (default `10.0` seconds).
--   **`log_session_metadata`** (`bool`, default: `True`): If True, logs session information into the `attributes` column, including `session_id`, `app_name`, `user_id`, and the session `state` dictionary (e.g., custom state like gchat thread-id, customer_id). State keys prefixed with `temp:` are automatically redacted. See [Built-in redaction](#built-in-redaction).
+-   **`log_session_metadata`** (`bool`, default: `True`): If True, logs session information into the `attributes` column, including `session_id`, `app_name`, `user_id`, and the session `state` dictionary (e.g., custom state like gchat thread-id, customer_id). State keys prefixed with `temp:` or `secret:` are automatically redacted. See [Built-in redaction](#built-in-redaction).
 -   **`custom_tags`** (`Dict[str, Any]`, default: `{}`): A dictionary of static tags (e.g., `{"env": "prod", "version": "1.0"}`) to be included in the `attributes` column for every event.
 -   **`auto_schema_upgrade`** (`bool`, default: `True`): When enabled, the plugin automatically adds new columns to an existing table when the plugin schema evolves. Only additive changes are made (columns are never dropped or altered). A version label (`adk_schema_version`) on the table ensures the diff runs at most once per schema version. Safe to leave enabled.
 -   **`create_views`** (`bool`, default: `True`): Added in 1.27.0. When enabled, automatically generates per-event-type BigQuery views that unnest structured JSON data (such as `content` or `attributes`) into flat, typed columns, significantly simplifying SQL queries.
@@ -829,8 +829,8 @@ Tracks changes to the agent's internal state (e.g., custom application state upd
 
 !!! note "Built-in redaction"
 
-    State keys prefixed with `temp:` are automatically redacted
-    to `[REDACTED]` in the logged `state_delta`. See
+    State keys prefixed with `temp:` or `secret:` are automatically
+    redacted to `[REDACTED]` in the logged `state_delta`. See
     [Built-in redaction](#built-in-redaction) for details.
 
 ```json
@@ -1250,8 +1250,11 @@ JSON:
 `client_secret`, `access_token`, `refresh_token`, `id_token`, `api_key`,
 `password`
 
-In addition, any state key prefixed with **`temp:`** is automatically
-replaced with `[REDACTED]` in the logged `state_delta`.
+In addition, any state key prefixed with **`temp:`** or **`secret:`** is
+automatically replaced with `[REDACTED]` in the logged `state_delta`.
+This means ADK session state stored under the `secret:` scope (such as
+OAuth tokens cached by credential services) is never persisted in
+BigQuery.
 
 !!! info "No configuration required"
 

--- a/docs/integrations/bigquery-agent-analytics.md
+++ b/docs/integrations/bigquery-agent-analytics.md
@@ -475,6 +475,7 @@ plugin = BigQueryAgentAnalyticsPlugin(
 -   **`custom_tags`** (`Dict[str, Any]`, default: `{}`): A dictionary of static tags (e.g., `{"env": "prod", "version": "1.0"}`) to be included in the `attributes` column for every event.
 -   **`auto_schema_upgrade`** (`bool`, default: `True`): When enabled, the plugin automatically adds new columns to an existing table when the plugin schema evolves. Only additive changes are made (columns are never dropped or altered). A version label (`adk_schema_version`) on the table ensures the diff runs at most once per schema version. Safe to leave enabled.
 -   **`create_views`** (`bool`, default: `True`): Added in 1.27.0. When enabled, automatically generates per-event-type BigQuery views that unnest structured JSON data (such as `content` or `attributes`) into flat, typed columns, significantly simplifying SQL queries.
+-   **`view_prefix`** (`str`, default: `"v"`): Prefix for auto-created view names. The default `"v"` produces views like `v_llm_request`. Set a distinct prefix per table when multiple plugin instances share the same dataset to avoid view-name collisions (e.g., `"v_staging"` produces `v_staging_llm_request`). Must be non-empty.
 
 
 The following code sample shows how to define a configuration for the
@@ -595,7 +596,26 @@ CLUSTER BY event_type, agent, user_id;
 
 When `create_views=True` (the default in 1.27.0 and higher), the plugin automatically generates views for each event type that unnest common JSON structures into flat, typed columns. This significantly simplifies SQL, eliminating the need to write complex `JSON_VALUE` or `JSON_QUERY` functions explicitly.
 
-View names follow the convention `v_{event_type_lowercase}` (for example, `LLM_REQUEST` becomes `v_llm_request`). You can also call the public async method `await plugin.create_analytics_views()` to manually refresh views, for example after a schema upgrade.
+View names follow the convention `{view_prefix}_{event_type_lowercase}` (for example, with the default prefix `"v"`, `LLM_REQUEST` becomes `v_llm_request`). Set `view_prefix` in `BigQueryLoggerConfig` to a distinct value when multiple plugin instances write to different tables in the same dataset, preventing view-name collisions:
+
+```python
+# Two plugins in the same dataset with distinct view prefixes
+plugin_prod = BigQueryAgentAnalyticsPlugin(
+    project_id=PROJECT_ID, dataset_id=DATASET_ID,
+    table_id="agent_events_prod",
+    config=BigQueryLoggerConfig(view_prefix="v_prod"),
+)
+# Creates views: v_prod_llm_request, v_prod_tool_completed, ...
+
+plugin_staging = BigQueryAgentAnalyticsPlugin(
+    project_id=PROJECT_ID, dataset_id=DATASET_ID,
+    table_id="agent_events_staging",
+    config=BigQueryLoggerConfig(view_prefix="v_staging"),
+)
+# Creates views: v_staging_llm_request, v_staging_tool_completed, ...
+```
+
+You can also call the public async method `await plugin.create_analytics_views()` to manually refresh views, for example after a schema upgrade.
 
 Every view includes these **common columns**: `timestamp`, `event_type`, `agent`, `session_id`, `invocation_id`, `user_id`, `trace_id`, `span_id`, `parent_span_id`, `status`, `error_message`, `is_truncated`.
 


### PR DESCRIPTION
## Summary

Aligns the BigQuery Agent Analytics plugin documentation with the latest `main` code in `google/adk-python`. Combines factual fixes (Phase 1) and structural improvements (Phase 2) from a comprehensive code-vs-doc audit.

### Phase 1: Factual fixes

- **Add built-in redaction documentation**: Document the `_SENSITIVE_KEYS` frozenset (`client_secret`, `access_token`, `refresh_token`, `id_token`, `api_key`, `password`) and auto-redaction of `temp:`/`secret:` prefixed state keys. The plugin has always had this, but the doc only mentioned custom `content_formatter`.
- **Fix STATE_DELTA example**: Replace `bigquery_token_cache` (now stored under `secret:bigquery_token_cache` and auto-redacted) with non-sensitive state keys like `customer_tier`.
- **Add RetryConfig defaults**: Document default values (`max_retries=3`, `initial_delay=1.0`, `multiplier=2.0`, `max_delay=10.0`) instead of just listing attribute names.
- **Clarify HITL completed events**: Only the 3 request event types have auto-created views; the 3 `*_COMPLETED` types do not. Added a note.
- **Add `log_session_metadata` cross-reference**: Links to the new built-in redaction section.

### Phase 2: Structural improvements

- **Complete view reference**: Expand from a single `v_llm_request` example to a comprehensive table of all 15 auto-created views with their event-specific columns.
- **Document `**kwargs` passthrough**: The constructor forwards kwargs to `BigQueryLoggerConfig`, enabling a simpler initialization pattern.
- **Document `create_analytics_views()` public method**: Available for manual view refresh after schema upgrades.
- **Update advanced queries to use views**: Token usage, latency, error analysis, and tool provenance queries now show view-based alternatives (recommended) alongside base-table queries.

## Test plan

- [ ] Verify all 15 view names match `_EVENT_VIEW_DEFS` keys in `bigquery_agent_analytics_plugin.py`
- [ ] Verify RetryConfig defaults match `RetryConfig` dataclass in source
- [ ] Verify `_SENSITIVE_KEYS` frozenset matches source
- [ ] Verify `create_analytics_views()` is a public async method in source
- [ ] Verify `**kwargs` passthrough in `__init__` signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)