### PR TITLE
docs: clarify function tool defaults

### DIFF
--- a/docs/tools-custom/function-tools.md
+++ b/docs/tools-custom/function-tools.md
@@ -94,6 +94,8 @@ A well-defined function signature is crucial for the LLM to use your tool correc
 === "Python"
     A parameter is considered **optional** if you provide a **default value**. This is the standard Python way to define optional arguments. You can also mark a parameter as optional using `typing.Optional[SomeType]` or the `| None` syntax (Python 3.10+).
 
+    Use defaults only for values that are truly optional. Do not add defaults for information the model should derive from the user request or ask the user to provide.
+
     ???+ "Example: Optional Parameters"
         ```python
         def search_flights(destination: str, departure_date: str, flexible_days: int = 0):

--- a/docs/tools-custom/index.md
+++ b/docs/tools-custom/index.md
@@ -357,7 +357,7 @@ Here are key guidelines for defining effective tool functions:
     * Use clear and descriptive names (e.g., `city` instead of `c`, `search_query` instead of `q`).
     * **Provide type hints in Python**  for all parameters (e.g., `city: str`, `user_id: int`, `items: list[str]`). This is essential for ADK to generate the correct schema for the LLM.
     * Ensure all parameter types are **JSON serializable**. All java primitives as well as standard Python types like `str`, `int`, `float`, `bool`, `list`, `dict`, and their combinations are generally safe. Avoid complex custom class instances as direct parameters unless they have a clear JSON representation.
-    * **Do not set default values** for parameters. E.g., `def my_func(param1: str = "default")`. Default values are not reliably supported or used by the underlying models during function call generation. All necessary information should be derived by the LLM from the context or explicitly requested if missing.
+    * **Avoid default values for information the model must provide.** E.g., avoid `def my_func(destination: str = "Paris")` if the destination should come from the user or conversation context. Default values can be appropriate for genuinely optional tuning parameters, but do not use them to hide required business inputs from the tool schema.
     * **`self` / `cls` Handled Automatically:** Implicit parameters like `self` (for instance methods) or `cls` (for class methods) are automatically handled by ADK and excluded from the schema shown to the LLM. You only need to define type hints and descriptions for the logical parameters your tool requires the LLM to provide.
 
 * **Return Type:**


### PR DESCRIPTION
## Summary
- clarify that defaults should not hide required user or business inputs from tool schemas
- preserve guidance that defaults are valid for genuinely optional tuning parameters
- align the parent custom tools guidance with the function tools optional parameter section

Fixes #1429

## Verification
- git diff --check
- python3 -m mkdocs build --strict