### PR TITLE
Restructure BigQuery Agent Analytics doc for scannability

### DIFF
--- a/docs/integrations/bigquery-agent-analytics.md
+++ b/docs/integrations/bigquery-agent-analytics.md
@@ -76,6 +76,7 @@ from google.adk.models.google_llm import Gemini
 from google.adk.plugins.bigquery_agent_analytics_plugin import BigQueryAgentAnalyticsPlugin
 
 os.environ['GOOGLE_CLOUD_PROJECT'] = 'your-gcp-project-id'
+os.environ['GOOGLE_CLOUD_LOCATION'] = 'us-central1'
 os.environ['GOOGLE_GENAI_USE_VERTEXAI'] = 'True'
 
 plugin = BigQueryAgentAnalyticsPlugin(
@@ -431,7 +432,7 @@ The following table lists all 16 auto-created views and their event-specific col
 | **`v_hitl_input_request`** | `tool_name` (STRING), `tool_args` (JSON) |
 | **`v_a2a_interaction`** | `response_content` (JSON), `a2a_task_id` (STRING), `a2a_context_id` (STRING), `a2a_request` (JSON), `a2a_response` (JSON) |
 
-### Event types and payloads {#event-types}
+## Event types and payloads {#event-types}
 
 The `content` column now contains a **JSON** object specific to the `event_type`.
 The `content_parts` column provides a structured view of the content, especially useful for images or offloaded data.
@@ -441,7 +442,7 @@ The `content_parts` column provides a structured view of the content, especially
     - Variable content fields are truncated to `max_content_length` (configured in `BigQueryLoggerConfig`, default 500KB).
     - If `gcs_bucket_name` is configured, large content is offloaded to GCS instead of being truncated, and a reference is stored in `content_parts.object_ref`.
 
-#### LLM interactions (plugin lifecycle)
+### LLM interactions (plugin lifecycle)
 
 These events track the raw requests sent to and responses received from the LLM.
 
@@ -522,7 +523,7 @@ Logged when an LLM call fails with an exception. The error message is captured a
 }
 ```
 
-#### Tool usage (plugin lifecycle)
+### Tool usage (plugin lifecycle)
 
 These events track the execution of tools by the agent. Each tool event includes a `tool_origin` field that classifies the tool's provenance:
 
@@ -595,7 +596,7 @@ Logged when a tool execution fails with an exception. Captures the tool name, ar
 }
 ```
 
-#### State Management
+### State Management
 
 These events track changes to the agent's state, typically triggered by tools.
 
@@ -621,7 +622,7 @@ Tracks changes to the agent's internal state (e.g., custom application state upd
 }
 ```
 
-#### Agent lifecycle & Generic Events
+### Agent lifecycle & Generic Events
 
 <table>
   <thead>
@@ -655,7 +656,7 @@ Tracks changes to the agent's internal state (e.g., custom application state upd
   </tbody>
 </table>
 
-#### Human-in-the-Loop (HITL) Events {#hitl-events}
+### Human-in-the-Loop (HITL) Events {#hitl-events}
 
 The plugin automatically detects calls to ADK's synthetic HITL tools and emits dedicated event types for them. These events are logged **in addition to** the normal `TOOL_STARTING` / `TOOL_COMPLETED` events.
 
@@ -718,7 +719,7 @@ HITL request events are detected from `function_call` parts in `on_event_callbac
     from the `agent_events` table using
     `WHERE event_type LIKE 'HITL_%_COMPLETED'`.
 
-#### A2A Interaction Events
+### A2A Interaction Events
 
 When your agent communicates with a remote agent via the Agent-to-Agent (A2A) protocol, the plugin logs an `A2A_INTERACTION` event capturing the request and response details.
 

--- a/docs/integrations/bigquery-agent-analytics.md
+++ b/docs/integrations/bigquery-agent-analytics.md
@@ -64,7 +64,137 @@ The following table lists all event types the plugin logs. For detailed payload 
 | `HITL_INPUT_REQUEST_COMPLETED` | User provides input response | synthetic tool name, result | *(base table only)* |
 | `A2A_INTERACTION` | Remote A2A call completes | response, task ID, context ID, request/response | `v_a2a_interaction` |
 
