### PR TITLE
docs(integration): add Atlan with updated copy and full tool list

### DIFF
--- a/docs/integrations/atlan.md
+++ b/docs/integrations/atlan.md
@@ -26,15 +26,15 @@ every agent task is grounded in trusted organizational context.
   glossary terms, and data products across your entire stack with natural
   language.
 
-- **Traverse end-to-end lineage**: Trace data flow upstream and downstream across
-  systems to understand dependencies before a schema change.
+- **Traverse end-to-end lineage**: Trace data flow upstream and downstream
+  across systems to understand dependencies before a schema change.
 
 - **Access governed data definitions**: Use glossaries, data domains, and
   certified metadata to ground agent output in trusted organizational context.
 
 - **Curate your metadata graph**: Update descriptions, certify assets, manage
-  glossaries, define data quality rules and schedules, and execute SQL — all
-  from your agent.
+  glossaries, define data quality rules and schedules, and execute SQL, all from
+  your agent.
 
 ## Prerequisites
 

--- a/docs/integrations/atlan.md
+++ b/docs/integrations/atlan.md
@@ -1,6 +1,6 @@
 ---
 catalog_title: Atlan
-catalog_description: Search, explore, and govern data assets in your Atlan catalog
+catalog_description: Bring your organization's full context into ADK — the knowledge, data, and semantics your AI agents need
 catalog_icon: /integrations/assets/atlan.png
 catalog_tags: ["mcp"]
 ---
@@ -11,22 +11,29 @@ catalog_tags: ["mcp"]
   <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span><span class="lst-typescript">TypeScript</span>
 </div>
 
-The [Atlan MCP Server](https://github.com/atlanhq/agent-toolkit) connects your
-ADK agent to your [Atlan](https://www.atlan.com/) data catalog, giving the
-agent the ability to discover, explore, govern, and manage data assets across
-your warehouses, lakes, BI tools, and pipelines using natural language.
+[Atlan](https://www.atlan.com/) is the context layer for enterprise AI. The
+[Atlan MCP Server](https://github.com/atlanhq/agent-toolkit) connects your ADK
+agent to your organization's context repos — the knowledge, data, and semantics
+your AI agents need to build effectively. Use Atlan's agent skills to search &
+discover enterprise context, traverse end-to-end lineage, access governed data
+definitions and glossaries, execute SQL, curate your metadata graph, and ensure
+data quality — so every agent task is grounded in trusted organizational context.
 
 ## Use cases
 
-- **Asset Discovery**: Search across tables, columns, dashboards, and pipelines
-  with semantic search to find the right data for an analysis or feature.
+- **Search and discover enterprise context** — find tables, columns, dashboards,
+  glossary terms, and data products across your entire stack with natural
+  language.
 
-- **Lineage and Impact Analysis**: Trace upstream sources or downstream
-  consumers of an asset to understand dependencies before a schema change.
+- **Traverse end-to-end lineage** — trace data flow upstream and downstream
+  across systems to understand dependencies before a schema change.
 
-- **Governance and Stewardship**: Update descriptions, certify assets,
-  manage glossaries and data domains, and create or schedule data quality
-  rules from the agent.
+- **Access governed data definitions** — use glossaries, data domains, and
+  certified metadata to ground agent output in trusted organizational context.
+
+- **Curate your metadata graph** — update descriptions, certify assets, manage
+  glossaries, define data quality rules and schedules, and execute SQL — all
+  from your agent.
 
 ## Prerequisites
 
@@ -51,7 +58,7 @@ your warehouses, lakes, BI tools, and pipelines using natural language.
         root_agent = Agent(
             model="gemini-flash-latest",
             name="atlan_agent",
-            instruction="Help users search, explore, and govern data assets in Atlan",
+            instruction="Help users search, discover, and manage enterprise data assets using Atlan",
             tools=[
                 McpToolset(
                     connection_params=StdioConnectionParams(
@@ -80,7 +87,7 @@ your warehouses, lakes, BI tools, and pipelines using natural language.
         const rootAgent = new LlmAgent({
             model: "gemini-flash-latest",
             name: "atlan_agent",
-            instruction: "Help users search, explore, and govern data assets in Atlan",
+            instruction: "Help users search, discover, and manage enterprise data assets using Atlan",
             tools: [
                 new MCPToolset({
                     type: "StdioConnectionParams",

--- a/docs/integrations/atlan.md
+++ b/docs/integrations/atlan.md
@@ -1,6 +1,6 @@
 ---
 catalog_title: Atlan
-catalog_description: Bring your organization's full context into ADK — the knowledge, data, and semantics your AI agents need
+catalog_description: Search, explore, and govern metadata, lineage, and business knowledge
 catalog_icon: /integrations/assets/atlan.png
 catalog_tags: ["mcp"]
 ---
@@ -11,27 +11,28 @@ catalog_tags: ["mcp"]
   <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span><span class="lst-typescript">TypeScript</span>
 </div>
 
-[Atlan](https://www.atlan.com/) is the context layer for enterprise AI. The
-[Atlan MCP Server](https://github.com/atlanhq/agent-toolkit) connects your ADK
-agent to your organization's context repos — the knowledge, data, and semantics
-your AI agents need to build effectively. Use Atlan's agent skills to search &
-discover enterprise context, traverse end-to-end lineage, access governed data
-definitions and glossaries, execute SQL, curate your metadata graph, and ensure
-data quality — so every agent task is grounded in trusted organizational context.
+The [Atlan MCP Server](https://github.com/atlanhq/agent-toolkit) connects your
+ADK agent to [Atlan](https://www.atlan.com/), the context layer for enterprise
+AI, giving your agent access to your organization's context repos: the
+knowledge, data, and semantics your AI agents need to build effectively. This
+integration gives your agent the ability to search and discover enterprise
+context, traverse end-to-end lineage, access governed data definitions and
+glossaries, execute SQL, curate your metadata graph, and ensure data quality, so
+every agent task is grounded in trusted organizational context.
 
 ## Use cases
 
-- **Search and discover enterprise context** — find tables, columns, dashboards,
+- **Search and discover enterprise context**: Find tables, columns, dashboards,
   glossary terms, and data products across your entire stack with natural
   language.
 
-- **Traverse end-to-end lineage** — trace data flow upstream and downstream
-  across systems to understand dependencies before a schema change.
+- **Traverse end-to-end lineage**: Trace data flow upstream and downstream across
+  systems to understand dependencies before a schema change.
 
-- **Access governed data definitions** — use glossaries, data domains, and
+- **Access governed data definitions**: Use glossaries, data domains, and
   certified metadata to ground agent output in trusted organizational context.
 
-- **Curate your metadata graph** — update descriptions, certify assets, manage
+- **Curate your metadata graph**: Update descriptions, certify assets, manage
   glossaries, define data quality rules and schedules, and execute SQL — all
   from your agent.
 


### PR DESCRIPTION
## Summary

- Adds the Atlan MCP integration page for ADK with copy aligned to the official Atlan IDE extensions (VS Code, Cursor, Windsurf)
- Positions Atlan as the **context layer for enterprise AI** rather than a data catalog
- Includes the complete set of **28 tools** exposed by the hosted MCP server (`mcp.atlan.com`), organized by capability: discovery and search, asset updates, glossaries and domains, data quality rules, custom metadata, and Atlan tags
- Supersedes #1739 (which can be closed once this is reviewed)