### PR TITLE
Update Java ADK dependency versions to 1.2.0

### DIFF
--- a/docs/deploy/cloud-run.md
+++ b/docs/deploy/cloud-run.md
@@ -532,12 +532,12 @@ unless you specify it as deployment setting, such as the `--with_ui` option for
           <dependency>
              <groupId>com.google.adk</groupId>
              <artifactId>google-adk</artifactId>
-             <version>1.0.0</version>
+             <version>1.2.0</version>
           </dependency>
           <dependency>
              <groupId>com.google.adk</groupId>
              <artifactId>google-adk-dev</artifactId>
-             <version>1.0.0</version>
+             <version>1.2.0</version>
           </dependency>
         </dependencies>
 

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -99,13 +99,13 @@
             <dependency>
                 <groupId>com.google.adk</groupId>
                 <artifactId>google-adk</artifactId>
-                <version>1.0.0</version>
+                <version>1.2.0</version>
             </dependency>
             <!-- The ADK dev web UI to debug your agent -->
             <dependency>
                 <groupId>com.google.adk</groupId>
                 <artifactId>google-adk-dev</artifactId>
-                <version>1.0.0</version>
+                <version>1.2.0</version>
             </dependency>
         </dependencies>
 
@@ -118,8 +118,8 @@
 
     ```title="build.gradle"
     dependencies {
-        implementation 'com.google.adk:google-adk:1.0.0'
-        implementation 'com.google.adk:google-adk-dev:1.0.0'
+        implementation 'com.google.adk:google-adk:1.2.0'
+        implementation 'com.google.adk:google-adk-dev:1.2.0'
     }
     ```
 

--- a/docs/get-started/java.md
+++ b/docs/get-started/java.md
@@ -103,7 +103,7 @@ An ADK agent project requires this dependency in your
     <dependency>
         <groupId>com.google.adk</groupId>
         <artifactId>google-adk</artifactId>
-        <version>1.0.0</version>
+        <version>1.2.0</version>
     </dependency>
 </dependencies>
 ```
@@ -138,13 +138,13 @@ additional settings with the following configuration code:
             <dependency>
                 <groupId>com.google.adk</groupId>
                 <artifactId>google-adk</artifactId>
-                <version>1.0.0</version>
+                <version>1.2.0</version>
             </dependency>
             <!-- The ADK dev web UI to debug your agent -->
             <dependency>
                 <groupId>com.google.adk</groupId>
                 <artifactId>google-adk-dev</artifactId>
-                <version>1.0.0</version>
+                <version>1.2.0</version>
             </dependency>
         </dependencies>
 

--- a/docs/get-started/streaming/quickstart-streaming-java.md
+++ b/docs/get-started/streaming/quickstart-streaming-java.md
@@ -191,7 +191,7 @@ Replace your existing pom.xml with the following.
     <auto-value.version>1.11.0</auto-value.version>
     <!-- Main class for exec-maven-plugin -->
     <exec.mainClass>samples.liveaudio.LiveAudioRun</exec.mainClass>
-    <google-adk.version>0.1.0</google-adk.version>
+    <google-adk.version>1.2.0</google-adk.version>
   </properties>
 
   <dependencyManagement>

--- a/docs/integrations/firestore-session-service.md
+++ b/docs/integrations/firestore-session-service.md
@@ -33,7 +33,7 @@ ADK provides a native integration for managing persistent agent session states u
 
     Ensure you use the same version for both `google-adk` and `google-adk-firestore-session-service` to guarantee compatibility.
 
-Add the following dependencies to your `pom.xml` (Maven) or `build.gradle` (Gradle), replacing `1.0.0` with your target ADK version:
+Add the following dependencies to your `pom.xml` (Maven) or `build.gradle` (Gradle), replacing `1.2.0` with your target ADK version:
 
 ### Maven
 
@@ -43,13 +43,13 @@ Add the following dependencies to your `pom.xml` (Maven) or `build.gradle` (Grad
     <dependency>
         <groupId>com.google.adk</groupId>
         <artifactId>google-adk</artifactId>
-        <version>1.0.0</version>
+        <version>1.2.0</version>
     </dependency>
     <!-- Firestore Session Service -->
     <dependency>
         <groupId>com.google.adk</groupId>
         <artifactId>google-adk-firestore-session-service</artifactId>
-        <version>1.0.0</version>
+        <version>1.2.0</version>
     </dependency>
 </dependencies>
 ```
@@ -59,9 +59,9 @@ Add the following dependencies to your `pom.xml` (Maven) or `build.gradle` (Grad
 ```gradle
 dependencies {
     // ADK Core
-    implementation 'com.google.adk:google-adk:1.0.0'
+    implementation 'com.google.adk:google-adk:1.2.0'
     // Firestore Session Service
-    implementation 'com.google.adk:google-adk-firestore-session-service:1.0.0'
+    implementation 'com.google.adk:google-adk-firestore-session-service:1.2.0'
 }
 ```
 

--- a/examples/java/cloud-run/pom.xml
+++ b/examples/java/cloud-run/pom.xml
@@ -20,13 +20,13 @@
     <dependency>
       <groupId>com.google.adk</groupId>
       <artifactId>google-adk</artifactId>
-      <version>0.1.0</version>
+      <version>1.2.0</version>
     </dependency>
     <!-- The ADK dev web UI to debug your agent -->
     <dependency>
       <groupId>com.google.adk</groupId>
       <artifactId>google-adk-dev</artifactId>
-      <version>0.1.0</version>
+      <version>1.2.0</version>
     </dependency>
   </dependencies>
 

--- a/examples/java/demos/patent-search-agent/pom.xml
+++ b/examples/java/demos/patent-search-agent/pom.xml
@@ -22,13 +22,13 @@
         <dependency>
             <groupId>com.google.adk</groupId>
             <artifactId>google-adk</artifactId>
-            <version>0.1.0</version>
+            <version>1.2.0</version>
         </dependency>
         <!-- The ADK dev web UI to debug your agent -->
         <dependency>
             <groupId>com.google.adk</groupId>
             <artifactId>google-adk-dev</artifactId>
-            <version>0.1.0</version>
+            <version>1.2.0</version>
         </dependency>
     </dependencies>
 

--- a/examples/java/snippets/pom.xml
+++ b/examples/java/snippets/pom.xml
@@ -19,12 +19,12 @@
         <dependency>
             <groupId>com.google.adk</groupId>
             <artifactId>google-adk</artifactId>
-            <version>0.9.0</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.adk</groupId>
             <artifactId>google-adk-dev</artifactId>
-            <version>0.9.0</version>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.yahoofinance-api</groupId>


### PR DESCRIPTION
Bumps all Java ADK dependency versions to 1.2.0 across docs and example projects to reflect the latest ADK Java release.