### PR TITLE
Update documentation for setting up logging in ADK

### DIFF
--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -4,31 +4,44 @@
   <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-go">Go v0.1.0</span>
 </div>
 
-Agent Development Kit (ADK) provides flexible and powerful logging capabilities to monitor agent behavior and debug issues effectively.
+Agent Development Kit (ADK) provides flexible and powerful logging capabilities
+to monitor agent behavior and debug issues effectively.
 
 ## Logging philosophy
 
-ADK's approach to logging is to provide detailed diagnostic information without being overly verbose by default. It is designed to be configured by the application developer, allowing you to tailor the log output to your specific needs, whether in a development or production environment.
+ADK's approach to logging is to provide detailed diagnostic information without
+being overly verbose by default. It is designed to be configured by the
+application developer, allowing you to tailor the log output to your specific
+needs, whether in a development or production environment.
 
-- **Standard Library Integration:** ADK uses the standard logging facilities of the host language (e.g., Python's `logging` module, Go's `log` package).
-- **Structured GenAI Logging:** ADK uses OpenTelemetry to log structured events for GenAI requests and responses, allowing for advanced monitoring and debugging in cloud environments.
-- **User-Configured:** While ADK provides defaults and integration with its CLI tools, it is ultimately the responsibility of the application developer to configure logging to suit their specific environment.
-
----
+- **Standard Library Integration:** ADK uses the standard logging facilities of
+  the host language (e.g., Python's `logging` module, Go's `log` package).
+- **Structured GenAI Logging:** ADK uses OpenTelemetry to log structured events
+  for GenAI requests and responses, allowing for advanced monitoring and
+  debugging in cloud environments.
+- **User-Configured:** While ADK provides defaults and integration with its CLI
+  tools, it is ultimately the responsibility of the application developer to
+  configure logging to suit their specific environment.
 
 ## Logging schema
 
-ADK emits logs using standard library facilities and structured GenAI events via OpenTelemetry.
+ADK emits logs using standard library facilities and structured GenAI events via
+OpenTelemetry.
 
 ### Structured GenAI logs
 
-Structured GenAI logs emitted via OpenTelemetry follow the [Semantic Conventions for GenAI](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-events.md).
+Structured GenAI logs emitted via OpenTelemetry follow the [Semantic Conventions
+for
+GenAI](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-events.md).
 
-By default prompt content is elided in logs for security. You can enable prompt logging using environment variables or programmatic configuration (see Setup section below).
+By default prompt content is elided in logs for security. You can enable prompt
+logging using environment variables or programmatic configuration (see Setup
+section below).
 
 ### Log levels (Python)
 
-The following table describes what is logged at different levels in Python when using the standard logger:
+The following table describes what is logged at different levels in Python when
+using the standard logger:
 
 | Level | Description | Type of Information Logged  |
 | :--- | :--- | :--- |
@@ -37,15 +50,18 @@ The following table describes what is logged at different levels in Python when 
 | **`WARNING`** | Indicates a potential issue or deprecated feature use. The agent continues to function, but attention may be required. | <ul><li>Use of deprecated methods or parameters.</li><li>Non-critical errors that the system recovered from.</li></ul> |
 | **`ERROR`** | A serious error that prevented an operation from completing. | <ul><li>Failed API calls to external services (e.g., LLM, Session Service).</li><li>Unhandled exceptions during agent execution.</li><li>Configuration errors.</li></ul> |
 
-> **Note:** It is recommended to use `INFO` or `WARNING` in production environments. Only enable `DEBUG` when actively troubleshooting an issue, as `DEBUG` logs can be very verbose and may contain sensitive information.
-
----
+!!! note
+    It is recommended to use `INFO` or `WARNING` in production environments.
+    Only enable `DEBUG` when actively troubleshooting an issue, as `DEBUG` logs
+    can be very verbose and may contain sensitive information.
 
 ## Logging setup
 
 ### Logging in ADK Web
 
