### PR TITLE
Fix RunConfig docs: correct import path and add missing fields

### DIFF
--- a/docs/runtime/runconfig.md
+++ b/docs/runtime/runconfig.md
@@ -1,459 +1,12 @@
 # Runtime Configuration
 
 <div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span>
 </div>
 
-`RunConfig` defines runtime behavior and options for agents in ADK. It controls
-speech and streaming settings, function calling, artifact saving, and limits on
-LLM calls.
-
-When constructing an agent run, you can pass a `RunConfig` to customize how the
-agent interacts with models, handles audio, and streams responses. By default,
-no streaming is enabled and inputs aren’t retained as artifacts. Use `RunConfig`
-to override these defaults.
-
-## Class Definition
-
-The `RunConfig` class holds configuration parameters for an agent's runtime behavior.
-
--   Python ADK uses Pydantic for this validation.
--   Go ADK has mutable structs by default.
--   Java ADK typically uses immutable data classes.
-
-
-- TypeScript ADK uses a standard interface, with type safety provided by the TypeScript compiler.
-
-=== "Python"
-
-    ```python
-    class RunConfig(BaseModel):
-        """Configs for runtime behavior of agents."""
-
-        model_config = ConfigDict(
-            extra='forbid',
-        )
-
-        speech_config: Optional[types.SpeechConfig] = None
-        response_modalities: Optional[list[str]] = None
-        avatar_config: Optional[types.AvatarConfig] = None
-        save_input_blobs_as_artifacts: bool = False  # DEPRECATED: use SaveFilesAsArtifactsPlugin
-        support_cfc: bool = False
-        streaming_mode: StreamingMode = StreamingMode.NONE
-        output_audio_transcription: Optional[types.AudioTranscriptionConfig] = Field(
-            default_factory=types.AudioTranscriptionConfig
-        )
-        input_audio_transcription: Optional[types.AudioTranscriptionConfig] = Field(
-            default_factory=types.AudioTranscriptionConfig
-        )
-        realtime_input_config: Optional[types.RealtimeInputConfig] = None
-        enable_affective_dialog: Optional[bool] = None
-        proactivity: Optional[types.ProactivityConfig] = None
-        session_resumption: Optional[types.SessionResumptionConfig] = None
-        context_window_compression: Optional[types.ContextWindowCompressionConfig] = None
-        save_live_blob: bool = False
-        tool_thread_pool_config: Optional[ToolThreadPoolConfig] = None
-        max_llm_calls: int = 500
-        custom_metadata: Optional[dict[str, Any]] = None
-        get_session_config: Optional[GetSessionConfig] = None
-    ```
-
-=== "TypeScript"
-
-    ```typescript
-    export interface RunConfig {
-      speechConfig?: SpeechConfig;
-      responseModalities?: Modality[];
-      saveInputBlobsAsArtifacts: boolean;
-      supportCfc: boolean;
-      streamingMode: StreamingMode;
-      outputAudioTranscription?: AudioTranscriptionConfig;
-      maxLlmCalls: number;
-      // ... and other properties
-    }
-
-    export enum StreamingMode {
-      NONE = 'none',
-      SSE = 'sse',
-      BIDI = 'bidi',
-    }
-    ```
-
-=== "Go"
-
-    ```go
-    type StreamingMode string
-
-    const (
-    	StreamingModeNone StreamingMode = "none"
-    	StreamingModeSSE  StreamingMode = "sse"
-    )
-
-    // RunConfig controls runtime behavior.
-    type RunConfig struct {
-    	// Streaming mode, None or StreamingMode.SSE.
-    	StreamingMode StreamingMode
-    	// Whether or not to save the input blobs as artifacts
-    	SaveInputBlobsAsArtifacts bool
-    }
-    ```
-
-=== "Java"
-
-    ```java
-    public abstract class RunConfig {
-
-      public enum StreamingMode {
-        NONE,
-        SSE,
-        BIDI
-      }
-
-      public abstract @Nullable SpeechConfig speechConfig();
-
-      public abstract ImmutableList<Modality> responseModalities();
-
-      public abstract boolean saveInputBlobsAsArtifacts();
-
-      public abstract @Nullable AudioTranscriptionConfig outputAudioTranscription();
-
-      public abstract int maxLlmCalls();
-
-      // ...
-    }
-    ```
-
-## Runtime Parameters
-
-| Parameter                       | Python Type                                  | TypeScript Type                       | Go Type         | Java Type                                             | Default (Py / TS / Go / Java)                                                                  | Description                                                                                                                                                 |
-| :------------------------------ | :------------------------------------------- | :------------------------------------ |:----------------|:------------------------------------------------------| :--------------------------------------------------------------------------------------------- |:------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `speech_config`                 | `Optional[types.SpeechConfig]`               | `SpeechConfig` (optional)             | N/A             | `SpeechConfig` (nullable via `@Nullable`)             | `None` / `undefined`/ N/A / `null`                                                             | Configures speech synthesis (voice, language) using the `SpeechConfig` type.                                                                                |
-| `response_modalities`           | `Optional[list[str]]`                        | `Modality[]` (optional)               | N/A             | `ImmutableList<Modality>`                             | `None` / `undefined` / N/A / Empty `ImmutableList`                                             | List of desired output modalities (e.g., Python: `["TEXT", "AUDIO"]`; Java/TS: uses structured `Modality` objects).                                         |
-| `save_input_blobs_as_artifacts` | `bool`                                       | `boolean`                             | `bool`          | `boolean`                                             | `False` / `false` / `false` / `false`                                                          | If `true`, saves input blobs (e.g., uploaded files) as run artifacts for debugging/auditing.                                                                |
-| `streaming_mode`                | `StreamingMode`                              | `StreamingMode`                       | `StreamingMode` | `StreamingMode`                                       | `StreamingMode.NONE` / `StreamingMode.NONE` / `agent.StreamingModeNone` / `StreamingMode.NONE` | Sets the streaming behavior: `NONE` (default), `SSE` (server-sent events), or `BIDI` (bidirectional).                                                       |
-| `output_audio_transcription`    | `Optional[types.AudioTranscriptionConfig]`   | `AudioTranscriptionConfig` (optional) | N/A             | `AudioTranscriptionConfig` (nullable via `@Nullable`) | `AudioTranscriptionConfig()` / `undefined` / N/A / `null`                                      | Configures transcription of generated audio output using the `AudioTranscriptionConfig` type.                                                               |
-| `max_llm_calls`                 | `int`                                        | `number`                              | N/A             | `int`                                                 | `500` / `500` / N/A / `500`                                                                    | Limits total LLM calls per run. `0` or negative means unlimited. Exceeding language limits (e.g. `sys.maxsize`, `Number.MAX_SAFE_INTEGER`) raises an error. |
-| `support_cfc`                   | `bool`                                       | `boolean`                             | N/A             | `bool`                                                | `False` / `false` / N/A / `false`                                                              | **Python/TypeScript:** Enables Compositional Function Calling. Requires `streaming_mode=SSE` and uses the LIVE API. **Experimental.**                       |
-| `avatar_config`                 | `Optional[types.AvatarConfig]`               | N/A                                   | N/A             | N/A                                                   | `None`                                                                                         | Avatar configuration for live agents.                                                                                                                       |
-| `input_audio_transcription`     | `Optional[types.AudioTranscriptionConfig]`   | N/A                                   | N/A             | N/A                                                   | `AudioTranscriptionConfig()`                                                                   | Configures transcription of audio input from the user in live agents.                                                                                       |
-| `realtime_input_config`         | `Optional[types.RealtimeInputConfig]`        | N/A                                   | N/A             | N/A                                                   | `None`                                                                                         | Realtime input configuration for live agents with audio input.                                                                                              |
-| `enable_affective_dialog`       | `Optional[bool]`                             | N/A                                   | N/A             | N/A                                                   | `None`                                                                                         | When enabled, the model detects emotions and adapts its responses accordingly.                                                                               |
-| `proactivity`                   | `Optional[types.ProactivityConfig]`          | N/A                                   | N/A             | N/A                                                   | `None`                                                                                         | Configures model proactivity — allows the model to respond proactively and ignore irrelevant input.                                                          |
-| `session_resumption`            | `Optional[types.SessionResumptionConfig]`    | N/A                                   | N/A             | N/A                                                   | `None`                                                                                         | Configures transparent session resumption. Only transparent mode is currently supported.                                                                    |
-| `context_window_compression`    | `Optional[types.ContextWindowCompressionConfig]` | N/A                                | N/A             | N/A                                                   | `None`                                                                                         | Enables context window compression for LLM input when set.                                                                                                  |
-| `save_live_blob`                | `bool`                                       | N/A                                   | N/A             | N/A                                                   | `False`                                                                                        | Saves live video and audio data to the session and artifact service.                                                                                         |
-| `tool_thread_pool_config`       | `Optional[ToolThreadPoolConfig]`             | N/A                                   | N/A             | N/A                                                   | `None`                                                                                         | Runs tools in a thread pool in live mode to keep the event loop responsive for user interruptions. See `ToolThreadPoolConfig`.                               |
-| `custom_metadata`               | `Optional[dict[str, Any]]`                   | N/A                                   | N/A             | N/A                                                   | `None`                                                                                         | Arbitrary custom metadata attached to the current invocation.                                                                                                |
-| `get_session_config`            | `Optional[GetSessionConfig]`                 | N/A                                   | N/A             | N/A                                                   | `None`                                                                                         | Controls which events are fetched when loading a session (e.g. `num_recent_events`). Useful with `EventsCompactionConfig`.                                  |
-
-
-### `speech_config`
-
-<div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-java">Java v0.1.0</span>
-</div>
-
-!!! Note
-    The interface or definition of `SpeechConfig` is the same, irrespective of the language.
-
-Speech configuration settings for live agents with audio capabilities. The
-`SpeechConfig` class has the following structure:
-
-```python
-class SpeechConfig(_common.BaseModel):
-    """The speech generation configuration."""
-
-    voice_config: Optional[VoiceConfig] = Field(
-        default=None,
-        description="""The configuration for the speaker to use.""",
-    )
-    language_code: Optional[str] = Field(
-        default=None,
-        description="""Language code (ISO 639. e.g. en-US) for the speech synthesization.
-        Only available for Live API.""",
-    )
-```
-
-The `voice_config` parameter uses the `VoiceConfig` class:
-
-```python
-class VoiceConfig(_common.BaseModel):
-    """The configuration for the voice to use."""
-
-    prebuilt_voice_config: Optional[PrebuiltVoiceConfig] = Field(
-        default=None,
-        description="""The configuration for the speaker to use.""",
-    )
-```
-
-And `PrebuiltVoiceConfig` has the following structure:
-
-```python
-class PrebuiltVoiceConfig(_common.BaseModel):
-    """The configuration for the prebuilt speaker to use."""
-
-    voice_name: Optional[str] = Field(
-        default=None,
-        description="""The name of the prebuilt voice to use.""",
-    )
-```
-
-These nested configuration classes allow you to specify:
-
-* `voice_config`: The name of the prebuilt voice to use (in the `PrebuiltVoiceConfig`)
-* `language_code`: ISO 639 language code (e.g., "en-US") for speech synthesis
-
-When implementing voice-enabled agents, configure these parameters to control
-how your agent sounds when speaking.
-
-### `response_modalities`
-
-<div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-java">Java v0.1.0</span>
-</div>
-
-Defines the output modalities for the agent. If not set, defaults to AUDIO.
-Response modalities determine how the agent communicates with users through
-various channels (e.g., text, audio).
-
-### `save_input_blobs_as_artifacts`
-
-<div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span>
-</div>
-
-!!! warning "Deprecated"
-    `save_input_blobs_as_artifacts` is deprecated. Use `SaveFilesAsArtifactsPlugin` instead for better control and flexibility. See `google.adk.plugins.SaveFilesAsArtifactsPlugin`.
-
-When enabled, input blobs will be saved as artifacts during agent execution.
-This is useful for debugging and audit purposes, allowing developers to review
-the exact data received by agents.
-
-### `support_cfc`
-
-<div class="language-support-tag" title="This feature is an experimental preview release.">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-preview">Experimental</span>
-</div>
-
-Enables Compositional Function Calling (CFC) support. Only applicable when using
-StreamingMode.SSE. When enabled, the LIVE API will be invoked as only it
-supports CFC functionality.
-
-!!! example "Experimental release"
-
-    The `support_cfc` feature is experimental and its API or behavior might
-    change in future releases.
-
-### `streaming_mode`
-
-<div class="language-support-tag" title="This feature is an experimental preview release.">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-go">Go v0.1.0</span>
-</div>
-
-Configures the streaming behavior of the agent. Possible values:
-
-* `StreamingMode.NONE`: No streaming; responses delivered as complete units
-* `StreamingMode.SSE`: Server-Sent Events streaming; one-way streaming from server to client
-* `StreamingMode.BIDI`: Reserved for bidirectional streaming. **Not currently used** in the standard `run_async()` execution path. For real bidirectional streaming, use `runner.run_live()` instead.
-
-Streaming modes affect both performance and user experience. SSE streaming lets users see partial responses as they're generated.
-
-### `output_audio_transcription`
-
-<div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-java">Java v0.1.0</span>
-</div>
-
-Configuration for transcribing audio outputs from live agents with audio
-response capability. This enables automatic transcription of audio responses for
-accessibility, record-keeping, and multi-modal applications.
-
-### `max_llm_calls`
-
-<div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-java">Java v0.1.0</span>
-</div>
-
-Sets a limit on the total number of LLM calls for a given agent run.
-
-* Values greater than 0 and less than `sys.maxsize`: Enforces a bound on LLM calls
-* Values less than or equal to 0: Allows unbounded LLM calls *(not recommended for production)*
-
-This parameter prevents excessive API usage and potential runaway processes.
-Since LLM calls often incur costs and consume resources, setting appropriate
-limits is crucial.
-
-### `input_audio_transcription`
-
-<div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
-</div>
-
-Configures transcription of audio input received from the user in live agents.
-Defaults to an `AudioTranscriptionConfig()` instance.
-
-### `realtime_input_config`
-
-<div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
-</div>
-
-Provides realtime input configuration for live agents that accept audio from users.
-
-### `enable_affective_dialog`
-
-<div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
-</div>
-
-When set to `True`, the model detects user emotions from the conversation and adapts its tone and responses accordingly.
-
-### `proactivity`
-
-<div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
-</div>
-
-Configures the proactivity of the model using `types.ProactivityConfig`. Allows the model to respond proactively to input and ignore irrelevant messages.
-
-### `session_resumption`
-
-<div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
-</div>
-
-Configures session resumption via `types.SessionResumptionConfig`. Only transparent session resumption mode is currently supported.
-
-### `context_window_compression`
-
-<div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
-</div>
-
-When set, enables context window compression for LLM input using `types.ContextWindowCompressionConfig`. Useful for long-running sessions that approach model context limits.
-
-### `save_live_blob`
-
-<div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
-</div>
-
-When `True`, saves live video and audio data to the session and artifact service. Replaces the deprecated `save_live_audio` field.
-
-### `tool_thread_pool_config`
-
-<div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
-</div>
-
-When set, tool executions in live mode run in a background thread pool instead of the main event loop. This keeps the event loop responsive to user interruptions and incoming model events.
-
-```python
-from google.adk.agents.run_config import RunConfig, ToolThreadPoolConfig
-
-# Default thread pool (4 workers)
-run_config = RunConfig(
-    tool_thread_pool_config=ToolThreadPoolConfig(),
-)
-
-# Custom thread pool
-run_config = RunConfig(
-    tool_thread_pool_config=ToolThreadPoolConfig(max_workers=8),
-)
-```
-
-!!! note "GIL considerations"
-    Thread pools help with blocking I/O and C extensions that release the GIL (e.g. `time.sleep()`, network calls, numpy). They do **not** help with pure Python CPU-bound code since the GIL prevents true parallel execution of Python bytecode.
-
-### `custom_metadata`
-
-<div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
-</div>
-
-A `dict[str, Any]` of arbitrary metadata attached to the current invocation. Useful for tracing or logging custom context alongside agent runs.
-
-### `get_session_config`
-
-<div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
-</div>
-
-Controls which events are fetched when loading a session. Accepts a `GetSessionConfig` instance (e.g. `num_recent_events`, `after_timestamp`). Especially useful in combination with `EventsCompactionConfig` to avoid loading the full event history on every invocation.
-
-```python
-from google.adk.agents.run_config import RunConfig
-from google.adk.sessions.base_session_service import GetSessionConfig
-
-run_config = RunConfig(
-    get_session_config=GetSessionConfig(num_recent_events=50),
-)
-```
-
-## Validation Rules
-
-<div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span>
-</div>
-
-The `RunConfig` class validates its parameters to ensure proper agent operation. While Python ADK uses `Pydantic` for automatic type validation, Java and TypeScript ADK rely on their static type systems and may include explicit checks in the `RunConfig`'s constructor.
-For the `max_llm_calls` parameter specifically:
-
-1. Extremely large values (like `sys.maxsize` in Python, `Integer.MAX_VALUE` in Java, or `Number.MAX_SAFE_INTEGER` in TypeScript) are typically disallowed to prevent issues.
-
-2. Values of zero or less will usually trigger a warning about unlimited LLM interactions.
-
-### Basic runtime configuration
-
-=== "Python"
-
-    ```python
-    from google.adk.agents.run_config import RunConfig, StreamingMode
-
-    config = RunConfig(
-        streaming_mode=StreamingMode.NONE,
-        max_llm_calls=100
-    )
-    ```
-
-=== "TypeScript"
-
-    ```typescript
-    import { RunConfig, StreamingMode } from '@google/adk';
-
-    const config: RunConfig = {
-      streamingMode: StreamingMode.NONE,
-      maxLlmCalls: 100,
-    };
-    ```
-
-=== "Go"
-
-    ```go
-    import "google.golang.org/adk/agent"
-
-    config := agent.RunConfig{
-        StreamingMode: agent.StreamingModeNone,
-    }
-    ```
-
-=== "Java"
-
-    ```java
-    import com.google.adk.agents.RunConfig;
-    import com.google.adk.agents.RunConfig.StreamingMode;
-
-    RunConfig config = RunConfig.builder()
-            .setStreamingMode(StreamingMode.NONE)
-            .setMaxLlmCalls(100)
-            .build();
-    ```
-
-This configuration creates a non-streaming agent with a limit of 100 LLM calls,
-suitable for simple task-oriented agents where complete responses are
-preferable.
-
-### Enabling streaming
+`RunConfig` controls how agents behave at runtime, including streaming mode,
+speech settings, LLM call limits, and live agent options. Pass a `RunConfig`
+to `runner.run_async()` or `runner.run_live()` to override default behavior.
 
 === "Python"
 
