### PR TITLE
docs: Override _run_impl instead of run in GetInput

### DIFF
--- a/docs/workflows/dynamic.md
+++ b/docs/workflows/dynamic.md
@@ -335,7 +335,7 @@ class GetInput(BaseNode):
     def get_name(self) -> str:
         return self.name
 
-    async def run(self) -> AsyncGenerator[Any, None]:
+    async def _run_impl(self) -> AsyncGenerator[Any, None]:
         # Yielding the request tells the workflow to pause and wait for input
         yield self.request
 


### PR DESCRIPTION
The 'run' is marked as @final in BaseNode class's implementation and hence can not be be overridden in the child class. Moreover, there is a method _run_impl() specifically for overriding. 

Overriding 'run' directly bypasses the logic that converts raw return values into Event objects. This causes downstream failures in _track_event_in_context, which expects a valid Event type Object.

The _run_impl is called inside the run method.
The  _run_impl can return any value and this value is appropriately converted to Event Object by run method. 

This change moves the custom logic for GetInput into _run_impl, allowing the base class to correctly wrap the yielded request in an Event object before it is tracked by the workflow loop.