### PR TITLE
fix/coding with ai inaccuracies

### DIFF
--- a/docs/deploy/agent-runtime/agents-cli.md
+++ b/docs/deploy/agent-runtime/agents-cli.md
@@ -1,16 +1,16 @@
-# Deploy to Agent Runtime with agents-cli
+# Deploy to Agent Runtime with Agents CLI
 
 <div class="language-support-tag" title="Agent Runtime currently supports only Python.">
     <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
 </div>
 
 This deployment procedure describes how to perform a deployment using
-[agents-cli](https://google.github.io/agents-cli/)
-and the ADK. Deploying to Agent Runtime via agents-cli provides an accelerated path to a production-ready environment. agents-cli automatically configures Google Cloud resources, CI/CD pipelines, and Infrastructure-as-Code (Terraform) to support the entire development lifecycle. As a best practice, always ensure you review the generated configurations to align with your organization’s security and compliance standards before production deployment.
+[Agents CLI in Agent Platform](https://google.github.io/agents-cli/)
+and the ADK. Deploying to Agent Runtime via Agents CLI provides an accelerated path to a production-ready environment. Agents CLI automatically configures Google Cloud resources, CI/CD pipelines, and Infrastructure-as-Code (Terraform) to support the entire development lifecycle. As a best practice, always ensure you review the generated configurations to align with your organization’s security and compliance standards before production deployment.
 
-This deployment guide uses agents-cli to apply a project template to your
+This deployment guide uses Agents CLI to apply a project template to your
 existing project, add deployment artifacts, and prepare your agent project for
-deployment. These instructions show you how to use agents-cli to provision a Google
+deployment. These instructions show you how to use Agents CLI to provision a Google
 Cloud project with services needed for deploying your ADK project, as follows:
 
 -   [Prerequisites](#prerequisites-ad): Set up Google Cloud
@@ -24,7 +24,7 @@ Cloud project with services needed for deploying your ADK project, as follows:
     required services in your Google Cloud project and upload your ADK project code.
 
 For information on testing a deployed agent, see [Test deployed agent](test.md).
-For more information on using agents-cli and its command line tools,
+For more information on using Agents CLI and its command line tools,
 see the
 [CLI reference](https://google.github.io/agents-cli/cli/)
 and
@@ -44,7 +44,7 @@ You need the following resources configured to use this deployment path:
     For new projects, see [Creating and managing projects](https://cloud.google.com/resource-manager/docs/creating-managing-projects).
 
 -   **Python Environment**: A Python version supported by
-    [agents-cli](https://google.github.io/agents-cli/guide/getting-started/).
+    [Agents CLI](https://google.github.io/agents-cli/guide/getting-started/).
 -   **uv Tool:** Manage Python development environment and running agents-cli
     tools. For installation details, see
     [Install uv](https://docs.astral.sh/uv/getting-started/installation/).
@@ -58,7 +58,7 @@ You need the following resources configured to use this deployment path:
 ### Prepare your ADK project {#prepare-ad}
 
 When you deploy an ADK project to Agent Runtime, you need some additional files
-to support the deployment operation. The following agents-cli command backs up your
+to support the deployment operation. The following Agents CLI command backs up your
 project and then adds files to your project for deployment purposes.
 
 These instructions assume you have an existing ADK project that you are modifying
@@ -83,14 +83,14 @@ To prepare your ADK project for deployment to Agent Runtime:
 
     Navigate to `your-project-directory/`
 
-1.  Run the agents-cli `scaffold enhance` command to add the files required for deployment into
+1.  Run the Agents CLI `scaffold enhance` command to add the files required for deployment into
     your project.
 
     ```shell
     agents-cli scaffold enhance --deployment-target agent_engine
     ```
 
-1.  Follow the instructions from the agents-cli tool. In general, you can accept
+1.  Follow the instructions from the Agents CLI tool. In general, you can accept
     the default answers to all questions. However for the **GCP region**,
     option, make sure you select one of the
     [supported regions](https://docs.cloud.google.com/agent-builder/locations#supported-regions-agent-engine)
@@ -103,10 +103,10 @@ When you successfully complete this process, the tool shows the following messag
 ```
 
 !!! tip "Note"
-    The agents-cli tool may show a reminder to connect to Google Cloud while
+    The Agents CLI tool may show a reminder to connect to Google Cloud while
     running, but that connection is *not required* at this stage.
 
-For more information about the changes agents-cli makes to your ADK project, see
+For more information about the changes Agents CLI makes to your ADK project, see
 [Changes to your ADK project](#adk-agents-cli-changes).
 
 ### Connect to your Google Cloud project {#connect-ad}
@@ -142,7 +142,7 @@ ID, you are ready to deploy your ADK project files to Agent Runtime.
 
 ### Deploy your ADK project {#deploy-ad}
 
-When using agents-cli, you deploy using the `agents-cli deploy` command. This
+When using Agents CLI, you deploy using the `agents-cli deploy` command. This
 command builds a container from your agent code, pushes it to a registry, and
 deploys it to Agent Runtime in the hosted environment.
 
@@ -184,7 +184,7 @@ deployed agent, see
 
 ### Changes to your ADK project {#adk-agents-cli-changes}
 
-The agents-cli tools add more files to your project for deployment. The procedure
+The Agents CLI tools add more files to your project for deployment. The procedure
 below backs up your existing project files before modifying them. This guide
 uses the
 [multi_tool_agent](https://github.com/google/adk-docs/tree/main/examples/python/snippets/get-started/multi_tool_agent)
@@ -198,7 +198,7 @@ my_agent/
 └─ .env
 ```
 
-After running the agents-cli scaffold enhance command to add Agent Runtime deployment
+After running the Agents CLI scaffold enhance command to add Agent Runtime deployment
 information, the new structure is as follows:
 
 ```
@@ -217,8 +217,8 @@ my-agent/
 ```
 
 See the *README.md* file in your updated ADK project folder for more information.
-For more information on using agents-cli, see the
-[agents-cli documentation](https://google.github.io/agents-cli/).
+For more information on using Agents CLI, see the
+[Agents CLI documentation](https://google.github.io/agents-cli/).
 
 ## Test deployed agents
 

--- a/docs/deploy/agent-runtime/index.md
+++ b/docs/deploy/agent-runtime/index.md
@@ -23,11 +23,11 @@ purposes:
     for users who are already familiar with configuring Google Cloud projects,
     and users preparing for production deployments.
 
-*   **[agents-cli deployment](/deploy/agent-runtime/agents-cli/)**:
+*   **[Agents CLI deployment](/deploy/agent-runtime/agents-cli/)**:
     Follow this accelerated deployment path to set up a fully configured Google
     Cloud environment with CI/CD, infrastructure-as-code, and deployment pipelines
     for your ADK agent. You need a Google Cloud project with billing enabled.
-    agents-cli in Agent Platform helps you deploy ADK projects quickly and it
+    Agents CLI in Agent Platform helps you deploy ADK projects quickly and it
     includes advanced service configurations that extend the core capabilities of
     the Agent Runtime runtime for more mature use cases.
 

--- a/docs/tutorials/coding-with-ai.md
+++ b/docs/tutorials/coding-with-ai.md
@@ -5,7 +5,7 @@ You can use AI coding assistants to build agents with Agent Development Kit
 into your project, or by connecting it to ADK documentation through an MCP
 server.
 
-- [**agents-cli**](#agents-cli): Command-line tool and coding skills for ADK development.
+- [**Agents CLI in Agent Platform**](#agents-cli): Command-line tool and coding skills for ADK development.
 - [**ADK Docs MCP Server**](#adk-docs-mcp-server): Connect your coding tool to
   ADK documentation through an MCP server.
 - [**ADK Docs Index**](#adk-docs-index): Machine-readable documentation files
@@ -13,18 +13,18 @@ server.
 
 ## agents-cli
 
-[agents-cli](https://google.github.io/agents-cli/) is the command-line tool for
+[Agents CLI in Agent Platform](https://google.github.io/agents-cli/) is the command-line tool for
 ADK development. It provides scaffolding commands, deployment tools, and
 development skills that work with any compatible coding assistant, including
 Gemini CLI, Antigravity, Claude Code, and Cursor.
 
-To install agents-cli and set up ADK development skills:
+To install Agents CLI and set up ADK development skills:
 
 ```bash
 uvx google-agents-cli setup
 ```
 
-This installs both the CLI and coding skills. Browse the [agents-cli
+This installs both the CLI and coding skills. Browse the [Agents CLI
 documentation](https://google.github.io/agents-cli/) for more details.
 
 ### CLI Commands

--- a/docs/tutorials/coding-with-ai.md
+++ b/docs/tutorials/coding-with-ai.md
@@ -34,8 +34,8 @@ documentation](https://google.github.io/agents-cli/) for more details.
 | `agents-cli scaffold create` | Create a new ADK agent project |
 | `agents-cli scaffold enhance` | Add deployment to existing project |
 | `agents-cli eval` | Run agent evaluations |
-| `agents-cli deploy` | Deploy to Agent Runtime or Cloud Run |
-| `agents-cli publish` | Publish agent to Agent Store |
+| `agents-cli deploy` | Deploy to Agent Runtime, Cloud Run, or GKE |
+| `agents-cli publish` | Publish to Gemini Enterprise |
 
 ### Development Skills
 
@@ -43,12 +43,13 @@ After setup, the following skills are available in your coding tool:
 
 | Skill | Description |
 |-------|-------------|
+| `google-agents-cli-workflow` | Development lifecycle and coding guidelines |
 | `google-agents-cli-adk-code` | Python API quick reference and docs index |
-| `google-agents-cli-adk-deploy` | Agent Runtime and Cloud Run deployment |
-| `google-agents-cli-adk-dev` | Development lifecycle and coding guidelines |
-| `google-agents-cli-adk-eval` | Evaluation methodology and scoring |
-| `google-agents-cli-adk-observe` | Tracing, logging, and integrations |
-| `google-agents-cli-adk-scaffold` | Project scaffolding |
+| `google-agents-cli-scaffold` | Project scaffolding |
+| `google-agents-cli-eval` | Evaluation methodology and scoring |
+| `google-agents-cli-deploy` | Agent Runtime, Cloud Run, and GKE deployment |
+| `google-agents-cli-publish` | Gemini Enterprise registration |
+| `google-agents-cli-observability` | Tracing, logging, and integrations |
 
 ## ADK Docs MCP Server
 


### PR DESCRIPTION
Corrects multiple inaccuracies in the Agents CLI documentation and applies consistent product branding.                                                
                                                                  
  Issues Fixed

  1. Incorrect skill names in coding-with-ai.md                                                                                                          
   
  All 6 skill names were wrong, using a non-existent -adk- naming pattern:                                                                               
  - google-agents-cli-adk-deploy → google-agents-cli-deploy       
  - google-agents-cli-adk-dev → google-agents-cli-workflow                                                                                               
  - google-agents-cli-adk-eval → google-agents-cli-eval           
  - google-agents-cli-adk-observe → google-agents-cli-observability                                                                                      
  - google-agents-cli-adk-scaffold → google-agents-cli-scaffold    
  - Added missing google-agents-cli-publish skill                                                                                                        
                                                                                                                                                         
  2. Missing GKE deployment target
                                                                                                                                                         
  Deploy command description was missing GKE as a supported target.                                                                                      
   
  3. Wrong publish destination                                                                                                                           
                                                                  
  Changed "Publish agent to Agent Store" to "Publish to Gemini Enterprise"                                                                               
   
  4. Inconsistent branding                                                                                                                               
                                                                  
  Applied full branding "Agents CLI in Agent Platform" in introductory paragraphs, shortened to "Agents CLI" in subsequent prose.  