@@ -462,8 +15,14 @@ preferable.
 
     config = RunConfig(
         streaming_mode=StreamingMode.SSE,
-        max_llm_calls=200
+        max_llm_calls=200,
     )
+
+    async for event in runner.run_async(
+        ...,
+        run_config=config,
+    ):
+        ...
     ```
 
 === "TypeScript"
@@ -494,110 +53,57 @@ preferable.
     import com.google.adk.agents.RunConfig.StreamingMode;
 
     RunConfig config = RunConfig.builder()
-        .setStreamingMode(StreamingMode.SSE)
-        .setMaxLlmCalls(200)
+        .streamingMode(StreamingMode.SSE)
+        .maxLlmCalls(200)
         .build();
     ```
 
-Using SSE streaming allows users to see responses as they're generated,
-providing a more responsive feel for chatbots and assistants.
+## Manage sessions and context
 
-### Enabling speech support
+<div class="language-support-tag">
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
+</div>
+
+For long-running sessions, you can control how much history is loaded and
+whether the context window is compressed:
+
+- `get_session_config`: Limits which events are fetched when loading a session.
+  Use `num_recent_events` or `after_timestamp` to avoid loading the full event
+  history on every invocation.
+- `context_window_compression`: Enables context window compression for LLM
+  input, useful when sessions approach model context limits.
 
 === "Python"
 
     ```python
-    from google.adk.agents.run_config import RunConfig, StreamingMode
-    from google.genai import types
+    from google.adk.agents.run_config import RunConfig
+    from google.adk.sessions.base_session_service import GetSessionConfig
 
-    # To save input blobs as artifacts, register SaveFilesAsArtifactsPlugin
-    # on the runner instead of using the deprecated save_input_blobs_as_artifacts flag.
     config = RunConfig(
-        speech_config=types.SpeechConfig(
-            language_code="en-US",
-            voice_config=types.VoiceConfig(
-                prebuilt_voice_config=types.PrebuiltVoiceConfig(
-                    voice_name="Kore"
-                )
-            ),
-        ),
-        response_modalities=["AUDIO", "TEXT"],
-        support_cfc=True,
-        streaming_mode=StreamingMode.SSE,
-        max_llm_calls=1000,
+        get_session_config=GetSessionConfig(num_recent_events=50),
     )
     ```
 