-## Prerequisites
+## Quickstart
+
+Add the plugin to your agent's `App` object. For prerequisites, see [Prerequisites](#prerequisites).
+
+```python title="agent.py"
+import os
+from google.adk.agents import Agent
+from google.adk.apps import App
+from google.adk.models.google_llm import Gemini
+from google.adk.plugins.bigquery_agent_analytics_plugin import BigQueryAgentAnalyticsPlugin
+
+os.environ['GOOGLE_CLOUD_PROJECT'] = 'your-gcp-project-id'
+os.environ['GOOGLE_GENAI_USE_VERTEXAI'] = 'True'
+
+plugin = BigQueryAgentAnalyticsPlugin(
+    project_id="your-gcp-project-id",
+    dataset_id="your-big-query-dataset-id",
+)
+
+root_agent = Agent(
+    model=Gemini(model="gemini-flash-latest"),
+    name='my_agent',
+    instruction="You are a helpful assistant.",
+)
+
+app = App(
+    name="my_agent",
+    root_agent=root_agent,
+    plugins=[plugin],
+)
+```
+
+### Run and test agent
+
+Test the plugin by running the agent and making a few requests through the chat
+interface, such as "tell me what you can do" or  "List datasets in my cloud project <your-gcp-project-id> ". These actions create events which are
+recorded in your Google Cloud project BigQuery instance. Once these events have
+been processed, you can view the data for them in the [BigQuery Console](https://console.cloud.google.com/bigquery), using this query
+
+```sql
+SELECT timestamp, event_type, content
+FROM `your-gcp-project-id.your-big-query-dataset-id.agent_events`
+ORDER BY timestamp DESC
+LIMIT 20;
+```
+
+??? example "Full example with GCS offloading, OpenTelemetry, and BigQuery tools"
+
+    ```python title="my_bq_agent/agent.py"
+    # my_bq_agent/agent.py
+    import os
+    import google.auth
+    from google.adk.apps import App
+    from google.adk.plugins.bigquery_agent_analytics_plugin import BigQueryAgentAnalyticsPlugin, BigQueryLoggerConfig
+    from google.adk.agents import Agent
+    from google.adk.models.google_llm import Gemini
+    from google.adk.tools.bigquery import BigQueryToolset, BigQueryCredentialsConfig
+
+
+    # --- OpenTelemetry TracerProvider Setup (Optional) ---
+    # ADK includes OpenTelemetry as a core dependency.
+    # Configuring a TracerProvider enables full distributed tracing
+    # (populates trace_id, span_id with standard OTel identifiers).
+    # If no TracerProvider is configured, the plugin falls back to internal
+    # UUIDs for span correlation while still preserving the parent-child hierarchy.
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    trace.set_tracer_provider(TracerProvider())
+
+    # --- Configuration ---
+    PROJECT_ID = os.environ.get("GOOGLE_CLOUD_PROJECT", "your-gcp-project-id")
+    DATASET_ID = os.environ.get("BIG_QUERY_DATASET_ID", "your-big-query-dataset-id")
+    # GOOGLE_CLOUD_LOCATION must be a valid Agent Platform region (e.g., "us-central1").
+    # BQ_LOCATION is the BigQuery dataset location, which can be a multi-region
+    # like "US" or "EU", or a single region like "us-central1".
+    VERTEX_LOCATION = os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1")
+    BQ_LOCATION = os.environ.get("BQ_LOCATION", "US")
+    GCS_BUCKET = os.environ.get("GCS_BUCKET_NAME", "your-gcs-bucket-name") # Optional
+
+    if PROJECT_ID == "your-gcp-project-id":
+        raise ValueError("Please set GOOGLE_CLOUD_PROJECT or update the code.")
+
+    # --- CRITICAL: Set environment variables BEFORE Gemini instantiation ---
+    os.environ['GOOGLE_CLOUD_PROJECT'] = PROJECT_ID
+    os.environ['GOOGLE_CLOUD_LOCATION'] = VERTEX_LOCATION
+    os.environ['GOOGLE_GENAI_USE_VERTEXAI'] = 'True'
+
+    # --- Initialize the Plugin with Config ---
+    bq_config = BigQueryLoggerConfig(
+        enabled=True,
+        gcs_bucket_name=GCS_BUCKET, # Enable GCS offloading for multimodal content
+        log_multi_modal_content=True,
+        max_content_length=500 * 1024, # 500 KB limit for inline text
+        batch_size=1, # Default is 1 for low latency, increase for high throughput
+        shutdown_timeout=10.0
+    )
+
+    bq_logging_plugin = BigQueryAgentAnalyticsPlugin(
+        project_id=PROJECT_ID,
+        dataset_id=DATASET_ID,
+        table_id="agent_events", # default table name is agent_events
+        config=bq_config,
+        location=BQ_LOCATION
+    )
+
+    # --- Initialize Tools and Model ---
+    credentials, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+    bigquery_toolset = BigQueryToolset(
+        credentials_config=BigQueryCredentialsConfig(credentials=credentials)
+    )
+
+    llm = Gemini(model="gemini-flash-latest")
+
+    root_agent = Agent(
+        model=llm,
+        name='my_bq_agent',
+        instruction="You are a helpful assistant with access to BigQuery tools.",
+        tools=[bigquery_toolset]
+    )
+
+    # --- Create the App ---
+    app = App(
+        name="my_bq_agent",
+        root_agent=root_agent,
+        plugins=[bq_logging_plugin],
+    )
+    ```
+
+> Deploying to Agent Runtime? See [Deploy to Agent Runtime](#deploy-agent-runtime).
+
+## Prerequisites {#prerequisites}
 
 -   **Google Cloud Project** with the **BigQuery API** enabled.
 -   **BigQuery Dataset:** Create a dataset to store logging tables before
@@ -91,371 +221,7 @@ For the agent to work properly, the principal (e.g., service account, user accou
 * `roles/bigquery.dataEditor` at Table Level to write log/event data.
 * **If using GCS offloading:** `roles/storage.objectCreator` and `roles/storage.objectViewer` on the target bucket.
 
-## Use with agent
-
-You use the BigQuery Agent Analytics Plugin by configuring and registering it with
-your ADK agent's App object. The following example shows an implementation of an
-agent with this plugin, including GCS offloading:
-
-```python title="my_bq_agent/agent.py"
-# my_bq_agent/agent.py
-import os
-import google.auth
-from google.adk.apps import App
-from google.adk.plugins.bigquery_agent_analytics_plugin import BigQueryAgentAnalyticsPlugin, BigQueryLoggerConfig
-from google.adk.agents import Agent
-from google.adk.models.google_llm import Gemini
-from google.adk.tools.bigquery import BigQueryToolset, BigQueryCredentialsConfig
-
-
-# --- OpenTelemetry TracerProvider Setup (Optional) ---
-# ADK includes OpenTelemetry as a core dependency.
-# Configuring a TracerProvider enables full distributed tracing
-# (populates trace_id, span_id with standard OTel identifiers).
-# If no TracerProvider is configured, the plugin falls back to internal
-# UUIDs for span correlation while still preserving the parent-child hierarchy.
-from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
-trace.set_tracer_provider(TracerProvider())
-
-# --- Configuration ---
-PROJECT_ID = os.environ.get("GOOGLE_CLOUD_PROJECT", "your-gcp-project-id")
-DATASET_ID = os.environ.get("BIG_QUERY_DATASET_ID", "your-big-query-dataset-id")
-# GOOGLE_CLOUD_LOCATION must be a valid Agent Platform region (e.g., "us-central1").
-# BQ_LOCATION is the BigQuery dataset location, which can be a multi-region
-# like "US" or "EU", or a single region like "us-central1".
-VERTEX_LOCATION = os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1")
-BQ_LOCATION = os.environ.get("BQ_LOCATION", "US")
-GCS_BUCKET = os.environ.get("GCS_BUCKET_NAME", "your-gcs-bucket-name") # Optional
-
-if PROJECT_ID == "your-gcp-project-id":
-    raise ValueError("Please set GOOGLE_CLOUD_PROJECT or update the code.")
-
-# --- CRITICAL: Set environment variables BEFORE Gemini instantiation ---
-os.environ['GOOGLE_CLOUD_PROJECT'] = PROJECT_ID
-os.environ['GOOGLE_CLOUD_LOCATION'] = VERTEX_LOCATION
-os.environ['GOOGLE_GENAI_USE_VERTEXAI'] = 'True'
-
-# --- Initialize the Plugin with Config ---
-bq_config = BigQueryLoggerConfig(
-    enabled=True,
-    gcs_bucket_name=GCS_BUCKET, # Enable GCS offloading for multimodal content
-    log_multi_modal_content=True,
-    max_content_length=500 * 1024, # 500 KB limit for inline text
-    batch_size=1, # Default is 1 for low latency, increase for high throughput
-    shutdown_timeout=10.0
-)
-
-bq_logging_plugin = BigQueryAgentAnalyticsPlugin(
-    project_id=PROJECT_ID,
-    dataset_id=DATASET_ID,
-    table_id="agent_events", # default table name is agent_events
-    config=bq_config,
-    location=BQ_LOCATION
-)
-
-# --- Initialize Tools and Model ---
-credentials, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
-bigquery_toolset = BigQueryToolset(
-    credentials_config=BigQueryCredentialsConfig(credentials=credentials)
-)
-
-llm = Gemini(model="gemini-flash-latest")
-
-root_agent = Agent(
-    model=llm,
-    name='my_bq_agent',
-    instruction="You are a helpful assistant with access to BigQuery tools.",
-    tools=[bigquery_toolset]
-)
-
-# --- Create the App ---
-app = App(
-    name="my_bq_agent",
-    root_agent=root_agent,
-    plugins=[bq_logging_plugin],
-)
-```
-
-### Run and test agent
-
-Test the plugin by running the agent and making a few requests through the chat
-interface, such as "tell me what you can do" or  "List datasets in my cloud project <your-gcp-project-id> ". These actions create events which are
-recorded in your Google Cloud project BigQuery instance. Once these events have
-been processed, you can view the data for them in the [BigQuery Console](https://console.cloud.google.com/bigquery), using this query
-
-```sql
-SELECT timestamp, event_type, content
-FROM `your-gcp-project-id.your-big-query-dataset-id.agent_events`
-ORDER BY timestamp DESC
-LIMIT 20;
-```
-
-## Deploy to Agent Runtime with the plugin {#deploy-agent-runtime}
-
-You can deploy an agent with the BigQuery Agent Analytics plugin to
-[Agent Runtime](https://cloud.google.com/vertex-ai/generative-ai/docs/agent-engine/overview).
-This section walks through the steps to deploy using the ADK CLI, and
-alternatively using the Agent Platform SDK programmatically.
-
-!!! important "Version Requirement"
-
-    Use ADK Python version **1.24.0 or higher** to deploy with this plugin to
-    Agent Runtime. Earlier versions had an issue where the plugin's asynchronous
-    log writer could be terminated by the serverless runtime before flushing
-    pending events. Starting from 1.24.0, the plugin performs a synchronous
-    flush at the end of each invocation to ensure all events are written.
-
-### Prerequisites
-
-Before deploying, ensure you have completed the general
-[Agent Runtime setup](/deploy/agent-runtime/deploy/#setup-cloud-project),
-including:
-
-1.  A Google Cloud project with the **Agent Platform API** and **Cloud Resource
-    Manager API** enabled.
-2.  A **BigQuery dataset** in the target project (or a cross-project dataset
-    with the correct permissions).
-3.  A **Cloud Storage staging bucket** for deployment artifacts.
-4.  The deploying service account has the IAM roles listed in
-    [IAM permissions](#iam-permissions).
-5.  Your coding environment is
-    [authenticated](/deploy/agent-runtime/deploy/#prerequisites-coding-env)
-    with `gcloud auth login` and `gcloud auth application-default login`.
-
-### Step 1: Define the agent and plugin
-
-Create your agent project folder with an `App` object that includes the plugin.
-The `App` object is required for Agent Runtime deployments with plugins.
-
-```
-my_bq_agent/
-├── __init__.py
-├── agent.py
-└── requirements.txt
-```
-
-```python title="my_bq_agent/__init__.py"
-from . import agent
-```
-
-```python title="my_bq_agent/agent.py"
-import os
-import google.auth
-from google.adk.agents import Agent
-from google.adk.apps import App
-from google.adk.models.google_llm import Gemini
-from google.adk.plugins.bigquery_agent_analytics_plugin import (
-    BigQueryAgentAnalyticsPlugin,
-    BigQueryLoggerConfig,
-)
-from google.adk.tools.bigquery import BigQueryToolset, BigQueryCredentialsConfig
-
-# --- Configuration ---
-PROJECT_ID = os.environ.get("GOOGLE_CLOUD_PROJECT", "your-gcp-project-id")
-DATASET_ID = os.environ.get("BQ_DATASET", "agent_analytics")
-# BQ_LOCATION is the BigQuery dataset location (multi-region "US"/"EU" or
-# a single region like "us-central1"). This is separate from the Agent Platform
-# region used by GOOGLE_CLOUD_LOCATION.
-BQ_LOCATION = os.environ.get("BQ_LOCATION", "US")
-
-os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "True"
-
-# --- Plugin ---
-bq_analytics_plugin = BigQueryAgentAnalyticsPlugin(
-    project_id=PROJECT_ID,
-    dataset_id=DATASET_ID,
-    location=BQ_LOCATION,
-    config=BigQueryLoggerConfig(
-        batch_size=1,
-        batch_flush_interval=0.5,
-        log_session_metadata=True,
-    ),
-)
-
-# --- Tools ---
-credentials, _ = google.auth.default(
-    scopes=["https://www.googleapis.com/auth/cloud-platform"]
-)
-bigquery_toolset = BigQueryToolset(
-    credentials_config=BigQueryCredentialsConfig(credentials=credentials)
-)
-
-# --- Agent ---
-root_agent = Agent(
-    model=Gemini(model="gemini-flash-latest"),
-    name="my_bq_agent",
-    instruction="You are a helpful assistant with access to BigQuery tools.",
-    tools=[bigquery_toolset],
-)
-
-# --- App (required for Agent Runtime with plugins) ---
-app = App(
-    name="my_bq_agent",
-    root_agent=root_agent,
-    plugins=[bq_analytics_plugin],
-)
-```
-
-```text title="my_bq_agent/requirements.txt"
-google-adk[bigquery]
-google-cloud-bigquery-storage
-pyarrow
-opentelemetry-api
-opentelemetry-sdk
-```
-
-### Step 2: Deploy using ADK CLI
-
-Use the `adk deploy agent_engine` command to deploy the agent. The `--adk_app`
-flag tells the CLI which `App` object to use:
-
-```shell
-PROJECT_ID=your-gcp-project-id
-LOCATION=us-central1
-
-adk deploy agent_engine \
-    --project=$PROJECT_ID \
-    --region=$LOCATION \
-    --staging_bucket=gs://your-staging-bucket \
-    --display_name="My BQ Analytics Agent" \
-    --adk_app=agent.app \
-    my_bq_agent
-```
-
-!!! tip "`--adk_app` flag"
-
-    The `--adk_app` flag specifies the module path and variable name of the
-    `App` object (in the format `module.variable`). In this example,
-    `agent.app` refers to the `app` variable in `agent.py`. This ensures the
-    deployment correctly picks up the plugin configuration.
-
-Once successfully deployed, you should see output like:
-
-```shell
-AgentEngine created. Resource name: projects/123456789/locations/us-central1/reasoningEngines/751619551677906944
-```
-
-Note the **Resource name** for the next step.
-
-### Step 3: Test the deployed agent
-
-After deployment, you can query the agent using the Agent Platform SDK:
-
-```python title="test_deployed_agent.py"
-import uuid
-import vertexai
-
-PROJECT_ID = "your-gcp-project-id"
-LOCATION = "us-central1"
-AGENT_ID = "751619551677906944"  # from deployment output
-
-vertexai.init(project=PROJECT_ID, location=LOCATION)
-client = vertexai.Client(project=PROJECT_ID, location=LOCATION)
-
-agent = client.agent_engines.get(
-    name=f"projects/{PROJECT_ID}/locations/{LOCATION}/reasoningEngines/{AGENT_ID}"
-)
-
-user_id = f"test_user_{uuid.uuid4().hex[:8]}"
-for chunk in agent.stream_query(
-    message="List datasets in my project", user_id=user_id
-):
-    print(chunk, end="", flush=True)
-```
-
-### Step 4: Verify events in BigQuery
-
-After sending a few queries to the deployed agent, verify that events are being
-logged by querying your BigQuery table:
-
-```sql
-SELECT timestamp, event_type, agent, content
-FROM `your-gcp-project-id.agent_analytics.agent_events`
-ORDER BY timestamp DESC
-LIMIT 20;
-```
-
-You should see events such as `INVOCATION_STARTING`, `LLM_REQUEST`,
-`LLM_RESPONSE`, `TOOL_STARTING`, `TOOL_COMPLETED`, and `INVOCATION_COMPLETED`.
-
-### Alternative: Deploy using the Agent Platform SDK
-
-You can also deploy programmatically using the Agent Platform SDK directly. This is
-useful for CI/CD pipelines or custom deployment workflows:
-
-```python title="deploy.py"
-import vertexai
-from vertexai import agent_engines
-from my_bq_agent.agent import app
-
-PROJECT_ID = "your-gcp-project-id"
-LOCATION = "us-central1"
-STAGING_BUCKET = "gs://your-staging-bucket"
-
-vertexai.init(
-    project=PROJECT_ID, location=LOCATION, staging_bucket=STAGING_BUCKET
-)
-client = vertexai.Client(project=PROJECT_ID, location=LOCATION)
-
-remote_app = client.agent_engines.create(
-    agent=app,
-    config={
-        "display_name": "My BQ Analytics Agent",
-        "staging_bucket": STAGING_BUCKET,
-        "requirements": [
-            "google-adk[bigquery]",
-            "google-cloud-aiplatform[agent_engines]",
-            "google-cloud-bigquery-storage",
-            "pyarrow",
-            "opentelemetry-api",
-            "opentelemetry-sdk",
-        ],
-    },
-)
-print(f"Deployed agent: {remote_app.api_resource.name}")
-```
-
-### Troubleshooting
-
-If events are not appearing in your BigQuery table after deployment:
-
-1.  **Check ADK version**: Ensure `google-adk>=1.24.0` is in your requirements.
-    Earlier versions do not flush pending events before the serverless runtime
-    suspends the process.
-
-2.  **Enable debug logging**: Add the following to the top of your `agent.py` to
-    surface any silent errors:
-
-    ```python
-    import logging
-    logging.basicConfig(level=logging.INFO)
-    logging.getLogger("google_adk").setLevel(logging.DEBUG)
-    ```
-
-3.  **Check IAM permissions**: The Agent Runtime service account needs
-    `roles/bigquery.dataEditor` on the target table and `roles/bigquery.jobUser`
-    on the project. For **cross-project** logging, also ensure the BigQuery API
-    is enabled in the source project and the service account has
-    `bigquery.tables.updateData` on the destination table.
-
-4.  **Verify plugin initialization**: In Cloud Logging, filter by
-    `resource.type="reasoning_engine"` and look for plugin startup messages or
-    error logs.
-
-5.  **Use immediate flush for debugging**: Set `batch_size=1` and
-    `batch_flush_interval=0.1` in `BigQueryLoggerConfig` to rule out buffering
-    issues.
-
-## Tracing and Observability
-
-The plugin supports **OpenTelemetry** for distributed tracing. OpenTelemetry is included as a core dependency of ADK and is always available.
-
-- **Automatic Span Management**: The plugin automatically generates spans for Agent execution, LLM calls, and Tool executions.
-- **OpenTelemetry Integration**: If a `TracerProvider` is configured (as shown in the example above), the plugin will use valid OTel spans, populating `trace_id`, `span_id`, and `parent_span_id` with standard OTel identifiers. This allows you to correlate agent logs with other services in your distributed system.
-- **Fallback Mechanism**: If no `TracerProvider` is configured (i.e., only the default no-op provider is active), the plugin automatically falls back to generating internal UUIDs for spans and uses the `invocation_id` as the trace ID. This ensures that the parent-child hierarchy (Agent -> Span -> Tool/LLM) is *always* preserved in the BigQuery logs, even without a configured `TracerProvider`.
-
-## Configuration options
+## Configuration options {#configuration-options}
 
 ### Constructor parameters
 
@@ -550,24 +316,6 @@ config = BigQueryLoggerConfig(
 
 plugin = BigQueryAgentAnalyticsPlugin(..., config=config)
 ```
-
-### Public methods
-
-The plugin exposes several public methods for lifecycle management:
-
--   **`await plugin.flush()`**: Flush all pending events to BigQuery. Call this before shutdown to avoid data loss.
--   **`await plugin.shutdown(timeout=None)`**: Gracefully shut down the plugin, flushing pending events and releasing resources. The optional `timeout` parameter overrides `shutdown_timeout` from the config.
--   **`await plugin.create_analytics_views()`**: Manually (re-)create all per-event-type analytics views. Useful after a schema upgrade or when views need to be refreshed.
--   **Async context manager**: The plugin supports `async with` for automatic startup and shutdown:
-
-    ```python
-    async with BigQueryAgentAnalyticsPlugin(
-        project_id=PROJECT_ID, dataset_id=DATASET_ID
-    ) as plugin:
-        # plugin is initialized and ready to use
-        ...
-    # plugin.shutdown() is called automatically on exit
-    ```
 
 ## Schema and production setup
 
@@ -991,11 +739,11 @@ Logged when an A2A remote agent call completes.
 }
 ```
 
-#### GCS Offloading Examples (Multimodal & Large Text)
+## Storage behavior: GCS offloading
 
-When `gcs_bucket_name` is configured, large text and multimodal content (images, audio, etc.) are automatically offloaded to GCS. The `content` column will contain a summary or placeholder, while `content_parts` contains the `object_ref` pointing to the GCS URI.
+When `gcs_bucket_name` is configured in `BigQueryLoggerConfig`, the plugin automatically offloads large text and multimodal content (images, audio, etc.) to Google Cloud Storage. The `content` column will contain a summary or placeholder, while `content_parts` stores the `object_ref` pointing to the GCS URI. See also `connection_id` and `max_content_length` in [Configuration options](#configuration-options).
 
-**Offloaded Text Example**
+### Offloaded Text Example
 
 ```json
 {
@@ -1016,7 +764,7 @@ When `gcs_bucket_name` is configured, large text and multimodal content (images,
 }
 ```
 
-**Offloaded Image Example**
+### Offloaded Image Example
 
 ```json
 {
@@ -1037,7 +785,7 @@ When `gcs_bucket_name` is configured, large text and multimodal content (images,
 }
 ```
 
-**Querying Offloaded Content (Get Signed URLs)**
+### Querying Offloaded Content (Get Signed URLs)
 
 ```sql
 SELECT
@@ -1055,9 +803,11 @@ ORDER BY timestamp DESC
 LIMIT 10;
 ```
 
-## Advanced analysis queries
+## Query recipes
 
-### Trace a specific conversation turn using trace_id
+### Debug a run
+
+#### Trace a specific conversation turn using trace_id
 
 ```sql
 SELECT timestamp, event_type, agent, JSON_VALUE(content, '$.response') as summary
@@ -1066,7 +816,48 @@ WHERE trace_id = 'your-trace-id'
 ORDER BY timestamp ASC;
 ```
 
-### Token usage analysis
+#### Span Hierarchy & Duration Analysis
+
+```sql
+SELECT
+  span_id,
+  parent_span_id,
+  event_type,
+  timestamp,
+  -- Extract duration from latency_ms for completed operations
+  CAST(JSON_VALUE(latency_ms, '$.total_ms') AS INT64) as duration_ms,
+  -- Identify the specific tool or operation
+  COALESCE(
+    JSON_VALUE(content, '$.tool'),
+    'LLM_CALL'
+  ) as operation
+FROM `your-gcp-project-id.your-dataset-id.agent_events`
+WHERE trace_id = 'your-trace-id'
+  AND event_type IN ('LLM_RESPONSE', 'TOOL_COMPLETED')
+ORDER BY timestamp ASC;
+```
+
+#### Error Analysis (LLM & Tool Errors)
+
+Using views (recommended):
+
+```sql
+-- Tool errors with provenance
+SELECT timestamp, agent, tool_name, tool_origin, error_message, total_ms
+FROM `your-gcp-project-id.your-dataset-id.v_tool_error`
+ORDER BY timestamp DESC
+LIMIT 20;
+
+-- LLM errors
+SELECT timestamp, agent, error_message, total_ms
+FROM `your-gcp-project-id.your-dataset-id.v_llm_error`
+ORDER BY timestamp DESC
+LIMIT 20;
+```
+
+### Monitor cost and performance
+
+#### Token usage analysis
 
 Using the `v_llm_response` view (recommended):
 
@@ -1087,40 +878,7 @@ FROM `your-gcp-project-id.your-dataset-id.agent_events`
 WHERE event_type = 'LLM_RESPONSE';
 ```
 
-### Querying Multimodal Content (using content_parts and ObjectRef)
-
-```sql
-SELECT
-  timestamp,
-  part.mime_type,
-  part.object_ref.uri as gcs_uri
-FROM `your-gcp-project-id.your-dataset-id.agent_events`,
-UNNEST(content_parts) as part
-WHERE part.mime_type LIKE 'image/%'
-ORDER BY timestamp DESC;
-```
-
-### Analyze Multimodal Content with BigQuery Remote Model (Gemini)
-
-```sql
-SELECT
-  logs.session_id,
-  -- Get a signed URL for the image
-  STRING(OBJ.GET_ACCESS_URL(parts.object_ref, "r").access_urls.read_url) as signed_url,
-  -- Analyze the image using a remote model (e.g., gemini-pro-vision)
-  AI.GENERATE(
-    ('Describe this image briefly. What company logo?', parts.object_ref)
-  ) AS generated_result
-FROM
-  `your-gcp-project-id.your-dataset-id.agent_events` logs,
-  UNNEST(logs.content_parts) AS parts
-WHERE
-  parts.mime_type LIKE 'image/%'
-ORDER BY logs.timestamp DESC
-LIMIT 1;
-```
-
-### Latency Analysis (LLM & Tools)
+#### Latency Analysis (LLM & Tools)
 
 Using views (recommended):
 
@@ -1147,46 +905,9 @@ WHERE event_type IN ('LLM_RESPONSE', 'TOOL_COMPLETED')
 GROUP BY event_type;
 ```
 
-### Span Hierarchy & Duration Analysis
+### Inspect tools and interactions
 
-```sql
-SELECT
-  span_id,
-  parent_span_id,
-  event_type,
-  timestamp,
-  -- Extract duration from latency_ms for completed operations
-  CAST(JSON_VALUE(latency_ms, '$.total_ms') AS INT64) as duration_ms,
-  -- Identify the specific tool or operation
-  COALESCE(
-    JSON_VALUE(content, '$.tool'),
-    'LLM_CALL'
-  ) as operation
-FROM `your-gcp-project-id.your-dataset-id.agent_events`
-WHERE trace_id = 'your-trace-id'
-  AND event_type IN ('LLM_RESPONSE', 'TOOL_COMPLETED')
-ORDER BY timestamp ASC;
-```
-
-### Error Analysis (LLM & Tool Errors)
-
-Using views (recommended):
-
-```sql
--- Tool errors with provenance
-SELECT timestamp, agent, tool_name, tool_origin, error_message, total_ms
-FROM `your-gcp-project-id.your-dataset-id.v_tool_error`
-ORDER BY timestamp DESC
-LIMIT 20;
-
--- LLM errors
-SELECT timestamp, agent, error_message, total_ms
-FROM `your-gcp-project-id.your-dataset-id.v_llm_error`
-ORDER BY timestamp DESC
-LIMIT 20;
-```
-
-### Tool Provenance Analysis
+#### Tool Provenance Analysis
 
 Using the `v_tool_completed` view (recommended):
 
@@ -1201,7 +922,7 @@ GROUP BY tool_origin, tool_name
 ORDER BY call_count DESC;
 ```
 
-### HITL Interaction Analysis
+#### HITL Interaction Analysis
 
 ```sql
 SELECT
@@ -1216,8 +937,42 @@ ORDER BY timestamp DESC
 LIMIT 20;
 ```
 
+### Analyze multimodal content
 
-### AI-Powered Root Cause Analysis (Agent Ops)
+#### Querying Multimodal Content (using content_parts and ObjectRef)
+
+```sql
+SELECT
+  timestamp,
+  part.mime_type,
+  part.object_ref.uri as gcs_uri
+FROM `your-gcp-project-id.your-dataset-id.agent_events`,
+UNNEST(content_parts) as part
+WHERE part.mime_type LIKE 'image/%'
+ORDER BY timestamp DESC;
+```
+
+#### Analyze Multimodal Content with BigQuery Remote Model (Gemini)
+
+```sql
+SELECT
+  logs.session_id,
+  -- Get a signed URL for the image
+  STRING(OBJ.GET_ACCESS_URL(parts.object_ref, "r").access_urls.read_url) as signed_url,
+  -- Analyze the image using a remote model (e.g., gemini-pro-vision)
+  AI.GENERATE(
+    ('Describe this image briefly. What company logo?', parts.object_ref)
+  ) AS generated_result
+FROM
+  `your-gcp-project-id.your-dataset-id.agent_events` logs,
+  UNNEST(logs.content_parts) AS parts
+WHERE
+  parts.mime_type LIKE 'image/%'
+ORDER BY logs.timestamp DESC
+LIMIT 1;
+```
+
+### AI-powered root cause analysis
 
 Automatically analyze failed sessions to determine the root cause of errors using BigQuery ML and Gemini.
 
@@ -1260,13 +1015,261 @@ You can also use [BigQuery Conversational Analytics](https://cloud.google.com/bi
 *   "What are the most common tool calls?"
 *   "Identify sessions with high token usage"
 
-## Consuming logged data with BigQuery Agent Analytics SDK
+## Deploy to Agent Runtime with the plugin {#deploy-agent-runtime}
 
-The [BigQuery Agent Analytics SDK](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main) provides a convenient way to consume and analyze the data logged by the BigQuery Agent Analytics plugin. The SDK offers pre-built utilities for querying, aggregating, and visualizing your agent's operational data directly from BigQuery.
+You can deploy an agent with the BigQuery Agent Analytics plugin to
+[Agent Runtime](https://cloud.google.com/vertex-ai/generative-ai/docs/agent-engine/overview).
+This section walks through the steps to deploy using the ADK CLI, and
+alternatively using the Agent Platform SDK programmatically.
 
-### Dashboard
+!!! important "Version Requirement"
 
-The BigQuery Agent Analytics SDK includes an [example Jupyter notebook](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/examples/dashboard_v2.ipynb) that demonstrates how to query and visualize your agent's performance data. Use it as a starting point to build your own custom dashboards tailored to your BigQuery Agent Analytics dataset.
+    Use ADK Python version **1.24.0 or higher** to deploy with this plugin to
+    Agent Runtime. Earlier versions had an issue where the plugin's asynchronous
+    log writer could be terminated by the serverless runtime before flushing
+    pending events. Starting from 1.24.0, the plugin performs a synchronous
+    flush at the end of each invocation to ensure all events are written.
+
+### Prerequisites
+
+Before deploying, ensure you have completed the general
+[Agent Runtime setup](/deploy/agent-runtime/deploy/#setup-cloud-project),
+including:
+
+1.  A Google Cloud project with the **Agent Platform API** and **Cloud Resource
+    Manager API** enabled.
+2.  A **BigQuery dataset** in the target project (or a cross-project dataset
+    with the correct permissions).
+3.  A **Cloud Storage staging bucket** for deployment artifacts.
+4.  The deploying service account has the IAM roles listed in
+    [IAM permissions](#iam-permissions).
+5.  Your coding environment is
+    [authenticated](/deploy/agent-runtime/deploy/#prerequisites-coding-env)
+    with `gcloud auth login` and `gcloud auth application-default login`.
+
+### Step 1: Define the agent and plugin
+
+Create your agent project folder with an `App` object that includes the plugin.
+The `App` object is required for Agent Runtime deployments with plugins.
+
+```
+my_bq_agent/
+├── __init__.py
+├── agent.py
+└── requirements.txt
+```
+
+```python title="my_bq_agent/__init__.py"
+from . import agent
+```
+
+```python title="my_bq_agent/agent.py"
+import os
+import google.auth
+from google.adk.agents import Agent
+from google.adk.apps import App
+from google.adk.models.google_llm import Gemini
+from google.adk.plugins.bigquery_agent_analytics_plugin import (
+    BigQueryAgentAnalyticsPlugin,
+    BigQueryLoggerConfig,
+)
+from google.adk.tools.bigquery import BigQueryToolset, BigQueryCredentialsConfig
+
+# --- Configuration ---
+PROJECT_ID = os.environ.get("GOOGLE_CLOUD_PROJECT", "your-gcp-project-id")
+DATASET_ID = os.environ.get("BQ_DATASET", "agent_analytics")
+# BQ_LOCATION is the BigQuery dataset location (multi-region "US"/"EU" or
+# a single region like "us-central1"). This is separate from the Agent Platform
+# region used by GOOGLE_CLOUD_LOCATION.
+BQ_LOCATION = os.environ.get("BQ_LOCATION", "US")
+
+os.environ["GOOGLE_GENAI_USE_VERTEXAI"] = "True"
+
+# --- Plugin ---
+bq_analytics_plugin = BigQueryAgentAnalyticsPlugin(
+    project_id=PROJECT_ID,
+    dataset_id=DATASET_ID,
+    location=BQ_LOCATION,
+    config=BigQueryLoggerConfig(
+        batch_size=1,
+        batch_flush_interval=0.5,
+        log_session_metadata=True,
+    ),
+)
+
+# --- Tools ---
+credentials, _ = google.auth.default(
+    scopes=["https://www.googleapis.com/auth/cloud-platform"]
+)
+bigquery_toolset = BigQueryToolset(
+    credentials_config=BigQueryCredentialsConfig(credentials=credentials)
+)
+
+# --- Agent ---
+root_agent = Agent(
+    model=Gemini(model="gemini-flash-latest"),
+    name="my_bq_agent",
+    instruction="You are a helpful assistant with access to BigQuery tools.",
+    tools=[bigquery_toolset],
+)
+
+# --- App (required for Agent Runtime with plugins) ---
+app = App(
+    name="my_bq_agent",
+    root_agent=root_agent,
+    plugins=[bq_analytics_plugin],
+)
+```
+
+```text title="my_bq_agent/requirements.txt"
+google-adk[bigquery]
+google-cloud-bigquery-storage
+pyarrow
+opentelemetry-api
+opentelemetry-sdk
+```
+
+### Step 2: Deploy using ADK CLI
+
+Use the `adk deploy agent_engine` command to deploy the agent. The `--adk_app`
+flag tells the CLI which `App` object to use:
+
+```shell
+PROJECT_ID=your-gcp-project-id
+LOCATION=us-central1
+
+adk deploy agent_engine \
+    --project=$PROJECT_ID \
+    --region=$LOCATION \
+    --staging_bucket=gs://your-staging-bucket \
+    --display_name="My BQ Analytics Agent" \
+    --adk_app=agent.app \
+    my_bq_agent
+```
+
+!!! tip "`--adk_app` flag"
+
+    The `--adk_app` flag specifies the module path and variable name of the
+    `App` object (in the format `module.variable`). In this example,
+    `agent.app` refers to the `app` variable in `agent.py`. This ensures the
+    deployment correctly picks up the plugin configuration.
+
+Once successfully deployed, you should see output like:
+
+```shell
+AgentEngine created. Resource name: projects/123456789/locations/us-central1/reasoningEngines/751619551677906944
+```
+
+Note the **Resource name** for the next step.
+
+### Step 3: Test the deployed agent
+
+After deployment, you can query the agent using the Agent Platform SDK:
+
+```python title="test_deployed_agent.py"
+import uuid
+import vertexai
+
+PROJECT_ID = "your-gcp-project-id"
+LOCATION = "us-central1"
+AGENT_ID = "751619551677906944"  # from deployment output
+
+vertexai.init(project=PROJECT_ID, location=LOCATION)
+client = vertexai.Client(project=PROJECT_ID, location=LOCATION)
+
+agent = client.agent_engines.get(
+    name=f"projects/{PROJECT_ID}/locations/{LOCATION}/reasoningEngines/{AGENT_ID}"
+)
+
+user_id = f"test_user_{uuid.uuid4().hex[:8]}"
+for chunk in agent.stream_query(
+    message="List datasets in my project", user_id=user_id
+):
+    print(chunk, end="", flush=True)
+```
+
+### Step 4: Verify events in BigQuery
+
+After sending a few queries to the deployed agent, verify that events are being
+logged by querying your BigQuery table:
+
+```sql
+SELECT timestamp, event_type, agent, content
+FROM `your-gcp-project-id.agent_analytics.agent_events`
+ORDER BY timestamp DESC
+LIMIT 20;
+```
+
+You should see events such as `INVOCATION_STARTING`, `LLM_REQUEST`,
+`LLM_RESPONSE`, `TOOL_STARTING`, `TOOL_COMPLETED`, and `INVOCATION_COMPLETED`.
+
+### Alternative: Deploy using the Agent Platform SDK
+
+You can also deploy programmatically using the Agent Platform SDK directly. This is
+useful for CI/CD pipelines or custom deployment workflows:
+
+```python title="deploy.py"
+import vertexai
+from vertexai import agent_engines
+from my_bq_agent.agent import app
+
+PROJECT_ID = "your-gcp-project-id"
+LOCATION = "us-central1"
+STAGING_BUCKET = "gs://your-staging-bucket"
+
+vertexai.init(
+    project=PROJECT_ID, location=LOCATION, staging_bucket=STAGING_BUCKET
+)
+client = vertexai.Client(project=PROJECT_ID, location=LOCATION)
+
+remote_app = client.agent_engines.create(
+    agent=app,
+    config={
+        "display_name": "My BQ Analytics Agent",
+        "staging_bucket": STAGING_BUCKET,
+        "requirements": [
+            "google-adk[bigquery]",
+            "google-cloud-aiplatform[agent_engines]",
+            "google-cloud-bigquery-storage",
+            "pyarrow",
+            "opentelemetry-api",
+            "opentelemetry-sdk",
+        ],
+    },
+)
+print(f"Deployed agent: {remote_app.api_resource.name}")
+```
+
+### Troubleshooting
+
+If events are not appearing in your BigQuery table after deployment:
+
+1.  **Check ADK version**: Ensure `google-adk>=1.24.0` is in your requirements.
+    Earlier versions do not flush pending events before the serverless runtime
+    suspends the process.
+
+2.  **Enable debug logging**: Add the following to the top of your `agent.py` to
+    surface any silent errors:
+
+    ```python
+    import logging
+    logging.basicConfig(level=logging.INFO)
+    logging.getLogger("google_adk").setLevel(logging.DEBUG)
+    ```
+
+3.  **Check IAM permissions**: The Agent Runtime service account needs
+    `roles/bigquery.dataEditor` on the target table and `roles/bigquery.jobUser`
+    on the project. For **cross-project** logging, also ensure the BigQuery API
+    is enabled in the source project and the service account has
+    `bigquery.tables.updateData` on the destination table.
+
+4.  **Verify plugin initialization**: In Cloud Logging, filter by
+    `resource.type="reasoning_engine"` and look for plugin startup messages or
+    error logs.
+
+5.  **Use immediate flush for debugging**: Set `batch_size=1` and
+    `batch_flush_interval=0.1` in `BigQueryLoggerConfig` to rule out buffering
+    issues.
 
 ## Security: Avoid logging sensitive credentials {#security-credentials}
 
@@ -1368,7 +1371,35 @@ config = BigQueryLoggerConfig(
 -   **Audit your logs** periodically to verify no unexpected sensitive data is
     being captured.
 
-## Multiprocessing and fork safety
+## Operations
+
+### Tracing and observability
+
+The plugin supports **OpenTelemetry** for distributed tracing. OpenTelemetry is included as a core dependency of ADK and is always available.
+
+- **Automatic Span Management**: The plugin automatically generates spans for Agent execution, LLM calls, and Tool executions.
+- **OpenTelemetry Integration**: If a `TracerProvider` is configured (as shown in the example above), the plugin will use valid OTel spans, populating `trace_id`, `span_id`, and `parent_span_id` with standard OTel identifiers. This allows you to correlate agent logs with other services in your distributed system.
+- **Fallback Mechanism**: If no `TracerProvider` is configured (i.e., only the default no-op provider is active), the plugin automatically falls back to generating internal UUIDs for spans and uses the `invocation_id` as the trace ID. This ensures that the parent-child hierarchy (Agent -> Span -> Tool/LLM) is *always* preserved in the BigQuery logs, even without a configured `TracerProvider`.
+
+### Public methods
+
+The plugin exposes several public methods for lifecycle management:
+
+-   **`await plugin.flush()`**: Flush all pending events to BigQuery. Call this before shutdown to avoid data loss.
+-   **`await plugin.shutdown(timeout=None)`**: Gracefully shut down the plugin, flushing pending events and releasing resources. The optional `timeout` parameter overrides `shutdown_timeout` from the config.
+-   **`await plugin.create_analytics_views()`**: Manually (re-)create all per-event-type analytics views. Useful after a schema upgrade or when views need to be refreshed.
+-   **Async context manager**: The plugin supports `async with` for automatic startup and shutdown:
+
+    ```python
+    async with BigQueryAgentAnalyticsPlugin(
+        project_id=PROJECT_ID, dataset_id=DATASET_ID
+    ) as plugin:
+        # plugin is initialized and ready to use
+        ...
+    # plugin.shutdown() is called automatically on exit
+    ```
+
+### Multiprocessing and fork safety
 
 The plugin is fork-aware: it sets `GRPC_ENABLE_FORK_SUPPORT=1` before loading the gRPC C-core library and registers an `os.register_at_fork` handler that resets inherited runtime state (gRPC channels, write streams, event loops) in child processes. This means the plugin can survive `os.fork()` without leaking file descriptors or sending data on a parent's connection.
 
@@ -1382,6 +1413,14 @@ For Gunicorn deployments specifically:
 !!! note
 
     The fork-safety mechanism resets runtime state only. It does **not** replay events that were queued but not yet flushed in the parent process at the time of fork. Call `await plugin.flush()` before forking if you need to guarantee delivery.
+
+## Consuming logged data with BigQuery Agent Analytics SDK
+
+The [BigQuery Agent Analytics SDK](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main) provides a convenient way to consume and analyze the data logged by the BigQuery Agent Analytics plugin. The SDK offers pre-built utilities for querying, aggregating, and visualizing your agent's operational data directly from BigQuery.
+
+### Dashboard
+
+The BigQuery Agent Analytics SDK includes an [example Jupyter notebook](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/examples/dashboard_v2.ipynb) that demonstrates how to query and visualize your agent's performance data. Use it as a starting point to build your own custom dashboards tailored to your BigQuery Agent Analytics dataset.
 
 ## Feedback
 We welcome your feedback on BigQuery Agent Analytics. If you have questions, suggestions, or encounter any issues, please reach out to the team at bqaa-feedback@google.com.

--- a/docs/integrations/bigquery-agent-analytics.md
+++ b/docs/integrations/bigquery-agent-analytics.md
@@ -40,7 +40,7 @@ Version 1.26.0 adds **Auto Schema Upgrade** (safely add new columns to existing 
 
 ### Captured events summary
 
-The following table lists every event the plugin logs. For detailed payload examples, see [Event types and payloads](#event-types).
+The following table lists all event types the plugin logs. For detailed payload examples, see [Event types and payloads](#event-types).
 
 | Event Type | Captured When | Key Payload Fields | View |
 |:---|:---|:---|:---|
@@ -59,7 +59,9 @@ The following table lists every event the plugin logs. For detailed payload exam
 | `HITL_CREDENTIAL_REQUEST` | Credential request is emitted | synthetic tool name, args | `v_hitl_credential_request` |
 | `HITL_CONFIRMATION_REQUEST` | Confirmation request is emitted | synthetic tool name, args | `v_hitl_confirmation_request` |
 | `HITL_INPUT_REQUEST` | User input request is emitted | synthetic tool name, args | `v_hitl_input_request` |
-| `HITL_*_COMPLETED` | HITL response is received | synthetic tool name, result | *(base table only)* |
+| `HITL_CREDENTIAL_REQUEST_COMPLETED` | User provides credential response | synthetic tool name, result | *(base table only)* |
+| `HITL_CONFIRMATION_REQUEST_COMPLETED` | User provides confirmation response | synthetic tool name, result | *(base table only)* |
+| `HITL_INPUT_REQUEST_COMPLETED` | User provides input response | synthetic tool name, result | *(base table only)* |
 | `A2A_INTERACTION` | Remote A2A call completes | response, task ID, context ID, request/response | `v_a2a_interaction` |
 
 ## Prerequisites

--- a/docs/integrations/bigquery-agent-analytics.md
+++ b/docs/integrations/bigquery-agent-analytics.md
@@ -38,8 +38,29 @@ Version 1.26.0 adds **Auto Schema Upgrade** (safely add new columns to existing 
 -   **Human-in-the-Loop (HITL) Tracing**: Dedicated event types for credential requests, confirmation prompts, and user input requests.
 -   **Queryable Event Views**: Automatically create flat, per-event-type BigQuery views (e.g., `v_llm_request`, `v_tool_completed`) to simplify downstream analytics by unnesting JSON payload data.
 
-The agent event data recorded varies based on the ADK event type. For more
-information, see [Event types and payloads](#event-types).
+### Captured events summary
+
+The following table lists every event the plugin logs. For detailed payload examples, see [Event types and payloads](#event-types).
+
+| Event Type | Captured When | Key Payload Fields | View |
+|:---|:---|:---|:---|
+| `USER_MESSAGE_RECEIVED` | A user message enters the invocation | text summary / content parts | `v_user_message_received` |
+| `INVOCATION_STARTING` | An invocation begins | *(common columns only)* | `v_invocation_starting` |
+| `INVOCATION_COMPLETED` | An invocation ends | *(common columns only)* | `v_invocation_completed` |
+| `AGENT_STARTING` | Agent execution begins | instruction summary | `v_agent_starting` |
+| `AGENT_COMPLETED` | Agent execution ends | latency | `v_agent_completed` |
+| `LLM_REQUEST` | A model request is sent | model, prompt, config, tools | `v_llm_request` |
+| `LLM_RESPONSE` | A model response is received | response, usage tokens, cache metadata, latency, TTFT | `v_llm_response` |
+| `LLM_ERROR` | A model call fails | error message, latency | `v_llm_error` |
+| `TOOL_STARTING` | A tool begins execution | tool name, args, origin | `v_tool_starting` |
+| `TOOL_COMPLETED` | A tool succeeds | tool name, result, origin, latency | `v_tool_completed` |
+| `TOOL_ERROR` | A tool fails | tool name, args, origin, error, latency | `v_tool_error` |
+| `STATE_DELTA` | Session state changes | state delta | `v_state_delta` |
+| `HITL_CREDENTIAL_REQUEST` | Credential request is emitted | synthetic tool name, args | `v_hitl_credential_request` |
+| `HITL_CONFIRMATION_REQUEST` | Confirmation request is emitted | synthetic tool name, args | `v_hitl_confirmation_request` |
+| `HITL_INPUT_REQUEST` | User input request is emitted | synthetic tool name, args | `v_hitl_input_request` |
+| `HITL_*_COMPLETED` | HITL response is received | synthetic tool name, result | *(base table only)* |
+| `A2A_INTERACTION` | Remote A2A call completes | response, task ID, context ID, request/response | `v_a2a_interaction` |
 
 ## Prerequisites
 
@@ -434,16 +455,18 @@ The plugin supports **OpenTelemetry** for distributed tracing. OpenTelemetry is 
 
 ## Configuration options
 
-The `BigQueryAgentAnalyticsPlugin` constructor accepts the following parameters:
+### Constructor parameters
 
--   **`project_id`** (`str`): The Google Cloud project ID.
--   **`dataset_id`** (`str`): The BigQuery dataset ID.
--   **`table_id`** (`Optional[str]`, default: `None`): The BigQuery table ID. Overrides `table_id` in `BigQueryLoggerConfig` if both are set.
--   **`config`** (`Optional[BigQueryLoggerConfig]`, default: `None`): A `BigQueryLoggerConfig` instance for detailed configuration.
--   **`location`** (`str`, default: `"US"`): The BigQuery dataset location (e.g., `"US"`, `"EU"`, `"us-central1"`).
--   **`credentials`** (`Optional[google.auth.credentials.Credentials]`, default: `None`): Explicit Google credentials for the plugin's BigQuery and GCS clients. If `None`, the plugin uses [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials). Use this for service-account, impersonated, or cross-project setups.
+The `BigQueryAgentAnalyticsPlugin` constructor accepts these parameters. It also accepts `**kwargs`, which are forwarded directly to `BigQueryLoggerConfig` (see below).
 
-The constructor also accepts `**kwargs`, which are forwarded directly to `BigQueryLoggerConfig`. This lets you pass config fields (like `batch_size` or `enabled`) without creating a separate config object:
+| Parameter | Type | Default | Use when |
+|:---|:---|:---|:---|
+| `project_id` | `str` | *(required)* | Select the Google Cloud project |
+| `dataset_id` | `str` | *(required)* | Select the BigQuery dataset |
+| `table_id` | `Optional[str]` | `None` | Use a custom table name (overrides config `table_id`) |
+| `config` | `Optional[BigQueryLoggerConfig]` | `None` | Pass a config object for detailed tuning |
+| `location` | `str` | `"US"` | Match the BigQuery dataset location (e.g., `"US"`, `"EU"`, `"us-central1"`) |
+| `credentials` | `Optional[google.auth.credentials.Credentials]` | `None` | Use explicit service-account, impersonated, or cross-project credentials instead of [ADC](https://cloud.google.com/docs/authentication/application-default-credentials) |
 
 ```python
 plugin = BigQueryAgentAnalyticsPlugin(
@@ -454,31 +477,30 @@ plugin = BigQueryAgentAnalyticsPlugin(
 )
 ```
 
--   **`enabled`** (`bool`, default: `True`): To disable the plugin from logging agent data to the BigQuery table, set this parameter to False.
--   **`table_id`** (`str`, default: `"agent_events"`): The BigQuery table ID within the dataset. Can also be overridden by the `table_id` parameter on the `BigQueryAgentAnalyticsPlugin` constructor, which takes precedence.
--   **`clustering_fields`** (`List[str]`, default: `["event_type", "agent", "user_id"]`): The fields used to cluster the BigQuery table when it is automatically created.
--   **`gcs_bucket_name`** (`Optional[str]`, default: `None`): The name of the GCS bucket to offload large content (images, blobs, large text) to. If not provided, large content may be truncated or replaced with placeholders.
--   **`connection_id`** (`Optional[str]`, default: `None`): The BigQuery connection ID (e.g., `us.my-connection`) to use as the authorizer for `ObjectRef` columns. Required for using `ObjectRef` with BigQuery ML.
--   **`max_content_length`** (`int`, default: `500 * 1024`): The maximum length (in characters) of text content to store **inline** in BigQuery before offloading to GCS (if configured) or truncating. Default is 500 KB.
--   **`batch_size`** (`int`, default: `1`): The number of events to batch before writing to BigQuery.
--   **`batch_flush_interval`** (`float`, default: `1.0`): The maximum time (in seconds) to wait before flushing a partial batch.
--   **`shutdown_timeout`** (`float`, default: `10.0`): Seconds to wait for logs to flush during shutdown.
--   **`event_allowlist`** (`Optional[List[str]]`, default: `None`): A list
-    of event types to log. If `None`, all events are logged except those in
-    `event_denylist`. For a comprehensive list of supported event types, refer
-    to the [Event types and payloads](#event-types) section.
--   **`event_denylist`** (`Optional[List[str]]`, default: `None`): A list of
-    event types to skip logging. For a comprehensive list of supported event
-    types, refer to the [Event types and payloads](#event-types) section.
--   **`content_formatter`** (`Optional[Callable[[Any, str], Any]]`, default: `None`): An optional function to format event content before logging. The function receives two arguments: the raw content and the event type string (e.g., `"LLM_REQUEST"`).
--   **`log_multi_modal_content`** (`bool`, default: `True`): Whether to log detailed content parts (including GCS references).
--   **`queue_max_size`** (`int`, default: `10000`): The maximum number of events to hold in the in-memory queue before dropping new events.
--   **`retry_config`** (`RetryConfig`, default: `RetryConfig()`): Configuration for retrying failed BigQuery writes. Sub-fields: `max_retries` (default `3`), `initial_delay` (default `1.0` seconds), `multiplier` (default `2.0`), `max_delay` (default `10.0` seconds).
--   **`log_session_metadata`** (`bool`, default: `True`): If True, logs session information into the `attributes` column, including `session_id`, `app_name`, `user_id`, and the session `state` dictionary (e.g., custom state like gchat thread-id, customer_id). State keys prefixed with `temp:` or `secret:` are automatically redacted. See [Built-in redaction](#built-in-redaction).
--   **`custom_tags`** (`Dict[str, Any]`, default: `{}`): A dictionary of static tags (e.g., `{"env": "prod", "version": "1.0"}`) to be included in the `attributes` column for every event.
--   **`auto_schema_upgrade`** (`bool`, default: `True`): When enabled, the plugin automatically adds new columns to an existing table when the plugin schema evolves. Only additive changes are made (columns are never dropped or altered). A version label (`adk_schema_version`) on the table ensures the diff runs at most once per schema version. Safe to leave enabled.
--   **`create_views`** (`bool`, default: `True`): Added in 1.27.0. When enabled, automatically generates per-event-type BigQuery views that unnest structured JSON data (such as `content` or `attributes`) into flat, typed columns, significantly simplifying SQL queries.
--   **`view_prefix`** (`str`, default: `"v"`): Prefix for auto-created view names. The default `"v"` produces views like `v_llm_request`. Set a distinct prefix per table when multiple plugin instances share the same dataset to avoid view-name collisions (e.g., `"v_staging"` produces `v_staging_llm_request`). Must be non-empty.
+### BigQueryLoggerConfig options
+
+| Option | Type | Default | Use when |
+|:---|:---|:---|:---|
+| `enabled` | `bool` | `True` | Temporarily disable logging |
+| `table_id` | `str` | `"agent_events"` | Use a custom table name (constructor value takes precedence) |
+| `clustering_fields` | `List[str]` | `["event_type", "agent", "user_id"]` | Customize table clustering on creation |
+| `gcs_bucket_name` | `Optional[str]` | `None` | Offload large text and multimodal content to GCS |
+| `connection_id` | `Optional[str]` | `None` | Use BigQuery ObjectRef / object tables (e.g., `us.my-connection`) |
+| `max_content_length` | `int` | `500 * 1024` | Control inline payload size before offloading/truncating |
+| `batch_size` | `int` | `1` | Tune write throughput vs. latency |
+| `batch_flush_interval` | `float` | `1.0` | Flush partial batches periodically (seconds) |
+| `shutdown_timeout` | `float` | `10.0` | Wait for final flush on shutdown (seconds) |
+| `event_allowlist` | `Optional[List[str]]` | `None` | Log only selected [event types](#event-types) |
+| `event_denylist` | `Optional[List[str]]` | `None` | Skip sensitive or noisy [event types](#event-types) |
+| `content_formatter` | `Optional[Callable]` | `None` | Apply custom masking/formatting per event (receives `(content, event_type)`) |
+| `log_multi_modal_content` | `bool` | `True` | Capture `content_parts` details including GCS references |
+| `queue_max_size` | `int` | `10000` | Bound the in-memory event queue |
+| `retry_config` | `RetryConfig` | `RetryConfig()` | Tune retry behavior (`max_retries=3`, `initial_delay=1.0`, `multiplier=2.0`, `max_delay=10.0`) |
+| `log_session_metadata` | `bool` | `True` | Add session info to `attributes` (`session_id`, `app_name`, `user_id`, `state`). Keys prefixed `temp:` or `secret:` are [redacted](#built-in-redaction). |
+| `custom_tags` | `Dict[str, Any]` | `{}` | Add static tags (e.g., `{"env": "prod"}`) to every event's `attributes` |
+| `auto_schema_upgrade` | `bool` | `True` | Automatically add new columns to existing tables (additive only) |
+| `create_views` | `bool` | `True` | Create per-event-type BigQuery views (1.27.0+) |
+| `view_prefix` | `str` | `"v"` | Avoid view-name collisions when multiple plugins share a dataset (e.g., `"v_staging"`) |
 
 
 The following code sample shows how to define a configuration for the
@@ -570,47 +592,46 @@ The events table (`agent_events`) uses a flexible schema. The following table pr
 | **is_truncated** | `BOOLEAN` | `NULLABLE` | `true` if `content` or `attributes` exceeded the BigQuery cell size limit (default 10MB) and were partially dropped. | `false` |
 | **content_parts** | `RECORD` | `REPEATED` | Array of multi-modal segments (Text, Image, Blob). Used when content cannot be serialized as simple JSON (e.g., large binaries or GCS refs). | `[{"mime_type": "text/plain", "text": "hello"}]` |
 
-The plugin automatically creates the table if it does not exist. However, for
-production, we recommend creating the table manually using the following DDL, which utilizes the **JSON** type for flexibility and **REPEATED RECORD**s for multimodal content.
+The plugin automatically creates the table if it does not exist. For production, you can optionally create the table manually using the DDL below.
 
-**Recommended DDL:**
+??? example "Manual DDL for production setup"
 
-```sql
-CREATE TABLE `your-gcp-project-id.adk_agent_logs.agent_events`
-(
-  timestamp TIMESTAMP NOT NULL OPTIONS(description="The UTC time at which the event was logged."),
-  event_type STRING OPTIONS(description="Indicates the type of event being logged (e.g., 'LLM_REQUEST', 'TOOL_COMPLETED')."),
-  agent STRING OPTIONS(description="The name of the ADK agent or author associated with the event."),
-  session_id STRING OPTIONS(description="A unique identifier to group events within a single conversation or user session."),
-  invocation_id STRING OPTIONS(description="A unique identifier for each individual agent execution or turn within a session."),
-  user_id STRING OPTIONS(description="The identifier of the user associated with the current session."),
-  trace_id STRING OPTIONS(description="OpenTelemetry trace ID for distributed tracing."),
-  span_id STRING OPTIONS(description="OpenTelemetry span ID for this specific operation."),
-  parent_span_id STRING OPTIONS(description="OpenTelemetry parent span ID to reconstruct hierarchy."),
-  content JSON OPTIONS(description="The event-specific data (payload) stored as JSON."),
-  content_parts ARRAY<STRUCT<
-    mime_type STRING,
-    uri STRING,
-    object_ref STRUCT<
-      uri STRING,
-      version STRING,
-      authorizer STRING,
-      details JSON
-    >,
-    text STRING,
-    part_index INT64,
-    part_attributes STRING,
-    storage_mode STRING
-  >> OPTIONS(description="Detailed content parts for multi-modal data."),
-  attributes JSON OPTIONS(description="Arbitrary key-value pairs for additional metadata (e.g., 'root_agent_name', 'model_version', 'usage_metadata', 'session_metadata', 'custom_tags')."),
-  latency_ms JSON OPTIONS(description="Latency measurements (e.g., total_ms)."),
-  status STRING OPTIONS(description="The outcome of the event, typically 'OK' or 'ERROR'."),
-  error_message STRING OPTIONS(description="Populated if an error occurs."),
-  is_truncated BOOLEAN OPTIONS(description="Flag indicates if content was truncated.")
-)
-PARTITION BY DATE(timestamp)
-CLUSTER BY event_type, agent, user_id;
-```
+    ```sql
+    CREATE TABLE `your-gcp-project-id.adk_agent_logs.agent_events`
+    (
+      timestamp TIMESTAMP NOT NULL OPTIONS(description="The UTC time at which the event was logged."),
+      event_type STRING OPTIONS(description="Indicates the type of event being logged (e.g., 'LLM_REQUEST', 'TOOL_COMPLETED')."),
+      agent STRING OPTIONS(description="The name of the ADK agent or author associated with the event."),
+      session_id STRING OPTIONS(description="A unique identifier to group events within a single conversation or user session."),
+      invocation_id STRING OPTIONS(description="A unique identifier for each individual agent execution or turn within a session."),
+      user_id STRING OPTIONS(description="The identifier of the user associated with the current session."),
+      trace_id STRING OPTIONS(description="OpenTelemetry trace ID for distributed tracing."),
+      span_id STRING OPTIONS(description="OpenTelemetry span ID for this specific operation."),
+      parent_span_id STRING OPTIONS(description="OpenTelemetry parent span ID to reconstruct hierarchy."),
+      content JSON OPTIONS(description="The event-specific data (payload) stored as JSON."),
+      content_parts ARRAY<STRUCT<
+        mime_type STRING,
+        uri STRING,
+        object_ref STRUCT<
+          uri STRING,
+          version STRING,
+          authorizer STRING,
+          details JSON
+        >,
+        text STRING,
+        part_index INT64,
+        part_attributes STRING,
+        storage_mode STRING
+      >> OPTIONS(description="Detailed content parts for multi-modal data."),
+      attributes JSON OPTIONS(description="Arbitrary key-value pairs for additional metadata (e.g., 'root_agent_name', 'model_version', 'usage_metadata', 'session_metadata', 'custom_tags')."),
+      latency_ms JSON OPTIONS(description="Latency measurements (e.g., total_ms)."),
+      status STRING OPTIONS(description="The outcome of the event, typically 'OK' or 'ERROR'."),
+      error_message STRING OPTIONS(description="Populated if an error occurs."),
+      is_truncated BOOLEAN OPTIONS(description="Flag indicates if content was truncated.")
+    )
+    PARTITION BY DATE(timestamp)
+    CLUSTER BY event_type, agent, user_id;
+    ```
 
 ### Automatically Created Views (1.27.0+)
 
@@ -1229,11 +1250,9 @@ FROM SessionContext;
 ```
 
 
-## Conversational Analytics in BigQuery
+### Conversational Analytics
 
-You can also use
-[BigQuery Conversational Analytics](https://cloud.google.com/bigquery/docs/conversational-analytics)
-to analyze your agent logs using natural language. Use this tool to answer questions like:
+You can also use [BigQuery Conversational Analytics](https://cloud.google.com/bigquery/docs/conversational-analytics) to analyze your agent logs using natural language. Example questions:
 
 *   "Show me the error rate over time"
 *   "What are the most common tool calls?"

--- a/docs/integrations/bigquery-agent-analytics.md
+++ b/docs/integrations/bigquery-agent-analytics.md
@@ -40,7 +40,7 @@ Version 1.26.0 adds **Auto Schema Upgrade** (safely add new columns to existing 
 
 ### Captured events summary
 
-The following table lists all event types the plugin logs. For detailed payload examples, see [Event types and payloads](#event-types).
+The following table lists all event types the plugin logs. For detailed payload examples, see [Event types and payloads](#event-types). The **View** column shows the BigQuery view optionally created when [`create_views`](#configuration-options) is enabled (the default).
 
 | Event Type | Captured When | Key Payload Fields | View |
 |:---|:---|:---|:---|
@@ -247,6 +247,8 @@ plugin = BigQueryAgentAnalyticsPlugin(
 ```
 
 ### BigQueryLoggerConfig options
+
+All options below are optional and have sensible defaults. Pass them to `BigQueryLoggerConfig` or as `**kwargs` to the plugin constructor.
 
 | Option | Type | Default | Use when |
 |:---|:---|:---|:---|
@@ -1010,7 +1012,7 @@ FROM SessionContext;
 
 ### Conversational Analytics
 
-You can also use [BigQuery Conversational Analytics](https://cloud.google.com/bigquery/docs/conversational-analytics) to analyze your agent logs using natural language. Example questions:
+You can also use [BigQuery Conversational Analytics](https://cloud.google.com/bigquery/docs/conversational-analytics) to analyze your agent logs using natural language. Create a conversational analytics agent in the [BigQuery Agents Hub](https://console.cloud.google.com/bigquery/agents_hub) connected to your `agent_events` table, then ask questions like:
 
 *   "Show me the error rate over time"
 *   "What are the most common tool calls?"
@@ -1415,16 +1417,22 @@ For Gunicorn deployments specifically:
 
     The fork-safety mechanism resets runtime state only. It does **not** replay events that were queued but not yet flushed in the parent process at the time of fork. Call `await plugin.flush()` before forking if you need to guarantee delivery.
 
-## Consuming logged data with BigQuery Agent Analytics SDK
+## Additional ways to consume logged data
 
-The [BigQuery Agent Analytics SDK](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main) provides a convenient way to consume and analyze the data logged by the BigQuery Agent Analytics plugin. The SDK offers pre-built utilities for querying, aggregating, and visualizing your agent's operational data directly from BigQuery.
+### BigQuery Agent Analytics SDK
 
-### Dashboard
+The [BigQuery Agent Analytics SDK](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/tree/main) provides a programmatic way to consume and analyze the data logged by the plugin. Use the SDK for:
 
-The BigQuery Agent Analytics SDK includes an [example Jupyter notebook](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/examples/dashboard_v2.ipynb) that demonstrates how to query and visualize your agent's performance data. Use it as a starting point to build your own custom dashboards tailored to your BigQuery Agent Analytics dataset.
+-   **Agent evaluation** — compare agent runs against expected outcomes.
+-   **Golden trajectory matching** — validate that agent execution paths match approved sequences.
+-   **Trace visualization** — reconstruct and visualize agent execution flows from logged spans.
+
+### Build a dashboard
+
+The BigQuery Agent Analytics SDK includes an [example Jupyter notebook](https://github.com/GoogleCloudPlatform/BigQuery-Agent-Analytics-SDK/blob/main/examples/dashboard_v2.ipynb) that demonstrates how to query and visualize your agent's performance data. Use it as a starting point to build your own custom dashboards tailored to your BigQuery Agent Analytics dataset. You can also publish the notebook as an interactive dashboard using [BigQuery Data app](https://cloud.google.com/bigquery/docs/data-app-overview).
 
 ## Feedback
-We welcome your feedback on BigQuery Agent Analytics. If you have questions, suggestions, or encounter any issues, please reach out to the team at bqaa-feedback@google.com.
+We welcome your feedback on BigQuery Agent Analytics. If you have questions, suggestions, or encounter any issues, please reach out to the team at [bqaa-feedback@google.com](mailto:bqaa-feedback@google.com).
 
 ## Additional resources
 


### PR DESCRIPTION
## Summary

Full restructure of the BigQuery Agent Analytics plugin doc, addressing #1710. Two phases in one PR:

### Phase 1 — Additive tables (no section moves)
- **Captured-events summary table**: 19-row table near the top listing all event types, when they fire, key fields, and corresponding view
- **Configuration reference tables**: Converted bullet list to two 4-column tables (constructor params + BigQueryLoggerConfig)
- **Collapsible DDL**: Production DDL wrapped in `??? example` admonition
- **Conversational Analytics**: Demoted from standalone `##` to `###` under query section

### Phase 2 — Structural reorder
- **Shortened quickstart**: Minimal 3-import example; full example with GCS/OTel/BigQuery tools moved to collapsible block
- **Agent Runtime moved later**: From position 4 (interrupting core narrative) to position 9 (after query recipes)
- **GCS offloading extracted**: From nested `####` under "Event types" to its own `## Storage behavior: GCS offloading`
- **Query recipes regrouped by task**: Debug a run, Monitor cost/performance, Inspect tools/interactions, Analyze multimodal, AI root cause, Conversational Analytics
- **Operations consolidated**: Tracing, Public methods, and Multiprocessing grouped under one `## Operations` section
- **New anchors**: `{#prerequisites}`, `{#configuration-options}`

### New section order
1. Overview + Use cases + Captured events
2. Quickstart (shortened)
3. Prerequisites + IAM
4. Configuration (tables)
5. Schema + Views
6. Event types + payloads
7. Storage behavior: GCS offloading
8. Query recipes (task-grouped)
9. Deploy to Agent Runtime
10. Security + redaction
11. Operations (tracing, methods, multiprocessing)
12. SDK / dashboards
13. Feedback + resources

### Anchors
All 5 existing anchors preserved: `#deploy-agent-runtime`, `#event-types`, `#hitl-events`, `#security-credentials`, `#built-in-redaction`. Added: `#prerequisites`, `#configuration-options`.

## Test plan
- [ ] Quickstart renders with minimal example + collapsible full example
- [ ] Captured-events table renders all 19 rows
- [ ] Config tables render correctly (constructor + BigQueryLoggerConfig)
- [ ] DDL is collapsible
- [ ] GCS offloading section renders correctly as standalone `##`
- [ ] Query recipes show task-based `###` grouping with `####` subsections
- [ ] Agent Runtime section appears after query recipes
- [ ] Operations section groups tracing + public methods + multiprocessing
- [ ] All 7 anchors resolve correctly
- [ ] No broken internal cross-references

Ref: #1710