### PR TITLE
docs(integrations/stackone): add search and execute mode to StackOne

### DIFF
--- a/docs/integrations/stackone.md
+++ b/docs/integrations/stackone.md
@@ -165,6 +165,90 @@ uv add stackone-adk
         asyncio.run(main())
         ```
 
+## Search and execute mode
+
+With `mode="search_and_execute"`, the plugin registers exactly two tools,
+`tool_search` and `tool_execute`. The model uses them at runtime to discover
+the right StackOne tool and invoke it, instead of seeing the full catalog
+upfront.
+
+Registering every tool definition with the model has three costs:
+
+- **Token overhead:** Tool schemas consume prompt tokens that could otherwise
+  be available for reasoning.
+- **Payload limits:** Large catalogs can exceed provider payload limits.
+  Gemini, for example, imposes hard limits on the size and number of function
+  declarations per request.
+- **Selection accuracy:** Tool-selection quality degrades as the tool
+  candidate set grows, since the model has more near-duplicates to
+  disambiguate.
+
+This mode keeps the registered tool count at two regardless of catalog size.
+The model resolves the right tool through a natural-language query at
+runtime.
+
+This mode requires `stackone-adk>=0.2.0`.
+
+=== "Python"
+
+    ```python
+    import asyncio
+
+    from google.adk.agents import Agent
+    from google.adk.apps import App
+    from google.adk.runners import InMemoryRunner
+    from stackone_adk import StackOnePlugin
+
+
+    async def main():
+        plugin = StackOnePlugin(
+            mode="search_and_execute",
+            account_ids=["YOUR_ACCOUNT_ID"],
+            search={"method": "auto", "top_k": 10},
+        )
+
+        agent = Agent(
+            model="gemini-flash-latest",
+            name="stackone_agent",
+            description="Connects to multiple SaaS providers through StackOne.",
+            instruction=(
+                "You are an assistant powered by StackOne. To answer the "
+                "user's request, first call tool_search with a short query "
+                "to find the right action, then call tool_execute with the "
+                "chosen tool name and parameters that match the schema "
+                "returned by tool_search."
+            ),
+            tools=plugin.get_tools(),
+        )
+
+        app = App(
+            name="stackone_app",
+            root_agent=agent,
+            plugins=[plugin],
+        )
+
+        async with InMemoryRunner(app=app) as runner:
+            events = await runner.run_debug(
+                "List the first 3 workers.",
+                quiet=True,
+            )
+            for event in reversed(events):
+                if event.content and event.content.parts:
+                    text_parts = [p.text for p in event.content.parts if p.text]
+                    if text_parts:
+                        print("".join(text_parts))
+                        break
+
+
+    asyncio.run(main())
+    ```
+
+The model first calls `tool_search` with a natural-language query and receives
+a short list of candidate tools, each with its name, description, and
+parameter schema. The model then calls `tool_execute` with the selected tool
+name and parameters that match the schema. Both calls route through StackOne's
+AI Integration Gateway via the SDK.
+
 ## Available tools
 
 Unlike integrations with a fixed set of tools, StackOne tools are **dynamically
@@ -211,6 +295,10 @@ Parameter | Type | Default | Description
 `providers` | `list[str] | None` | `None` | Filter by provider names (e.g., `["calendly", "hibob"]`).
 `actions` | `list[str] | None` | `None` | Filter by action patterns using glob syntax.
 `account_ids` | `list[str] | None` | `None` | Scope tools to specific connected account IDs.
+`mode` | `Literal["search_and_execute"] | None` | `None` | Tool registration strategy. With `None`, every discovered tool is registered with the agent. With `"search_and_execute"`, the plugin registers two tools (`tool_search` and `tool_execute`), and the model selects and invokes tools at runtime.
+`search` | `SearchConfig | None` | `None` | Search backend configuration forwarded to `StackOneToolSet`. Takes effect when `mode="search_and_execute"`. Defaults to `{"method": "auto"}` in that mode.
+`execute` | `ExecuteToolsConfig | None` | `None` | Execution configuration forwarded to `StackOneToolSet`.
+`timeout` | `float` | `180.0` | Per-request timeout in seconds for HTTP calls (account discovery and tool execution). Increase for slow connectors.
 
 ### Tool filtering
 


### PR DESCRIPTION
## Summary

This PR adds docs for the  `mode="search_and_execute"` shipped in [`stackone-adk` 0.2.0](https://pypi.org/project/stackone-adk/0.2.0/) on the StackOne integration page.

## Changes

Single file: `docs/integrations/stackone.md`. Two additive blocks, not much of  restructuring of existing content:

1. **New `## Search and execute mode` section** between `## Use with agent` and `## Available tools`. Covers when to use the mode, the three costs of registering every tool definition (token overhead, payload limits, selection accuracy), a runnable Python code sample, and the `tool_search` to `tool_execute` flow.
2. **Four rows added to the Plugin parameters table**: `mode`, `search`, `execute`, `timeout`.

## Motivation & Benefits 

When several SaaS providers are linked to a single StackOne account, the full tool catalog can exceed Gemini's hard limits on function declarations per request. `mode="search_and_execute"` keeps the registered tool count at two and lets the model discover and invoke the right tool at runtime via `tool_search`. 

## Verification

- Code sample executed end-to-end against a real StackOne account using `gemini-flash-latest`. The agent invoked `tool_search`, then `tool_execute`, and returned the expected response.
- `mkdocs serve` renders the page correctly: new section, Python code tab, and the four new parameter rows all display as expected.

## References

- PyPI release: <https://pypi.org/project/stackone-adk/0.2.0/>
- Plugin source: <https://github.com/StackOneHQ/stackone-adk-plugin>

## Acceptance criteria

Per [CONTRIBUTING.md](https://github.com/google/adk-docs/blob/main/CONTRIBUTING.md):

- [x] **Completeness and testability**: code sample is functional and runnable; verified against a live account.
- [x] **Value for developers**: this mode is the recommended approach when several providers are linked, since the default mode can exceed Gemini's payload caps for large catalogs.
- [x] **Publishability**: no TOS violations or proprietary content.
- [x] Tested locally with `mkdocs serve`.
- [x] Matches the page's existing formatting conventions and uses American English.