-=== "TypeScript"
+## Enable streaming
 
-    ```typescript
-    import { RunConfig, StreamingMode } from '@google/adk';
+To control how the agent delivers responses, set the `streaming_mode` parameter:
 
-    const config: RunConfig = {
-        speechConfig: {
-            languageCode: "en-US",
-            voiceConfig: {
-                prebuiltVoiceConfig: {
-                    voiceName: "Kore"
-                }
-            },
-        },
-        responseModalities: [
-          { modality: "AUDIO" },
-          { modality: "TEXT" }
-        ],
-        saveInputBlobsAsArtifacts: true,
-        supportCfc: true,
-        streamingMode: StreamingMode.SSE,
-        maxLlmCalls: 1000,
-    };
-    ```
+- **`StreamingMode.NONE`** (default): The runner returns one complete response
+  per turn. Suitable for CLI tools, batch processing, and synchronous workflows.
+- **`StreamingMode.SSE`**: Server-Sent Events streaming. The runner yields
+  partial events as the LLM generates, enabling typewriter-style UIs and
+  real-time chat displays.
+- **`StreamingMode.BIDI`**: Reserved for bidirectional streaming, but **not
+  used** in the standard `run_async()` path. For bidirectional streaming, use
+  `runner.run_live()` instead.
 
