### PR TITLE
Update banner for ADK 2.0 Beta and TypeScript 1.0

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -48,14 +48,14 @@
 -->
 {% block announce %}
 <span class="announce-item">
-  <strong>New Releases!</strong> Check out our blog posts for
-  <a href="https://developers.googleblog.com/adk-go-10-arrives/" target="_blank" rel="noopener">
-    ADK Go 1.0
+  <strong>New Releases!</strong> Explore
+  <a href="/2.0/">
+    ADK Python 2.0 Beta
   </a>
-  and
-  <a href="https://developers.googleblog.com/announcing-adk-for-java-100-building-the-future-of-ai-agents-in-java/"
-    target="_blank" rel="noopener">
-    ADK Java 1.0
+  with workflows and agent teams, and
+  <a href="https://github.com/google/adk-js/releases/tag/adk-v1.0.0" target="_blank" rel="noopener">
+    ADK TypeScript 1.0
   </a>
+  is now available
 </span>
 {% endblock %}


### PR DESCRIPTION
Update site announcement banner: "Explore ADK Python 2.0 Beta with workflows and agent teams, and ADK TypeScript 1.0 is now available".