-When running agents using the ADK's `adk web`, `adk api_server`, `adk deploy cloud_run` and `adk deploy gke` commands, you can control the log verbosity or destination.
+When running agents using the ADK's `adk web`, `adk api_server`, `adk deploy
+cloud_run` and `adk deploy gke` commands, you can control the log verbosity or
+destination.
 
 #### Logging level
 
@@ -55,28 +71,38 @@ To start the web server with `DEBUG` level logging, run:
 adk web --log_level DEBUG path/to/your/agents_dir
 ```
 
-The available log levels for the `--log_level` option are: `DEBUG`, `INFO` (default), `WARNING`, `ERROR`, `CRITICAL`.
+The available log levels for the `--log_level` option are: `DEBUG`, `INFO`
+(default), `WARNING`, `ERROR`, `CRITICAL`.
 
 #### Capture prompt content
 
-By default a prompt content is elided in logs for security. You can enable prompt logging using the environment variable:
+By default a prompt content is elided in logs for security. You can enable
+prompt logging using the environment variable:
 
 ```bash
 export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
 ```
 
-> **Note:**  The OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT setting logs the full content of user prompts and agent responses. This is useful for debugging but may capture sensitive data or PII. In production, set this to false or ensure you have appropriate data handling policies in place.
+!!! warning
+    The `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` setting logs the
+    full content of user prompts and agent responses. This is useful for
+    debugging but may capture sensitive data or PII. In production, set this to
+    false or ensure you have appropriate data handling policies in place.
 
 #### OTLP export
 
-To export logs to an OTLP-compatible backend, set the standard OTel environment variables:
+To export logs to an OTLP-compatible backend, set the standard OTel environment
+variables:
 
 ```bash
 export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="http://your-collector:4318/v1/logs"
 adk web path/to/your/agents_dir
 ```
 
-> **Note:**  You can also set the general `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable if you would like to send metrics and traces to the same endpoint in addition to logs.
+!!! note
+    You can also set the general `OTEL_EXPORTER_OTLP_ENDPOINT` environment
+    variable if you would like to send metrics and traces to the same endpoint
+    in addition to logs.
 
 
 #### GCP export setup
@@ -89,11 +115,13 @@ adk web -otel_to_cloud path/to/your/agents_dir
 
 ### Python programmatic setup
 
-In Python, ADK uses the standard `logging` module and OpenTelemetry for structured GenAI logs.
+In Python, ADK uses the standard `logging` module and OpenTelemetry for
+structured GenAI logs.
 
 #### Logging level
 
-To enable detailed logging, including `DEBUG` level messages, add the following to the top of your script:
+To enable detailed logging, including `DEBUG` level messages, add the following
+to the top of your script:
 
 ```python
 import logging
