### PR TITLE
Improve BigQuery Agent Analytics SDK discoverability in docs

### DIFF
--- a/docs/integrations/bigquery-agent-analytics.md
+++ b/docs/integrations/bigquery-agent-analytics.md
@@ -1207,13 +1207,13 @@ to analyze your agent logs using natural language. Use this tool to answer quest
 *   "What are the most common tool calls?"
 *   "Identify sessions with high token usage"
 
-## Consuming logged data
+## Consuming logged data with BigQuery Agent Analytics SDK
 
 The [BigQuery Agent Analytics SDK](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main) provides a convenient way to consume and analyze the data logged by the BigQuery Agent Analytics plugin. The SDK offers pre-built utilities for querying, aggregating, and visualizing your agent's operational data directly from BigQuery.
 
 ### Dashboard
 
-You can visualize your agent's performance using the pre-built [dashboard notebook](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/examples/dashboard_v2.ipynb).
+The BigQuery Agent Analytics SDK includes an [example Jupyter notebook](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/examples/dashboard_v2.ipynb) that demonstrates how to query and visualize your agent's performance data. Use it as a starting point to build your own custom dashboards tailored to your BigQuery Agent Analytics dataset.
 
 ## Security: Avoid logging sensitive credentials {#security-credentials}
 


### PR DESCRIPTION
## Summary
- Add "BigQuery Agent Analytics SDK" to the "Consuming logged data" section heading so it appears directly in the sidebar navigation, improving discoverability.
- Clarify that the dashboard notebook is an example Jupyter notebook intended as a starting point for users to build their own custom dashboards against their BQ Agent Analytics dataset.

## Test plan
- [ ] Verify the updated heading renders correctly in the sidebar navigation
- [ ] Confirm the dashboard section language clearly conveys it's an example notebook

🤖 Generated with [Claude Code](https://claude.com/claude-code)