### PR TITLE
Update ADK 2.0 docs: fix code examples, alpha to beta, and cleanup

### DIFF
--- a/docs/2.0/index.md
+++ b/docs/2.0/index.md
@@ -1,8 +1,8 @@
-# Welcome to ADK 2.0 Alpha
+# Welcome to ADK 2.0 Beta
 
-!!! example "Alpha Release"
+!!! example "Beta Release"
 
-    ADK 2.0 is an Alpha release and may cause breaking changes when used with prior
+    ADK 2.0 is a Beta release and may cause breaking changes when used with prior
     versions of ADK. Do not use ADK 2.0 if you require backwards compatibility, such
     as in production environments. We encourage you to test this release and we
     welcome your
@@ -10,7 +10,7 @@
 
 ADK 2.0 introduces powerful tools for building sophisticated AI agents, and
 helps you structure agents to execute challenging tasks with more control,
-predictability, and reliability. ADK 2.0 is available as an Alpha release for
+predictability, and reliability. ADK 2.0 is available as a Beta release for
 Python and includes the following key features:
 
 -   [**Graph-based workflows**](/workflows/): Build deterministic agent

--- a/docs/2.0/index.md
+++ b/docs/2.0/index.md
@@ -38,12 +38,6 @@ issues so we have a chance to address them. Report any ADK 1.0 to ADK 2.0
 incompatibilities you encounter through our
 [issue tracker](https://github.com/google/adk-python/issues/new?template=bug_report.md&labels=v2).
 
-!!! danger "WARNING: DO NOT MIX ADK 2.0 and ADK 1.0 data storage systems"
-
-    If you use persistent storage for ADK 2.0 projects, **DO NOT allow ADK 2.0
-    projects to share storage with ADK 1.0 projects**, including, but not limited to,
-    session storage, memory systems, and evaluation data. Doing so may result in
-    loss of data or make the data unusable in ADK 1.0 projects.
 
 ## Install ADK 2.0 {#install}
 
@@ -51,7 +45,7 @@ While ADK 2.0 is available as a pre-GA release, it is not installed automaticall
 You must select it as an installation option. This version has the following
 system requirements:
 
-*   **Python 3.11** or later
+*   **Python 3.10** or later
 *   `pip` for installing packages
 
 To install ADK 2.0, follow these steps:

--- a/docs/workflows/collaboration.md
+++ b/docs/workflows/collaboration.md
@@ -1,7 +1,7 @@
 # Build collaborative agent teams
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v2.0.0</span><span class="lst-preview">Alpha</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v2.0.0</span><span class="lst-preview">Beta</span>
 </div>
 
 Some complex tasks may require multiple agents with specific responsibilities
@@ -28,9 +28,9 @@ available for collaboration modes:
 This guide covers how to use modes for your subagents and how these modes impact
 agent behavior.
 
-!!! example "Alpha Release"
+!!! example "Beta Release"
 
-    ADK 2.0 is an Alpha release and may cause breaking changes when used with prior
+    ADK 2.0 is a Beta release and may cause breaking changes when used with prior
     versions of ADK. Do not use ADK 2.0 if you require backwards compatibility, such
     as in production environments. We encourage you to test this release and we
     welcome your

--- a/docs/workflows/collaboration.md
+++ b/docs/workflows/collaboration.md
@@ -42,7 +42,7 @@ The following code example shows how to set operating modes for
 a small team of subagents and assign them to a coordinator agent:
 
 ```python
-from google.adk.workflow.agents.llm_agent import Agent
+from google.adk import Agent
 
 weather_agent = Agent(
     name="weather_checker",

--- a/docs/workflows/data-handling.md
+++ b/docs/workflows/data-handling.md
@@ -20,12 +20,6 @@ data format schemas and specific instruction syntax.
     welcome your
     [feedback](https://github.com/google/adk-python/issues/new?template=feature_request.md&labels=v2)!
 
-!!! danger "WARNING: DO NOT MIX ADK 2.0 and ADK 1.0 data storage systems"
-
-    If you use persistent storage for ADK 2.0 projects, **DO NOT allow ADK 2.0
-    projects to share storage with ADK 1.0 projects**, including, but not limited to,
-    session storage, memory systems, and evaluation data. Doing so may result in
-    loss of data or make the data unusable in ADK 1.0 projects.
 
 ## Workflow graph Events
 

--- a/docs/workflows/data-handling.md
+++ b/docs/workflows/data-handling.md
@@ -75,8 +75,8 @@ containing the data, as shown in the following code sample:
 def my_function_node_1():
     return Event(output="The Result")
 
-def my_function_node_2(node_input: Content):
-    output_value = node_input.parts[0].text.lower()
+def my_function_node_2(node_input: str):
+    output_value = node_input.lower()
     return Event(output=output_value) # "the result"
 ```
 
@@ -138,7 +138,7 @@ async def task_attempt_node(node_input: Content, attempts: int):
       },
   )
 
