### PR TITLE
docs: document LoadArtifactsTool usage

### DIFF
--- a/docs/artifacts/index.md
+++ b/docs/artifacts/index.md
@@ -804,6 +804,45 @@ The artifact interaction methods are available directly on instances of `Callbac
         }
         ```
 
+#### Letting the Agent Load Artifacts On Demand
+
+For Python agents, you can add `LoadArtifactsTool` when the model should decide
+which available artifacts to load before answering. This is useful when users
+ask follow-up questions about uploaded files or large generated outputs that are
+stored as artifacts instead of kept in the conversation context.
+
+`LoadArtifactsTool` lists available artifacts in the model instructions. When
+the model calls the `load_artifacts` tool, ADK temporarily appends the selected
+artifact contents to that request so the model can answer with the file content
+in context. The loaded artifact content is not permanently saved back into the
+session history, so the model should call the tool again when it needs the same
+artifact in a later turn.
+
+=== "Python"
+
+    ```python
+    from google.adk.agents import LlmAgent
+    from google.adk.tools.load_artifacts_tool import LoadArtifactsTool
+
+    root_agent = LlmAgent(
+        name="artifact_reader",
+        model="gemini-2.5-flash",
+        instruction=(
+            "Answer questions about available user files. "
+            "Call load_artifacts before answering when you need file contents."
+        ),
+        tools=[
+            LoadArtifactsTool(),
+        ],
+    )
+    ```
+
+    Make sure the `Runner` for this agent is configured with an
+    `artifact_service`; otherwise artifact listing and loading will fail. If
+    your artifacts need human-readable summaries, subclass `LoadArtifactsTool`
+    and customize its request instructions before loading the selected artifact
+    contents.
+
 #### Listing Artifact Filenames
 
 *   **Code Example:**

--- a/docs/artifacts/index.md
+++ b/docs/artifacts/index.md
@@ -804,12 +804,12 @@ The artifact interaction methods are available directly on instances of `Callbac
         }
         ```
 
-#### Letting the Agent Load Artifacts On Demand
+#### Using `LoadArtifactsTool`
 
-For Python agents, you can add `LoadArtifactsTool` when the model should decide
-which available artifacts to load before answering. This is useful when users
-ask follow-up questions about uploaded files or large generated outputs that are
-stored as artifacts instead of kept in the conversation context.
+You can add `LoadArtifactsTool` when the model should decide which available
+artifacts to load before answering. This is useful when users ask follow-up
+questions about uploaded files or large generated outputs that are stored as
+artifacts instead of kept in the conversation context.
 
 `LoadArtifactsTool` lists available artifacts in the model instructions. When
 the model calls the `load_artifacts` tool, ADK temporarily appends the selected
@@ -826,7 +826,7 @@ artifact in a later turn.
 
     root_agent = LlmAgent(
         name="artifact_reader",
-        model="gemini-2.5-flash",
+        model="gemini-flash-latest",
         instruction=(
             "Answer questions about available user files. "
             "Call load_artifacts before answering when you need file contents."
@@ -842,6 +842,29 @@ artifact in a later turn.
     your artifacts need human-readable summaries, subclass `LoadArtifactsTool`
     and customize its request instructions before loading the selected artifact
     contents.
+
+=== "Go"
+
+    ```go
+    import (
+      "google.golang.org/adk/agent/llmagent"
+      "google.golang.org/adk/tool"
+      "google.golang.org/adk/tool/loadartifactstool"
+    )
+
+    agent, err := llmagent.New(llmagent.Config{
+        Name:        "artifact_reader",
+        Model:       model,
+        Instruction: "Answer questions about available user files. " +
+            "When user asks about artifacts, load them and describe them.",
+        Tools: []tool.Tool{
+            loadartifactstool.New(),
+        },
+    })
+    ```
+
+    Make sure the `runner.Config` for this agent includes an
+    `ArtifactService`; otherwise artifact listing and loading will fail.
 
 #### Listing Artifact Filenames
 


### PR DESCRIPTION
## Summary
- add a Python section showing how to add `LoadArtifactsTool` to an agent
- explain that loaded artifact contents are temporarily appended to the model request
- call out the `artifact_service` prerequisite and customization path for artifact summaries

Fixes #844

## Verification
- git diff --check
- python3 -m mkdocs build --strict