-=== "Java"
+Set `support_cfc=True` alongside `StreamingMode.SSE` to enable Compositional
+Function Calling (CFC), which allows the model to dynamically compose and
+execute function calls. CFC uses the Live API under the hood.
 
-    ```java
-    import com.google.adk.agents.RunConfig;
-    import com.google.adk.agents.RunConfig.StreamingMode;
-    import com.google.common.collect.ImmutableList;
-    import com.google.genai.types.Content;
-    import com.google.genai.types.Modality;
-    import com.google.genai.types.Part;
-    import com.google.genai.types.PrebuiltVoiceConfig;
-    import com.google.genai.types.SpeechConfig;
-    import com.google.genai.types.VoiceConfig;
-
-    RunConfig runConfig =
-        RunConfig.builder()
-            .setStreamingMode(StreamingMode.SSE)
-            .setMaxLlmCalls(1000)
-            .setSaveInputBlobsAsArtifacts(true)
-            .setResponseModalities(ImmutableList.of(new Modality("AUDIO"), new Modality("TEXT")))
-            .setSpeechConfig(
-                SpeechConfig.builder()
-                    .voiceConfig(
-                        VoiceConfig.builder()
-                            .prebuiltVoiceConfig(
-                                PrebuiltVoiceConfig.builder().voiceName("Kore").build())
-                            .build())
-                    .languageCode("en-US")
-                    .build())
-            .build();
-    ```
-
-This comprehensive example configures an agent with:
-
-* Speech capabilities using the "Kore" voice (US English)
-* Both audio and text output modalities
-* Artifact saving for input blobs in TypeScript/Java (in Python, prefer `SaveFilesAsArtifactsPlugin`)
-* Experimental CFC support enabled **(Python and TypeScript)**
-* SSE streaming for responsive interaction
-* A limit of 1000 LLM calls
-
-### Enabling CFC Support
-
-<div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-preview">Experimental</span>
-</div>
+!!! example "Experimental"
+    CFC support is experimental and its API or behavior may change in future
+    releases.
 
 === "Python"
 