-async def read_state_node(ctx: WorkflowContext):
+async def read_state_node(ctx: Context):
   print(f"attempts state: {ctx.state}") # attempts state: attempts: 1
 
 root_agent = Workflow(
@@ -188,7 +188,7 @@ flight_searcher = Agent(
     input_schema=FlightSearchInput,
     output_schema=FlightSearchOutput,
     tools=[search_flights_api],
-    mode="single-turn",
+    mode="single_turn",
     ...
 )
 

--- a/docs/workflows/data-handling.md
+++ b/docs/workflows/data-handling.md
@@ -1,7 +1,7 @@
 # Data handling for agent workflows
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v2.0.0</span><span class="lst-preview">Alpha</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v2.0.0</span><span class="lst-preview">Beta</span>
 </div>
 
 Structuring and managing data between agents and graph-based notes is critical
@@ -12,9 +12,9 @@ the essential parameters for events, data, content, and state, and explains how
 to implement structured data transfer for both function and agent nodes using
 data format schemas and specific instruction syntax.
 
-!!! example "Alpha Release"
+!!! example "Beta Release"
 
-    ADK 2.0 is an Alpha release and may cause breaking changes when used with prior
+    ADK 2.0 is a Beta release and may cause breaking changes when used with prior
     versions of ADK. Do not use ADK 2.0 if you require backwards compatibility, such
     as in production environments. We encourage you to test this release and we
     welcome your

--- a/docs/workflows/dynamic.md
+++ b/docs/workflows/dynamic.md
@@ -1,7 +1,7 @@
 # Dynamic workflows
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v2.0.0</span><span class="lst-preview">Alpha</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v2.0.0</span><span class="lst-preview">Beta</span>
 </div>
 
 The ADK framework provides a programmatic way to define workflows as a more
@@ -30,9 +30,9 @@ the benefits of dynamic workflows in ADK:
     internally compose lower-level nodes, keeping the overall workflow graph
     clean and manageable.
 
-!!! example "Alpha Release"
+!!! example "Beta Release"
 
-    ADK 2.0 is an Alpha release and may cause breaking changes when used with prior
+    ADK 2.0 is a Beta release and may cause breaking changes when used with prior
     versions of ADK. Do not use ADK 2.0 if you require backwards compatibility, such
     as in production environments. We encourage you to test this release and we
     welcome your

--- a/docs/workflows/dynamic.md
+++ b/docs/workflows/dynamic.md
@@ -47,9 +47,9 @@ The following dynamic workflow code example shows how to define a basic
 workflow containing a single node with a function:
 
 ```python
-from google.adk import Workflow
-from google.adk import Event
 from google.adk import Context
+from google.adk import Workflow
+from google.adk.workflow import node
 from typing import Any
 
 @node(name="hello_node")
@@ -60,7 +60,7 @@ def my_node(node_input: Any):
 @node(rerun_on_resume=True)
 async def my_workflow(ctx: Context, node_input: str) -> str:
     # run_node executes a node and returns its output
-    result = await ctx.run_node(my_node, input_data="hello")
+    result = await ctx.run_node(my_node, node_input="hello")
     return result
 
 # Run the workflow
@@ -127,8 +127,8 @@ for those nodes, as shown in the following code sample:
 @node(rerun_on_resume=True)
 async def my_workflow(ctx):
     # run_node executes a node and returns its output
-    result = await ctx.run_node(my_function_node, input_data="Hello")
-    result_formatted = await ctx.run_node(my_formatting_node, input_data=result)
+    result = await ctx.run_node(my_function_node, node_input="Hello")
+    result_formatted = await ctx.run_node(my_formatting_node, node_input=result)
     return result_formatted
 
 # Run the workflow
@@ -149,6 +149,7 @@ pass string data between an agent node and a function node:
 
 ```python
 from google.adk import Context
+from google.adk.workflow import node
 
 @node(rerun_on_resume=True)
 async def editorial_workflow(ctx: Context, user_request: str):
@@ -168,6 +169,7 @@ following code example:
 ```python
 from google.adk import Agent
 from google.adk import Context
+from google.adk.workflow import node
 from pydantic import BaseModel
 
 class CityTime(BaseModel):
@@ -228,6 +230,11 @@ following code example shows how to use dynamic workflows to construct a
 workflow loop for generating, reviewing, and updating code:
 
 ```python
+from google.adk import Context
+from google.adk import Event
+from google.adk.agents import LlmAgent
+from google.adk.workflow import node
+
 coder_agent = LlmAgent(
     name="generator_agent",
     model="gemini-flash-latest",
@@ -236,10 +243,14 @@ coder_agent = LlmAgent(
 )
 
 @node(name="lint_reviewer")
-compile_lint_check = ApiNode()
+async def compile_lint_check(ctx: Context, code: str):
+    # Simulate API call or lint check
+    class Response:
+        findings = ""
+    return Response()
 
 fixer_agent = LlmAgent(
-    name="generator_agent",
+    name="fixer_agent",
     model="gemini-flash-latest",
     instruction="""Refactor current code {code}.
         Based on compile & lint review: {findings}""",
@@ -247,13 +258,13 @@ fixer_agent = LlmAgent(
 )
 
 @node # workflow node
-async def code_workflow(ctx):
-  code = await ctx.run_node(coder_agent)
+async def code_workflow(ctx: Context, user_request: str):
+  code = await ctx.run_node(coder_agent, user_request)
   check_resp = await ctx.run_node(compile_lint_check, code)
 
   while check_resp.findings:
     yield Event(state={"code": code, "findings": check_resp.findings})
-    code = await ctx.run_node(fixer_agent)
+    code = await ctx.run_node(fixer_agent, {"code": code, "findings": check_resp.findings})
 
     check_resp = await ctx.run_node(compile_lint_check, code)
 
@@ -376,21 +387,33 @@ executing node in a workflow:
     system attempts to re-run those nodes in your workflow.
 
 ```python
+from google.adk import Context
+from google.adk.workflow import node
+from pydantic import BaseModel
+from typing import Any
+import asyncio
+
 class Order(BaseModel):
   order_id: str
   cart_items: list[Product]
 
-def shorten_link(ctx, node_input: str):
-
+@node(rerun_on_resume=True)
+async def process_all_orders(ctx: Context, node_input: Any):
   orders = await get_orders()
 
   process_tasks = []
-  for i, order in enumerate(orders):
-    task = ctx.run_node(process_order, order, name=order.order_id))
-
+  for order in orders:
+    # Use run_id to provide a custom identifier.
+    # Custom run_ids must contain at least one non-numeric character
+    # to avoid collision with auto-generated sequential numeric IDs.
+    task = ctx.run_node(process_order, order, run_id=f"order-{order.order_id}")
     process_tasks.append(task)
 
-  result = asyncio.gather(*process_tasks)
-
-  yield result
+  results = await asyncio.gather(*process_tasks)
+  return results
 ```
+
+By default, auto-generated run IDs are sequential integers starting from
+`"1"` (represented as strings). Custom `run_id` values must contain at
+least one non-numeric character to avoid collisions with these
+auto-generated IDs.

--- a/docs/workflows/graph-routes.md
+++ b/docs/workflows/graph-routes.md
@@ -1,7 +1,7 @@
 # Build graph routes for agent workflows
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v2.0.0</span><span class="lst-preview">Alpha</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v2.0.0</span><span class="lst-preview">Beta</span>
 </div>
 
 Graph-based workflows in ADK define agent logic as a graph of execution nodes
@@ -41,9 +41,9 @@ tasks are routed and executed. This structured node definition improves the
 predictability of agents and enhances reliability for complex tasks that require
 defined steps and process management.
 
-!!! example "Alpha Release"
+!!! example "Beta Release"
 
-    ADK 2.0 is an Alpha release and may cause breaking changes when used with prior
+    ADK 2.0 is a Beta release and may cause breaking changes when used with prior
     versions of ADK. Do not use ADK 2.0 if you require backwards compatibility, such
     as in production environments. We encourage you to test this release and we
     welcome your

--- a/docs/workflows/human-input.md
+++ b/docs/workflows/human-input.md
@@ -1,7 +1,7 @@
 # Human input for agent workflows
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v2.0.0</span><span class="lst-preview">Alpha</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v2.0.0</span><span class="lst-preview">Beta</span>
 </div>
 
 Being able to request human input for data input, decision verification, or
@@ -11,9 +11,9 @@ specifically built for obtaining input from humans as part of a workflow. These
 nodes do not require artificial intelligence (AI) models to run, which can make
 the input process more predictable and reliable.
 
-!!! example "Alpha Release"
+!!! example "Beta Release"
 
-    ADK 2.0 is an Alpha release and may cause breaking changes when used with prior
+    ADK 2.0 is a Beta release and may cause breaking changes when used with prior
     versions of ADK. Do not use ADK 2.0 if you require backwards compatibility, such
     as in production environments. We encourage you to test this release and we
     welcome your

--- a/docs/workflows/human-input.md
+++ b/docs/workflows/human-input.md
@@ -90,9 +90,7 @@ async def initial_prompt(ctx: Context):
            Hobby,
            Example of attraction you liked
    """
-   resp = {"user_response": str}
-
-   yield RequestInput(message=input_message, response_schema=resp)
+   yield RequestInput(message=input_message, response_schema=str)
 ```
 
 ### Request input with data payload
@@ -109,6 +107,10 @@ class ActivitiesList(BaseModel):
    activity has a name and a description"""
    itinerary: List[Dict[str, str]]
 
+class UserFeedback(BaseModel):
+   """Expected response structure from the user."""
+   user_response: str
+
 async def get_user_feedback(node_input: ActivitiesList):
    """
    Retrieves the user's thoughts on the agents initial itinerary in order to
@@ -124,6 +126,6 @@ async def get_user_feedback(node_input: ActivitiesList):
    yield RequestInput(
        message=message,
        payload=node_input,
-       response_schema={"user":"response"}
+        response_schema=UserFeedback,
    )
 ```

--- a/docs/workflows/index.md
+++ b/docs/workflows/index.md
@@ -1,7 +1,7 @@
 # Graph-based agent workflows
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v2.0.0</span><span class="lst-preview">Alpha</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v2.0.0</span><span class="lst-preview">Beta</span>
 </div>
 
 Graph-based workflows in ADK let you build agents with more precise control,
@@ -33,9 +33,9 @@ provide the following advantages:
 -   **Enhance reliability:** Improve the predictability of your agents by
     relying on structured node definitions rather than prompts alone.
 
-!!! example "Alpha Release"
+!!! example "Beta Release"
 
-    ADK 2.0 is an Alpha release and may cause breaking changes when used with prior
+    ADK 2.0 is a Beta release and may cause breaking changes when used with prior
     versions of ADK. Do not use ADK 2.0 if you require backwards compatibility, such
     as in production environments. We encourage you to test this release and we
     welcome your


### PR DESCRIPTION
- Update release status from Alpha to Beta across all 2.0 pages
- Fix code examples across workflow docs
- Update minimum Python version from 3.11 to 3.10
- Remove outdated ADK 1.0/2.0 storage mixing warning