### PR TITLE
Add links to Agent Identity Authentication Manager user guides

### DIFF
--- a/docs/tools-custom/authentication.md
+++ b/docs/tools-custom/authentication.md
@@ -34,11 +34,16 @@ When deploying agents to production hosted environments, your agent's ability to
 properly authenticate to restricted tools and services becomes more challenging
 and more important to properly manage. This authentication challenge can become
 even more complicated when users of your agent have varying levels of access to
-restricted tools and data. Rather than writing code to handle the authentication
-process and credential managment for various tools used by your agent, use an
-*authentication manager* service that manages *both* for you. This service
-should handle the storage of keys and secrets, as well as the acquisition,
-management, and storage of OAuth access or refresh tokens.
+restricted tools and data.
+
+Rather than writing code to handle the authentication process and credential
+management for various tools used by your agent, use an *authentication manager*
+service that manages *both* for you. This service should handle the storage of
+keys and secrets, as well as the acquisition, management, and storage of OAuth
+access or refresh tokens. Learn more about Agent Identity Authentication Manager
+for [2-legged OAuth](https://docs.cloud.google.com/iam/docs/auth-with-2lo),
+[3-legged OAuth](https://docs.cloud.google.com/iam/docs/auth-with-3lo), and [API
+key](https://docs.cloud.google.com/iam/docs/auth-with-api-key).
 
 ### Self-managed authentication
 


### PR DESCRIPTION
Add links to the three new Cloud IAM user guides to the Authentication Manager section on the tools authentication page.