@@ -607,7 +113,7 @@ This comprehensive example configures an agent with:
     config = RunConfig(
         streaming_mode=StreamingMode.SSE,
         support_cfc=True,
-        max_llm_calls=150
+        max_llm_calls=150,
     )
     ```
 
@@ -623,11 +129,188 @@ This comprehensive example configures an agent with:
     };
     ```
 
-Enabling Compositional Function Calling (CFC) creates an agent that can
-dynamically execute functions based on model outputs, powerful for applications
-requiring complex workflows.
+=== "Go"
 
-!!! example "Experimental release"
+    ```go
+    import "google.golang.org/adk/agent"
 
-    The Compositional Function Calling (CFC) streaming feature is an
-    experimental release.
+    config := agent.RunConfig{
+        StreamingMode: agent.StreamingModeSSE,
+    }
+    ```
+
+=== "Java"
+
+    ```java
+    import com.google.adk.agents.RunConfig;
+    import com.google.adk.agents.RunConfig.StreamingMode;
+
+    RunConfig config = RunConfig.builder()
+        .streamingMode(StreamingMode.SSE)
+        .maxLlmCalls(150)
+        .build();
+    ```
+
+## Configure audio and speech
+
+<div class="language-support-tag">
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span><span class="lst-typescript">TypeScript</span><span class="lst-java">Java</span>
+</div>
+
+For voice-enabled agents, configure speech synthesis, audio transcription, and
+response modalities.
+
+- `speech_config`: Sets the voice and language for speech output (e.g., the
+  "Kore" voice with `en-US`).
+- `response_modalities`: Controls output formats. Set to `["AUDIO", "TEXT"]` for
+  agents that both speak and return text.
+- `output_audio_transcription` / `input_audio_transcription`: Enable
+  transcription of audio output from the model and audio input from the user.
+  Both default to `AudioTranscriptionConfig()` in Python.
+
+=== "Python"
+
+    ```python
+    from google.adk.agents.run_config import RunConfig, StreamingMode
+    from google.genai import types
+
+    config = RunConfig(
+        speech_config=types.SpeechConfig(
+            language_code="en-US",
+            voice_config=types.VoiceConfig(
+                prebuilt_voice_config=types.PrebuiltVoiceConfig(
+                    voice_name="Kore"
+                )
+            ),
+        ),
+        response_modalities=["AUDIO", "TEXT"],
+        streaming_mode=StreamingMode.SSE,
+        max_llm_calls=1000,
+    )
+    ```
+
+=== "TypeScript"
+
+    ```typescript
+    import { RunConfig, StreamingMode } from '@google/adk';
+    import { Modality } from '@google/genai';
+
+    const config: RunConfig = {
+        speechConfig: {
+            languageCode: "en-US",
+            voiceConfig: {
+                prebuiltVoiceConfig: {
+                    voiceName: "Kore"
+                }
+            },
+        },
+        responseModalities: [Modality.AUDIO, Modality.TEXT],
+        streamingMode: StreamingMode.SSE,
+        maxLlmCalls: 1000,
+    };
+    ```
+
+=== "Java"
+
+    ```java
+    import com.google.adk.agents.RunConfig;
+    import com.google.adk.agents.RunConfig.StreamingMode;
+    import com.google.common.collect.ImmutableList;
+    import com.google.genai.types.Modality;
+    import com.google.genai.types.PrebuiltVoiceConfig;
+    import com.google.genai.types.SpeechConfig;
+    import com.google.genai.types.VoiceConfig;
+
+    RunConfig runConfig =
+        RunConfig.builder()
+            .streamingMode(StreamingMode.SSE)
+            .maxLlmCalls(1000)
+            .responseModalities(ImmutableList.of(new Modality(Modality.Known.AUDIO), new Modality(Modality.Known.TEXT)))
+            .speechConfig(
+                SpeechConfig.builder()
+                    .voiceConfig(
+                        VoiceConfig.builder()
+                            .prebuiltVoiceConfig(
+                                PrebuiltVoiceConfig.builder().voiceName("Kore").build())
+                            .build())
+                    .languageCode("en-US")
+                    .build())
+            .build();
+    ```
+
+## Configure live agents
+
+<div class="language-support-tag">
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span><span class="lst-typescript">TypeScript</span>
+</div>
+
+When using `runner.run_live()`, configure real-time behavior with these
+additional parameters:
+
+- `realtime_input_config`: Configures how audio input is received from users.
+- `proactivity`: Allows the model to respond proactively and ignore irrelevant
+  input.
+- `enable_affective_dialog`: When `True`, the model detects user emotions and
+  adapts its tone accordingly.
+- `avatar_config`: Configures an avatar for live agents.
+- `session_resumption`: Enables transparent session resumption across
+  disconnects.
+- `save_live_blob`: When `True`, saves live audio and video data to the session
+  and artifact service.
+- `tool_thread_pool_config`: Runs tool executions in a background thread pool
+  to keep the event loop responsive to user interruptions.
+
+Not all parameters are available in every language. See the
+[API reference](#api-reference) for language-specific details.
+
+=== "Python"
+
+    ```python
+    from google.adk.agents.run_config import RunConfig, ToolThreadPoolConfig
+
+    config = RunConfig(
+        save_live_blob=True,
+        tool_thread_pool_config=ToolThreadPoolConfig(max_workers=8),
+    )
+    ```
+
+    !!! note "Thread pool and the GIL"
+        Thread pools help with blocking I/O and C extensions that release the
+        GIL (e.g. `time.sleep()`, network calls, numpy). They do **not** help
+        with pure Python CPU-bound code since the GIL prevents true parallel
+        execution of Python bytecode.
+
+=== "TypeScript"
+
+    ```typescript
+    import { RunConfig } from '@google/adk';
+
+    const config: RunConfig = {
+        enableAffectiveDialog: true,
+        proactivity: {
+            proactiveAudio: true,
+        },
+    };
+    ```
+
+## Configure runtime limits and debugging
+
+Use these parameters to control runtime guardrails and debugging:
+
+- `max_llm_calls`: Caps the total number of LLM calls per run (default: 500).
+  Set to 0 or negative for unlimited calls, though this is not recommended for
+  production. Values at or above `sys.maxsize` raise an error.
+- `save_input_blobs_as_artifacts`: When `True`, saves input blobs (e.g.,
+  uploaded files) as run artifacts for debugging and auditing.
+- `custom_metadata`: A `dict[str, Any]` of arbitrary metadata attached to the
+  invocation, useful for tracing or logging.
+
+## API reference
+
+For the complete list of fields, types, and defaults, see the API reference for
+your language:
+
+- [Python API reference](../api-reference/python/google-adk.html#google.adk.agents.RunConfig)
+- [TypeScript API reference](../api-reference/typescript/interfaces/RunConfig.html)
+- [Go API reference](https://pkg.go.dev/google.golang.org/adk/agent#RunConfig)
+- [Java API reference](../api-reference/java/com/google/adk/agents/RunConfig.html)

--- a/docs/runtime/runconfig.md
+++ b/docs/runtime/runconfig.md
@@ -36,11 +36,26 @@ The `RunConfig` class holds configuration parameters for an agent's runtime beha
 
         speech_config: Optional[types.SpeechConfig] = None
         response_modalities: Optional[list[str]] = None
-        save_input_blobs_as_artifacts: bool = False
+        avatar_config: Optional[types.AvatarConfig] = None
+        save_input_blobs_as_artifacts: bool = False  # DEPRECATED: use SaveFilesAsArtifactsPlugin
         support_cfc: bool = False
         streaming_mode: StreamingMode = StreamingMode.NONE
-        output_audio_transcription: Optional[types.AudioTranscriptionConfig] = None
+        output_audio_transcription: Optional[types.AudioTranscriptionConfig] = Field(
+            default_factory=types.AudioTranscriptionConfig
+        )
+        input_audio_transcription: Optional[types.AudioTranscriptionConfig] = Field(
+            default_factory=types.AudioTranscriptionConfig
+        )
+        realtime_input_config: Optional[types.RealtimeInputConfig] = None
+        enable_affective_dialog: Optional[bool] = None
+        proactivity: Optional[types.ProactivityConfig] = None
+        session_resumption: Optional[types.SessionResumptionConfig] = None
+        context_window_compression: Optional[types.ContextWindowCompressionConfig] = None
+        save_live_blob: bool = False
+        tool_thread_pool_config: Optional[ToolThreadPoolConfig] = None
         max_llm_calls: int = 500
+        custom_metadata: Optional[dict[str, Any]] = None
+        get_session_config: Optional[GetSessionConfig] = None
     ```
 
 === "TypeScript"
@@ -116,9 +131,20 @@ The `RunConfig` class holds configuration parameters for an agent's runtime beha
 | `response_modalities`           | `Optional[list[str]]`                        | `Modality[]` (optional)               | N/A             | `ImmutableList<Modality>`                             | `None` / `undefined` / N/A / Empty `ImmutableList`                                             | List of desired output modalities (e.g., Python: `["TEXT", "AUDIO"]`; Java/TS: uses structured `Modality` objects).                                         |
 | `save_input_blobs_as_artifacts` | `bool`                                       | `boolean`                             | `bool`          | `boolean`                                             | `False` / `false` / `false` / `false`                                                          | If `true`, saves input blobs (e.g., uploaded files) as run artifacts for debugging/auditing.                                                                |
 | `streaming_mode`                | `StreamingMode`                              | `StreamingMode`                       | `StreamingMode` | `StreamingMode`                                       | `StreamingMode.NONE` / `StreamingMode.NONE` / `agent.StreamingModeNone` / `StreamingMode.NONE` | Sets the streaming behavior: `NONE` (default), `SSE` (server-sent events), or `BIDI` (bidirectional).                                                       |
-| `output_audio_transcription`    | `Optional[types.AudioTranscriptionConfig]`   | `AudioTranscriptionConfig` (optional) | N/A             | `AudioTranscriptionConfig` (nullable via `@Nullable`) | `None` / `undefined` / N/A / `null`                                                            | Configures transcription of generated audio output using the `AudioTranscriptionConfig` type.                                                               |
+| `output_audio_transcription`    | `Optional[types.AudioTranscriptionConfig]`   | `AudioTranscriptionConfig` (optional) | N/A             | `AudioTranscriptionConfig` (nullable via `@Nullable`) | `AudioTranscriptionConfig()` / `undefined` / N/A / `null`                                      | Configures transcription of generated audio output using the `AudioTranscriptionConfig` type.                                                               |
 | `max_llm_calls`                 | `int`                                        | `number`                              | N/A             | `int`                                                 | `500` / `500` / N/A / `500`                                                                    | Limits total LLM calls per run. `0` or negative means unlimited. Exceeding language limits (e.g. `sys.maxsize`, `Number.MAX_SAFE_INTEGER`) raises an error. |
 | `support_cfc`                   | `bool`                                       | `boolean`                             | N/A             | `bool`                                                | `False` / `false` / N/A / `false`                                                              | **Python/TypeScript:** Enables Compositional Function Calling. Requires `streaming_mode=SSE` and uses the LIVE API. **Experimental.**                       |
+| `avatar_config`                 | `Optional[types.AvatarConfig]`               | N/A                                   | N/A             | N/A                                                   | `None`                                                                                         | Avatar configuration for live agents.                                                                                                                       |
+| `input_audio_transcription`     | `Optional[types.AudioTranscriptionConfig]`   | N/A                                   | N/A             | N/A                                                   | `AudioTranscriptionConfig()`                                                                   | Configures transcription of audio input from the user in live agents.                                                                                       |
+| `realtime_input_config`         | `Optional[types.RealtimeInputConfig]`        | N/A                                   | N/A             | N/A                                                   | `None`                                                                                         | Realtime input configuration for live agents with audio input.                                                                                              |
+| `enable_affective_dialog`       | `Optional[bool]`                             | N/A                                   | N/A             | N/A                                                   | `None`                                                                                         | When enabled, the model detects emotions and adapts its responses accordingly.                                                                               |
+| `proactivity`                   | `Optional[types.ProactivityConfig]`          | N/A                                   | N/A             | N/A                                                   | `None`                                                                                         | Configures model proactivity — allows the model to respond proactively and ignore irrelevant input.                                                          |
+| `session_resumption`            | `Optional[types.SessionResumptionConfig]`    | N/A                                   | N/A             | N/A                                                   | `None`                                                                                         | Configures transparent session resumption. Only transparent mode is currently supported.                                                                    |
+| `context_window_compression`    | `Optional[types.ContextWindowCompressionConfig]` | N/A                                | N/A             | N/A                                                   | `None`                                                                                         | Enables context window compression for LLM input when set.                                                                                                  |
+| `save_live_blob`                | `bool`                                       | N/A                                   | N/A             | N/A                                                   | `False`                                                                                        | Saves live video and audio data to the session and artifact service.                                                                                         |
+| `tool_thread_pool_config`       | `Optional[ToolThreadPoolConfig]`             | N/A                                   | N/A             | N/A                                                   | `None`                                                                                         | Runs tools in a thread pool in live mode to keep the event loop responsive for user interruptions. See `ToolThreadPoolConfig`.                               |
+| `custom_metadata`               | `Optional[dict[str, Any]]`                   | N/A                                   | N/A             | N/A                                                   | `None`                                                                                         | Arbitrary custom metadata attached to the current invocation.                                                                                                |
+| `get_session_config`            | `Optional[GetSessionConfig]`                 | N/A                                   | N/A             | N/A                                                   | `None`                                                                                         | Controls which events are fetched when loading a session (e.g. `num_recent_events`). Useful with `EventsCompactionConfig`.                                  |
 
 
 ### `speech_config`
@@ -196,6 +222,9 @@ various channels (e.g., text, audio).
     <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span>
 </div>
 
+!!! warning "Deprecated"
+    `save_input_blobs_as_artifacts` is deprecated. Use `SaveFilesAsArtifactsPlugin` instead for better control and flexibility. See `google.adk.plugins.SaveFilesAsArtifactsPlugin`.
+
 When enabled, input blobs will be saved as artifacts during agent execution.
 This is useful for debugging and audit purposes, allowing developers to review
 the exact data received by agents.
@@ -225,9 +254,9 @@ Configures the streaming behavior of the agent. Possible values:
 
 * `StreamingMode.NONE`: No streaming; responses delivered as complete units
 * `StreamingMode.SSE`: Server-Sent Events streaming; one-way streaming from server to client
-* `StreamingMode.BIDI`: Bidirectional streaming; simultaneous communication in both directions
+* `StreamingMode.BIDI`: Reserved for bidirectional streaming. **Not currently used** in the standard `run_async()` execution path. For real bidirectional streaming, use `runner.run_live()` instead.
 
-Streaming modes affect both performance and user experience. SSE streaming lets users see partial responses as they're generated, while BIDI streaming enables real-time interactive experiences.
+Streaming modes affect both performance and user experience. SSE streaming lets users see partial responses as they're generated.
 
 ### `output_audio_transcription`
 
@@ -254,6 +283,113 @@ This parameter prevents excessive API usage and potential runaway processes.
 Since LLM calls often incur costs and consume resources, setting appropriate
 limits is crucial.
 
+### `input_audio_transcription`
+
+<div class="language-support-tag">
+    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
+</div>
+
+Configures transcription of audio input received from the user in live agents.
+Defaults to an `AudioTranscriptionConfig()` instance.
+
+### `realtime_input_config`
+
+<div class="language-support-tag">
+    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
+</div>
+
+Provides realtime input configuration for live agents that accept audio from users.
+
+### `enable_affective_dialog`
+
+<div class="language-support-tag">
+    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
+</div>
+
+When set to `True`, the model detects user emotions from the conversation and adapts its tone and responses accordingly.
+
+### `proactivity`
+
+<div class="language-support-tag">
+    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
+</div>
+
+Configures the proactivity of the model using `types.ProactivityConfig`. Allows the model to respond proactively to input and ignore irrelevant messages.
+
+### `session_resumption`
+
+<div class="language-support-tag">
+    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
+</div>
+
+Configures session resumption via `types.SessionResumptionConfig`. Only transparent session resumption mode is currently supported.
+
+### `context_window_compression`
+
+<div class="language-support-tag">
+    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
+</div>
+
+When set, enables context window compression for LLM input using `types.ContextWindowCompressionConfig`. Useful for long-running sessions that approach model context limits.
+
+### `save_live_blob`
+
+<div class="language-support-tag">
+    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
+</div>
+
+When `True`, saves live video and audio data to the session and artifact service. Replaces the deprecated `save_live_audio` field.
+
+### `tool_thread_pool_config`
+
+<div class="language-support-tag">
+    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
+</div>
+
+When set, tool executions in live mode run in a background thread pool instead of the main event loop. This keeps the event loop responsive to user interruptions and incoming model events.
+
+```python
+from google.adk.agents.run_config import RunConfig, ToolThreadPoolConfig
+
+# Default thread pool (4 workers)
+run_config = RunConfig(
+    tool_thread_pool_config=ToolThreadPoolConfig(),
+)
+
+# Custom thread pool
+run_config = RunConfig(
+    tool_thread_pool_config=ToolThreadPoolConfig(max_workers=8),
+)
+```
+
+!!! note "GIL considerations"
+    Thread pools help with blocking I/O and C extensions that release the GIL (e.g. `time.sleep()`, network calls, numpy). They do **not** help with pure Python CPU-bound code since the GIL prevents true parallel execution of Python bytecode.
+
+### `custom_metadata`
+
+<div class="language-support-tag">
+    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
+</div>
+
+A `dict[str, Any]` of arbitrary metadata attached to the current invocation. Useful for tracing or logging custom context alongside agent runs.
+
+### `get_session_config`
+
+<div class="language-support-tag">
+    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
+</div>
+
+Controls which events are fetched when loading a session. Accepts a `GetSessionConfig` instance (e.g. `num_recent_events`, `after_timestamp`). Especially useful in combination with `EventsCompactionConfig` to avoid loading the full event history on every invocation.
+
+```python
+from google.adk.agents.run_config import RunConfig
+from google.adk.sessions.base_session_service import GetSessionConfig
+
+run_config = RunConfig(
+    get_session_config=GetSessionConfig(num_recent_events=50),
+)
+```
+
 ## Validation Rules
 
 <div class="language-support-tag">
@@ -272,7 +408,7 @@ For the `max_llm_calls` parameter specifically:
 === "Python"
 
     ```python
-    from google.genai.adk import RunConfig, StreamingMode
+    from google.adk.agents.run_config import RunConfig, StreamingMode
 
     config = RunConfig(
         streaming_mode=StreamingMode.NONE,
@@ -322,7 +458,7 @@ preferable.
 === "Python"
 
     ```python
-    from google.genai.adk import RunConfig, StreamingMode
+    from google.adk.agents.run_config import RunConfig, StreamingMode
 
     config = RunConfig(
         streaming_mode=StreamingMode.SSE,
@@ -371,9 +507,11 @@ providing a more responsive feel for chatbots and assistants.
 === "Python"
 
     ```python
-    from google.genai.adk import RunConfig, StreamingMode
+    from google.adk.agents.run_config import RunConfig, StreamingMode
     from google.genai import types
 
+    # To save input blobs as artifacts, register SaveFilesAsArtifactsPlugin
+    # on the runner instead of using the deprecated save_input_blobs_as_artifacts flag.
     config = RunConfig(
         speech_config=types.SpeechConfig(
             language_code="en-US",
@@ -384,7 +522,6 @@ providing a more responsive feel for chatbots and assistants.
             ),
         ),
         response_modalities=["AUDIO", "TEXT"],
-        save_input_blobs_as_artifacts=True,
         support_cfc=True,
         streaming_mode=StreamingMode.SSE,
         max_llm_calls=1000,
@@ -451,7 +588,7 @@ This comprehensive example configures an agent with:
 
 * Speech capabilities using the "Kore" voice (US English)
 * Both audio and text output modalities
-* Artifact saving for input blobs (useful for debugging)
+* Artifact saving for input blobs in TypeScript/Java (in Python, prefer `SaveFilesAsArtifactsPlugin`)
 * Experimental CFC support enabled **(Python and TypeScript)**
 * SSE streaming for responsive interaction
 * A limit of 1000 LLM calls
@@ -465,7 +602,7 @@ This comprehensive example configures an agent with:
 === "Python"
 
     ```python
-    from google.genai.adk import RunConfig, StreamingMode
+    from google.adk.agents.run_config import RunConfig, StreamingMode
 
     config = RunConfig(
         streaming_mode=StreamingMode.SSE,


### PR DESCRIPTION
## Summary

The `RunConfig` documentation page was out of sync with the actual implementation in [adk-python](https://github.com/google/adk-python/blob/main/src/google/adk/agents/run_config.py). This PR brings it back in line.

### Import path (critical)

All Python examples used:

```python
from google.genai.adk import RunConfig, StreamingMode  # does not exist
```

The actual import is:

```python
from google.adk.agents.run_config import RunConfig, StreamingMode
```

Fixed across all four occurrences.

### Missing fields

Added 11 previously undocumented fields to the Python class definition, the parameter table, and dedicated subsections:

- `avatar_config`
- `input_audio_transcription`
- `realtime_input_config`
- `enable_affective_dialog`
- `proactivity`
- `session_resumption`
- `context_window_compression`
- `save_live_blob`
- `tool_thread_pool_config` (with code example + GIL note)
- `custom_metadata`
- `get_session_config` (with code example)

### Deprecations

- Marked `save_input_blobs_as_artifacts` as deprecated and pointed readers to `SaveFilesAsArtifactsPlugin`. Removed it from the comprehensive Python example.

### Corrections

- `StreamingMode.BIDI`: the docs claimed it enables bidirectional streaming. The source comment is explicit that BIDI is not used by `run_async()` and that real bidirectional streaming goes through `runner.run_live()`. Updated the description accordingly.
- `output_audio_transcription`: default in the table corrected from `None` to `AudioTranscriptionConfig()` (the field uses `default_factory=types.AudioTranscriptionConfig`).

## Test plan

- [x] `mkdocs serve` builds with no errors or warnings
- [x] `/runtime/runconfig/` page renders and includes the new sections
- [x] No remaining references to `google.genai.adk` on the page