@@ -106,7 +134,8 @@ logging.basicConfig(
 
 #### Capture prompt content
 
-You can enable full prompt logging programmatically by setting an environment variable:
+You can enable full prompt logging programmatically by setting an environment
+variable:
 
 ```python
 import os
@@ -116,7 +145,8 @@ os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = "true"
 
 #### OTLP export
 
-To export logs to an OpenTelemetry Collector (or an OTLP-compatible backend) programmatically:
+To export logs to an OpenTelemetry Collector (or an OTLP-compatible backend)
+programmatically:
 
 ```python
 from google.adk.telemetry.setup import maybe_set_otel_providers
@@ -130,7 +160,8 @@ maybe_set_otel_providers()
 
 #### GCP export setup
 
-To export logs to Google Cloud Logging programmatically, use the OpenTelemetry Google Cloud exporter. Here is an example in Python:
+To export logs to Google Cloud Logging programmatically, use the OpenTelemetry
+Google Cloud exporter. Here is an example in Python:
 
 ```python
 from google.adk.telemetry.google_cloud import get_gcp_exporters
@@ -147,7 +178,8 @@ maybe_set_otel_providers([gcp_exporters])
 
 ### Go programmatic setup
 
-In Go, ADK uses the `google.golang.org/adk/telemetry` package for OpenTelemetry configuration and the standard `log` package for general events.
+In Go, ADK uses the `google.golang.org/adk/telemetry` package for OpenTelemetry
+configuration and the standard `log` package for general events.
 
 #### Capture prompt content
 
@@ -176,7 +208,10 @@ func main() {
 
 #### OTLP export
 
-To export logs to an OTLP-compatible backend, configure the standard OpenTelemetry environment variables (e.g., `OTEL_EXPORTER_OTLP_ENDPOINT` or `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`). The ADK telemetry package will automatically use these settings when initialized.
+To export logs to an OTLP-compatible backend, configure the standard
+OpenTelemetry environment variables (e.g., `OTEL_EXPORTER_OTLP_ENDPOINT` or
+`OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`). The ADK telemetry package will
+automatically use these settings when initialized.
 
 #### GCP export setup
 
@@ -209,11 +244,10 @@ If using the Go launcher, you can also enable GCP export via the CLI flag:
 go run main.go web -otel_to_cloud
 ```
 
-General events (like server startup or HTTP requests) are logged using the standard Go `log` package. These logs are written to `stderr` by default.
+General events (like server startup or HTTP requests) are logged using the
+standard Go `log` package. These logs are written to `stderr` by default.
 
----
-
-## Reading and understanding the logs
+## Understanding log output
 
 ### Sample Python log entry
 
@@ -228,75 +262,44 @@ General events (like server startup or HTTP requests) are logged using the stand
 | `google_adk.models.google_llm`  | `%(name)s`       | Logger name (the module that produced the log) |
 | `LLM Request: contents { ... }` | `%(message)s`    | The actual log message                         |
 
-By reading the logger name, you can immediately pinpoint the source of the log and understand its context within the agent's architecture.
+By reading the logger name, you can immediately pinpoint the source of the log
+and understand its context within the agent's architecture.
 
-### Debugging with logs: A practical example (Python)
+### Debugging example
 
-**Scenario:** Your agent is not producing the expected output, and you suspect the prompt being sent to the LLM is incorrect.
+After enabling `DEBUG` logging (see [Logging level](#logging-level) above), run
+your agent and look for messages from the `google.adk.models.google_llm` logger.
+The output shows the full LLM request and response:
 
-**Steps:**
+```text
+2025-07-10 15:26:13,778 - DEBUG - google_adk.google.adk.models.google_llm -
+LLM Request:
+-----------------------------------------------------------
+System Instruction:
+      You roll dice and answer questions about the outcome of the dice rolls.
+      ...
+-----------------------------------------------------------
+Contents:
+{"parts":[{"text":"Roll a 6 sided dice"}],"role":"user"}
+{"parts":[{"function_call":{"args":{"sides":6},"name":"roll_die"}}],"role":"model"}
+{"parts":[{"function_response":{"name":"roll_die","response":{"result":2}}}],"role":"user"}
+-----------------------------------------------------------
+Functions:
+roll_die: {'sides': {'type': <Type.INTEGER: 'INTEGER'>}}
+check_prime: {'nums': {'items': {'type': <Type.INTEGER: 'INTEGER'>}, 'type': <Type.ARRAY: 'ARRAY'>}}
+-----------------------------------------------------------
+2025-07-10 15:26:14,309 - INFO - google_adk.google.adk.models.google_llm -
+LLM Response:
+-----------------------------------------------------------
+Text:
+I have rolled a 6 sided die, and the result is 2.
+...
+```
 
-1.  **Enable DEBUG Logging:** In your `main.py`, set the logging level to `DEBUG` as shown in the configuration example.
-    ```python
-    logging.basicConfig(
-        level=logging.DEBUG,
-        format='%(asctime)s - %(levelname)s - %(name)s - %(message)s'
-    )
-    ```
+From this output you can verify:
 
-2.  **Run Your Agent:** Execute your agent's task as you normally would.
-
-3.  **Inspect the Logs:** Look through the console output for a message from the `google.adk.models.google_llm` logger that starts with `LLM Request:`.
-
-    ```log
-    ...
-    2025-07-10 15:26:13,778 - DEBUG - google_adk.google.adk.models.google_llm - Sending out request, model: gemini-flash-latest, backend: GoogleLLMVariant.GEMINI_API, stream: False
-    2025-07-10 15:26:13,778 - DEBUG - google_adk.google.adk.models.google_llm -
-    LLM Request:
-    -----------------------------------------------------------
-    System Instruction:
-          You roll dice and answer questions about the outcome of the dice rolls.
-          You can roll dice of different sizes.
-          You can use multiple tools in parallel by calling functions in parallel(in one request and in one round).
-          It is ok to discuss previous dice roles, and comment on the dice rolls.
-          When you are asked to roll a die, you must call the roll_die tool with the number of sides. Be sure to pass in an integer. Do not pass in a string.
-          You should never roll a die on your own.
-          When checking prime numbers, call the check_prime tool with a list of integers. Be sure to pass in a list of integers. You should never pass in a string.
-          You should not check prime numbers before calling the tool.
-          When you are asked to roll a die and check prime numbers, you should always make the following two function calls:
-          1. You should first call the roll_die tool to get a roll. Wait for the function response before calling the check_prime tool.
-          2. After you get the function response from roll_die tool, you should call the check_prime tool with the roll_die result.
-          2.1 If user asks you to check primes based on previous rolls, make sure you include the previous rolls in the list.
-          3. When you respond, you must include the roll_die result from step 1.
-          You should always perform the previous 3 steps when asking for a roll and checking prime numbers.
-          You should not rely on the previous history on prime results.
-    You are an agent. Your internal name is "hello_world_agent".
-    The description about you is "hello world agent that can roll a dice of 8 sides and check prime numbers."
-    -----------------------------------------------------------
-    Contents:
-    {"parts":[{"text":"Roll a 6 sided dice"}],"role":"user"}
-    {"parts":[{"function_call":{"args":{"sides":6},"name":"roll_die"}}],"role":"model"}
-    {"parts":[{"function_response":{"name":"roll_die","response":{"result":2}}}],"role":"user"}
-    -----------------------------------------------------------
-    Functions:
-    roll_die: {'sides': {'type': <Type.INTEGER: 'INTEGER'>}}
-    check_prime: {'nums': {'items': {'type': <Type.INTEGER: 'INTEGER'>}, 'type': <Type.ARRAY: 'ARRAY'>}}
-    -----------------------------------------------------------
-    2025-07-10 15:26:13,779 - INFO - google_genai.models - AFC is enabled with max remote calls: 10.
-    2025-07-10 15:26:14,309 - INFO - google_adk.google.adk.models.google_llm -
-    LLM Response:
-    -----------------------------------------------------------
-    Text:
-    I have rolled a 6 sided die, and the result is 2.
-    ...
-    ```
-
-4.  **Analyze the Prompt:** By examining the `System Instruction`, `contents`, `functions` sections of the logged request, you can verify:
-    -   Is the system instruction correct?
-    -   Is the conversation history (`user` and `model` turns) accurate?
-    -   Is the most recent user query included?
-    -   Are the correct tools being provided to the model?
-    -   Are the tools correctly called by the model?
-    -   How long it takes for the model to respond?
-
-This detailed output allows you to diagnose a wide range of issues, from incorrect prompt engineering to problems with tool definitions, directly from the log files.
+- Is the system instruction correct?
+- Is the conversation history (`user` and `model` turns) accurate?
+- Are the correct tools being provided to the model?
+- Are the tools correctly called by the model?
+- How long it takes for the model to respond?

--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -37,7 +37,7 @@ The following table describes what is logged at different levels in Python when 
 | **`WARNING`** | Indicates a potential issue or deprecated feature use. The agent continues to function, but attention may be required. | <ul><li>Use of deprecated methods or parameters.</li><li>Non-critical errors that the system recovered from.</li></ul> |
 | **`ERROR`** | A serious error that prevented an operation from completing. | <ul><li>Failed API calls to external services (e.g., LLM, Session Service).</li><li>Unhandled exceptions during agent execution.</li><li>Configuration errors.</li></ul> |
 
-**Note:** It is recommended to use `INFO` or `WARNING` in production environments. Only enable `DEBUG` when actively troubleshooting an issue, as `DEBUG` logs can be very verbose and may contain sensitive information.
+> **Note:** It is recommended to use `INFO` or `WARNING` in production environments. Only enable `DEBUG` when actively troubleshooting an issue, as `DEBUG` logs can be very verbose and may contain sensitive information.
 
 ---
 

--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -24,7 +24,7 @@ ADK emits logs using standard library facilities and structured GenAI events via
 
 Structured GenAI logs emitted via OpenTelemetry follow the [Semantic Conventions for GenAI](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-events.md).
 
-In Go, prompt content is elided in logs for security by default. You can enable prompt logging using environment variables or programmatic configuration (see Setup section below).
+By default prompt content is elided in logs for security. You can enable prompt logging using environment variables or programmatic configuration (see Setup section below).
 
 ### Log levels (Python)
 
@@ -45,11 +45,9 @@ The following table describes what is logged at different levels in Python when 
 
 ### Logging in ADK Web
 
-When running agents using the ADK's built-in web or API servers, you can control the log verbosity or destination.
+When running agents using the ADK's `adk web`, `adk api_server`, `adk deploy cloud_run` and `adk deploy gke` commands, you can control the log verbosity or destination.
 
 #### Logging level
-
-The `adk web`, `adk api_server`, and `adk deploy cloud_run` commands all accept a `--log_level` option.
 
 To start the web server with `DEBUG` level logging, run:
 
@@ -58,6 +56,16 @@ adk web --log_level DEBUG path/to/your/agents_dir
 ```
 
 The available log levels for the `--log_level` option are: `DEBUG`, `INFO` (default), `WARNING`, `ERROR`, `CRITICAL`.
+
+#### Capture prompt content
+
+By default a prompt content is elided in logs for security. You can enable prompt logging using the environment variable:
+
+```bash
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
+```
+
+> **Note:**  The OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT setting logs the full content of user prompts and agent responses. This is useful for debugging but may capture sensitive data or PII. In production, set this to false or ensure you have appropriate data handling policies in place.
 
 #### OTLP export
 
@@ -98,6 +106,16 @@ logging.basicConfig(
 )
 ```
 
+#### Capture prompt content
+
+You can enable full prompt logging programmatically by setting an environment variable:
+
+```python
+import os
+
+os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = True
+```
+
 #### OTLP export
 
 To export logs to an OpenTelemetry Collector (or an OTLP-compatible backend) programmatically:
@@ -131,15 +149,9 @@ maybe_set_otel_providers([gcp_exporters])
 
 ### Go programmatic configuration
 
-#### Logging level
+#### Capture prompt content
 
-By default, prompt content is elided in logs for security. You can enable prompt logging using the environment variable:
-
-```bash
-export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
-```
-
-Or programmatically when initializing telemetry:
+You can enable full prompt logging programmatically when initializing telemetry:
 
 ```go
 package main

--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -1,10 +1,10 @@
 # Agent activity logging
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-go">Go v0.1.0</span>
 </div>
 
-Agent Development Kit (ADK) provides flexible and powerful logging capabilities to monitor agent behavior and debug issues effectively. Understanding how to configure and interpret these logs is crucial for monitoring agent behavior and debugging issues effectively.
+Agent Development Kit (ADK) provides flexible and powerful logging capabilities to monitor agent behavior and debug issues effectively.
 
 ## Logging philosophy
 
@@ -69,7 +69,7 @@ export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
 
 #### OTLP export
 
-To export traces to an OTLP-compatible backend, set the standard OTel environment variables:
+To export logs to an OTLP-compatible backend, set the standard OTel environment variables:
 
 ```bash
 export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="http://your-collector:4318/v1/logs"
@@ -87,15 +87,13 @@ You can enable GCP export using the `-otel_to_cloud` flag:
 adk web -otel_to_cloud path/to/your/agents_dir
 ```
 
-### Programmatic logging setup
+### Python programmatic setup
 
-You can also configure logging programmatically in your application code.
-
-#### Python programmatic configuration
+In Python, ADK uses the standard `logging` module and OpenTelemetry for structured GenAI logs.
 
 #### Logging level
 
-In Python, you can use the standard `logging` module. To enable detailed logging, including `DEBUG` level messages, add the following to the top of your script:
+To enable detailed logging, including `DEBUG` level messages, add the following to the top of your script:
 
 ```python
 import logging
@@ -113,7 +111,7 @@ You can enable full prompt logging programmatically by setting an environment va
 ```python
 import os
 
-os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = True
+os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = "true"
 ```
 
 #### OTLP export
@@ -132,7 +130,7 @@ maybe_set_otel_providers()
 
 #### GCP export setup
 
-To export metrics to Google Cloud Logging programmatically, use the OpenTelemetry Google Cloud exporter. Here is an example in Python:
+To export logs to Google Cloud Logging programmatically, use the OpenTelemetry Google Cloud exporter. Here is an example in Python:
 
 ```python
 from google.adk.telemetry.google_cloud import get_gcp_exporters
@@ -147,7 +145,9 @@ os.environ["OTEL_RESOURCE_ATTRIBUTES"] = "key1=value1,key2=value2"
 maybe_set_otel_providers([gcp_exporters])
 ```
 
-### Go programmatic configuration
+### Go programmatic setup
+
+In Go, ADK uses the `google.golang.org/adk/telemetry` package for OpenTelemetry configuration and the standard `log` package for general events.
 
 #### Capture prompt content
 
@@ -201,6 +201,12 @@ func main() {
 	defer tp.Shutdown(ctx)
 	tp.SetGlobalOtelProviders()
 }
+```
+
+If using the Go launcher, you can also enable GCP export via the CLI flag:
+
+```bash
+go run main.go web -otel_to_cloud
 ```
 
 General events (like server startup or HTTP requests) are logged using the standard Go `log` package. These logs are written to `stderr` by default.

--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -6,7 +6,7 @@
 
 Agent Development Kit (ADK) provides flexible and powerful logging capabilities to monitor agent behavior and debug issues effectively. Understanding how to configure and interpret these logs is crucial for monitoring agent behavior and debugging issues effectively.
 
-## Logging Philosophy
+## Logging philosophy
 
 ADK's approach to logging is to provide detailed diagnostic information without being overly verbose by default. It is designed to be configured by the application developer, allowing you to tailor the log output to your specific needs, whether in a development or production environment.
 
@@ -16,42 +16,19 @@ ADK's approach to logging is to provide detailed diagnostic information without 
 
 ---
 
-## Configuring Logging in Python
+## Logging schema
 
-In Python, ADK uses the standard `logging` module.
+ADK emits logs using standard library facilities and structured GenAI events via OpenTelemetry.
 
-### Example Configuration
+### Structured GenAI logs
 
-To enable detailed logging, including `DEBUG` level messages, add the following to the top of your script:
+Structured GenAI logs emitted via OpenTelemetry follow the [Semantic Conventions for GenAI](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-events.md).
 
-```python
-import logging
+In Go, prompt content is elided in logs for security by default. You can enable prompt logging using environment variables or programmatic configuration (see Setup section below).
 
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(asctime)s - %(levelname)s - %(name)s - %(message)s'
-)
-```
+### Log levels (Python)
 
-### Configuring Logging with the ADK CLI (Python)
-
-When running Python agents using the ADK's built-in web or API servers, you can easily control the log verbosity directly from the command line. The `adk web`, `adk api_server`, and `adk deploy cloud_run` commands all accept a `--log_level` option.
-
-To start the web server with `DEBUG` level logging, run:
-
-```bash
-adk web --log_level DEBUG path/to/your/agents_dir
-```
-
-The available log levels for the `--log_level` option are:
-
-- `DEBUG`
-- `INFO` (default)
-- `WARNING`
-- `ERROR`
-- `CRITICAL`
-
-### Log Levels (Python)
+The following table describes what is logged at different levels in Python when using the standard logger:
 
 | Level | Description | Type of Information Logged  |
 | :--- | :--- | :--- |
@@ -64,27 +41,109 @@ The available log levels for the `--log_level` option are:
 
 ---
 
-## Configuring Logging in Go
+## Logging setup
 
-In Go, ADK uses the standard `log` package for general events and OpenTelemetry for GenAI activity logging.
+### Logging in ADK Web
 
-### OpenTelemetry Logging
+When running agents using the ADK's built-in web or API servers, you can control the log verbosity or destination.
 
-ADK Go uses OpenTelemetry (OTel) to log GenAI requests and responses. By default, prompt content is elided in logs for security. You can enable prompt logging using environment variables or programmatic configuration.
+#### Logging level
 
-#### Enabling Prompt Logging
+The `adk web`, `adk api_server`, and `adk deploy cloud_run` commands all accept a `--log_level` option.
 
-Set the following environment variable to `true` to include full prompts in your OTel logs:
+To start the web server with `DEBUG` level logging, run:
+
+```bash
+adk web --log_level DEBUG path/to/your/agents_dir
+```
+
+The available log levels for the `--log_level` option are: `DEBUG`, `INFO` (default), `WARNING`, `ERROR`, `CRITICAL`.
+
+#### OTLP export
+
+To export traces to an OTLP-compatible backend, set the standard OTel environment variables:
+
+```bash
+export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="http://your-collector:4318/v1/logs"
+adk web path/to/your/agents_dir
+```
+
+> **Note:**  You can also set the general `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable if you would like to send metrics and traces to the same endpoint in addition to logs.
+
+
+#### GCP export setup
+
+You can enable GCP export using the `-otel_to_cloud` flag:
+
+```bash
+adk web -otel_to_cloud path/to/your/agents_dir
+```
+
+### Programmatic logging setup
+
+You can also configure logging programmatically in your application code.
+
+#### Python programmatic configuration
+
+#### Logging level
+
+In Python, you can use the standard `logging` module. To enable detailed logging, including `DEBUG` level messages, add the following to the top of your script:
+
+```python
+import logging
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)s - %(levelname)s - %(name)s - %(message)s'
+)
+```
+
+#### OTLP export
+
+To export logs to an OpenTelemetry Collector (or an OTLP-compatible backend) programmatically:
+
+```python
+from google.adk.telemetry.setup import maybe_set_otel_providers
+import os
+
+os.environ["OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"] = "http://your-collector:4318/v1/logs"
+os.environ["OTEL_SERVICE_NAME"] = "your-adk-agent"
+os.environ["OTEL_RESOURCE_ATTRIBUTES"] = "key1=value1,key2=value2"
+maybe_set_otel_providers()
+```
+
+#### GCP export setup
+
+To export metrics to Google Cloud Logging programmatically, use the OpenTelemetry Google Cloud exporter. Here is an example in Python:
+
+```python
+from google.adk.telemetry.google_cloud import get_gcp_exporters
+from google.adk.telemetry.setup import maybe_set_otel_providers
+import os
+
+gcp_exporters = get_gcp_exporters(
+  enable_cloud_logging = True,
+)
+os.environ["OTEL_SERVICE_NAME"] = "your-adk-agent"
+os.environ["OTEL_RESOURCE_ATTRIBUTES"] = "key1=value1,key2=value2"
+maybe_set_otel_providers([gcp_exporters])
+```
+
+### Go programmatic configuration
+
+#### Logging level
+
+By default, prompt content is elided in logs for security. You can enable prompt logging using the environment variable:
 
 ```bash
 export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
 ```
 
-#### Programmatic Configuration
-
-You can configure telemetry providers using the `google.golang.org/adk/telemetry` package.
+Or programmatically when initializing telemetry:
 
 ```go
+package main
+
 import (
 	"context"
 	"google.golang.org/adk/telemetry"
@@ -92,58 +151,71 @@ import (
 
 func main() {
 	ctx := context.Background()
-
-	// Initialize telemetry with prompt content logging enabled
 	tp, err := telemetry.New(ctx,
 		telemetry.WithGenAICaptureMessageContent(true),
-		// Add other options like WithOtelToCloud(true) for GCP export
 	)
 	if err != nil {
 		// handle error
 	}
 	defer tp.Shutdown(ctx)
-
-	// Register as global OTel providers
 	tp.SetGlobalOtelProviders()
-
-	// Your ADK agent code follows...
 }
 ```
 
-### General Logging
+#### OTLP export
+
+To export logs to an OTLP-compatible backend, configure the standard OpenTelemetry environment variables (e.g., `OTEL_EXPORTER_OTLP_ENDPOINT` or `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`). The ADK telemetry package will automatically use these settings when initialized.
+
+#### GCP export setup
+
+To export logs to Google Cloud Logging, use the `WithOtelToCloud` option:
+
+```go
+package main
+
+import (
+	"context"
+	"google.golang.org/adk/telemetry"
+)
+
+func main() {
+	ctx := context.Background()
+	tp, err := telemetry.New(ctx,
+		telemetry.WithOtelToCloud(true),
+	)
+	if err != nil {
+		// handle error
+	}
+	defer tp.Shutdown(ctx)
+	tp.SetGlobalOtelProviders()
+}
+```
 
 General events (like server startup or HTTP requests) are logged using the standard Go `log` package. These logs are written to `stderr` by default.
 
-### Configuring Logging with the ADK Go Launcher
-
-When using the ADK Go `full.Launcher` or `prod.Launcher`, telemetry is automatically initialized. You can enable GCP export using the `-otel_to_cloud` flag:
-
-```bash
-go run main.go web -otel_to_cloud a2a
-```
-
 ---
 
-## Reading and Understanding the Logs
+## Reading and understanding the logs
 
-The structure of logs depends on your configuration. Structured GenAI logs emitted via OpenTelemetry follow the [Semantic Conventions for GenAI](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-events.md).
-
-### Sample Python Log Entry
+### Sample Python log entry
 
 ```text
 2025-07-08 11:22:33,456 - DEBUG - google_adk.models.google_llm - LLM Request: contents { ... }
 ```
+
 | Log Segment                     | Format Specifier | Meaning                                        |
 | ------------------------------- | ---------------- | ---------------------------------------------- |
 | `2025-07-08 11:22:33,456`       | `%(asctime)s`    | Timestamp                                      |
 | `DEBUG`                         | `%(levelname)s`  | Severity level                                 |
 | `google_adk.models.google_llm`  | `%(name)s`       | Logger name (the module that produced the log) |
 | `LLM Request: contents { ... }` | `%(message)s`    | The actual log message                         |
+
 By reading the logger name, you can immediately pinpoint the source of the log and understand its context within the agent's architecture.
 
-### Debugging with Logs: A Practical Example (Python)
+### Debugging with logs: A practical example (Python)
 
 **Scenario:** Your agent is not producing the expected output, and you suspect the prompt being sent to the LLM is incorrect.
+
 **Steps:**
 
 1.  **Enable DEBUG Logging:** In your `main.py`, set the logging level to `DEBUG` as shown in the configuration example.
@@ -176,7 +248,7 @@ By reading the logger name, you can immediately pinpoint the source of the log a
           When you are asked to roll a die and check prime numbers, you should always make the following two function calls:
           1. You should first call the roll_die tool to get a roll. Wait for the function response before calling the check_prime tool.
           2. After you get the function response from roll_die tool, you should call the check_prime tool with the roll_die result.
-            2.1 If user asks you to check primes based on previous rolls, make sure you include the previous rolls in the list.
+          2.1 If user asks you to check primes based on previous rolls, make sure you include the previous rolls in the list.
           3. When you respond, you must include the roll_die result from step 1.
           You should always perform the previous 3 steps when asking for a roll and checking prime numbers.
           You should not rely on the previous history on prime results.


### PR DESCRIPTION
Restructured the `docs/observability/logging.md` file to align with the structure used in `metrics.md` and `traces.md`  and added detailed subsections for Adk Web/Python and Go configuration.