### PR TITLE
Add AGENT_RESPONSE event type and view to BigQuery Agent Analytics docs

### DIFF
--- a/docs/integrations/bigquery-agent-analytics.md
+++ b/docs/integrations/bigquery-agent-analytics.md
@@ -85,6 +85,7 @@ shows the BigQuery view optionally created when
 | `HITL_CONFIRMATION_REQUEST_COMPLETED` | User provides confirmation response | synthetic tool name, result | *(base table only)* |
 | `HITL_INPUT_REQUEST_COMPLETED` | User provides input response | synthetic tool name, result | *(base table only)* |
 | `A2A_INTERACTION` | Remote A2A call completes | response, task ID, context ID, request/response | `v_a2a_interaction` |
+| `AGENT_RESPONSE` | Final agent response is yielded | response text, source event metadata | `v_agent_response` |
 
 ## Quickstart
 
@@ -468,7 +469,7 @@ Every view includes these **common columns**: `timestamp`, `event_type`,
 `agent`, `session_id`, `invocation_id`, `user_id`, `trace_id`, `span_id`,
 `parent_span_id`, `status`, `error_message`, `is_truncated`.
 
-The following table lists all 16 auto-created views and their event-specific
+The following table lists all 17 auto-created views and their event-specific
 columns:
 
 | View Name | Event-Specific Columns |
@@ -489,6 +490,7 @@ columns:
 | **`v_hitl_confirmation_request`** | `tool_name` (STRING), `tool_args` (JSON) |
 | **`v_hitl_input_request`** | `tool_name` (STRING), `tool_args` (JSON) |
 | **`v_a2a_interaction`** | `response_content` (JSON), `a2a_task_id` (STRING), `a2a_context_id` (STRING), `a2a_request` (JSON), `a2a_response` (JSON) |
+| **`v_agent_response`** | `response_text` (STRING), `source_event_id` (STRING), `source_event_author` (STRING), `source_event_branch` (STRING) |
 
 ## Event types and payloads {#event-types}
 
@@ -698,6 +700,23 @@ updated by tools).
 | `AGENT_STARTING` | `"You are a helpful agent..."` |
 | `AGENT_COMPLETED` | `{}` |
 | `USER_MESSAGE_RECEIVED` | `{"text_summary": "Help me book a flight."}` |
+| `AGENT_RESPONSE` | `{"response_text": "Here are the flights...", "source_event_id": "...", "source_event_author": "flight_agent", "source_event_branch": "main"}` |
+
+**AGENT_RESPONSE**
+
+Logged when the agent yields a final response to the user. Captures the response text along with metadata about the source event that produced it.
+
+```json
+{
+  "event_type": "AGENT_RESPONSE",
+  "content": {
+    "response_text": "Here are the available flights...",
+    "source_event_id": "evt-abc123",
+    "source_event_author": "flight_agent",
+    "source_event_branch": "main"
+  }
+}
+```
 
 ### Human-in-the-Loop (HITL) Events {#hitl-events}
 

--- a/docs/integrations/bigquery-agent-analytics.md
+++ b/docs/integrations/bigquery-agent-analytics.md
@@ -85,7 +85,7 @@ shows the BigQuery view optionally created when
 | `HITL_CONFIRMATION_REQUEST_COMPLETED` | User provides confirmation response | synthetic tool name, result | *(base table only)* |
 | `HITL_INPUT_REQUEST_COMPLETED` | User provides input response | synthetic tool name, result | *(base table only)* |
 | `A2A_INTERACTION` | Remote A2A call completes | response, task ID, context ID, request/response | `v_a2a_interaction` |
-| `AGENT_RESPONSE` | Final agent response is yielded | response text, source event metadata | `v_agent_response` |
+| `AGENT_RESPONSE` | Final agent response is yielded | response (content), source event ID/author/branch (attributes) | `v_agent_response` |
 
 ## Quickstart
 
@@ -700,17 +700,19 @@ updated by tools).
 | `AGENT_STARTING` | `"You are a helpful agent..."` |
 | `AGENT_COMPLETED` | `{}` |
 | `USER_MESSAGE_RECEIVED` | `{"text_summary": "Help me book a flight."}` |
-| `AGENT_RESPONSE` | `{"response_text": "Here are the flights...", "source_event_id": "...", "source_event_author": "flight_agent", "source_event_branch": "main"}` |
+| `AGENT_RESPONSE` | `{"response": "Here are the flights..."}` |
 
 **AGENT_RESPONSE**
 
-Logged when the agent yields a final response to the user. Captures the response text along with metadata about the source event that produced it.
+Logged when the agent yields a final response to the user. The response text is stored in `content`, while the source event metadata is stored in `attributes`.
 
 ```json
 {
   "event_type": "AGENT_RESPONSE",
   "content": {
-    "response_text": "Here are the available flights...",
+    "response": "Here are the available flights..."
+  },
+  "attributes": {
     "source_event_id": "evt-abc123",
     "source_event_author": "flight_agent",
     "source_event_branch": "main"


### PR DESCRIPTION
## Summary

The BigQuery Agent Analytics plugin now logs an `AGENT_RESPONSE` event when the agent yields a final response to the user, with a corresponding `v_agent_response` view. This PR adds the missing documentation.

- Add `AGENT_RESPONSE` to the captured events summary table
- Add `v_agent_response` view row with columns: `response_text` (STRING), `source_event_id` (STRING), `source_event_author` (STRING), `source_event_branch` (STRING)
- Update auto-created view count from 16 to 17
- Add event type documentation with JSON payload example under "Agent lifecycle & Generic Events"

Reviewed against `adk-python@main` (2026-05-12).

## Test plan
- [ ] Captured events table renders with the new AGENT_RESPONSE row
- [ ] Views table renders with v_agent_response row and correct column list
- [ ] View count reads "17 auto-created views"
- [ ] AGENT_RESPONSE payload example renders correctly under Agent lifecycle