### PR TITLE
Constrain header, nav, and footer width on home page to match other pages

### DIFF
--- a/docs/stylesheets/homepage.css
+++ b/docs/stylesheets/homepage.css
@@ -24,16 +24,16 @@
 
 /* JS fallback via body class */
 body.adk-landing-page { overflow-x: hidden !important; }
-body.adk-landing-page .md-grid { max-width: 100% !important; width: 100% !important; }
+body.adk-landing-page .md-main .md-grid { max-width: 100% !important; width: 100% !important; }
 body.adk-landing-page .md-main__inner { max-width: none !important; margin: 0 !important; padding: 0 !important; }
 body.adk-landing-page .md-content { max-width: none !important; margin: 0 !important; flex-grow: 1 !important; }
 body.adk-landing-page .md-content__inner { max-width: 1280px !important; margin: 0 auto !important; padding: 0 clamp(16px, 4vw, 48px) !important; box-sizing: border-box !important; overflow-x: hidden !important; }
-body.adk-landing-page .md-header__inner { max-width: 100% !important; overflow-x: hidden !important; padding-right: 20px !important; }
+body.adk-landing-page .md-header__inner { overflow-x: hidden !important; }
 
 /* Responsive header repo links — full text → icons only (≤1200px) → hidden (≤900px) */
 .md-header__title { flex-shrink: 1 !important; min-width: 120px !important; overflow: hidden !important; }
 .md-header__source { flex-shrink: 0 !important; display: flex !important; gap: 2px !important; flex-wrap: nowrap !important; max-width: none !important; width: auto !important; }
-body.adk-landing-page .md-header__inner { padding-right: 12px !important; }
+
 .md-header .md-source { min-width: auto !important; width: auto !important; margin-right: 2px !important; }
 .md-header .md-source__repository { font-size: 0.65rem; white-space: nowrap; }
 .md-header .md-source__icon svg { width: 1rem !important; height: 1rem !important; }


### PR DESCRIPTION
The home page header and footer were stretching to 100% viewport width, while all other pages constrain them to 80% via the global `.md-grid` rule. This PR scopes the homepage CSS overrides to only the main content area so the header and footer match the rest of the site.

Fixes #1632.