### PR TITLE
Update e2a integration page with remote MCP server and 7 tools

### DIFF
--- a/docs/integrations/e2a.md
+++ b/docs/integrations/e2a.md
@@ -53,7 +53,7 @@ your agent. Outbound mail can be held for human approval before it ships.
 
         ```python
         from google.adk.agents import Agent
-        from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+        from google.adk.tools.mcp_tool import McpToolset
         from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
         from mcp import StdioServerParameters
 
@@ -94,7 +94,7 @@ your agent. Outbound mail can be held for human approval before it ships.
         import os
 
         from google.adk.agents import Agent
-        from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+        from google.adk.tools.mcp_tool import McpToolset
         from google.adk.tools.mcp_tool.mcp_session_manager import (
             StreamableHTTPConnectionParams,
         )

--- a/docs/integrations/e2a.md
+++ b/docs/integrations/e2a.md
@@ -53,7 +53,7 @@ your agent. Outbound mail can be held for human approval before it ships.
 
         ```python
         from google.adk.agents import Agent
-        from google.adk.tools.mcp_tool import McpToolset
+        from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
         from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
         from mcp import StdioServerParameters
 
@@ -94,7 +94,7 @@ your agent. Outbound mail can be held for human approval before it ships.
         import os
 
         from google.adk.agents import Agent
-        from google.adk.tools.mcp_tool import McpToolset
+        from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
         from google.adk.tools.mcp_tool.mcp_session_manager import (
             StreamableHTTPConnectionParams,
         )

--- a/docs/integrations/e2a.md
+++ b/docs/integrations/e2a.md
@@ -88,7 +88,7 @@ your agent. Outbound mail can be held for human approval before it ships.
         )
         ```
 
-    === "Hosted MCP Server"
+    === "Remote MCP Server"
 
         ```python
         import os
@@ -160,7 +160,7 @@ your agent. Outbound mail can be held for human approval before it ships.
         export { rootAgent };
         ```
 
-    === "Hosted MCP Server"
+    === "Remote MCP Server"
 
         ```typescript
         import { LlmAgent, MCPToolset } from "@google/adk";

--- a/docs/integrations/e2a.md
+++ b/docs/integrations/e2a.md
@@ -12,38 +12,33 @@ catalog_tags: ["mcp"]
 </div>
 
 The [e2a MCP Server](https://github.com/Mnexa-AI/e2a/tree/main/mcp) connects
-your ADK agent to [e2a](https://e2a.dev), an authenticated email gateway
-built for AI agents. Inbound mail is SPF/DKIM-verified before it reaches
-your agent. Outbound mail can be held for human approval before it ships.
+your ADK agent to [e2a](https://e2a.dev), an authenticated email gateway built
+for AI agents. This integration gives your agent its own email inbox to send,
+receive, and reply to messages using natural language, with SPF/DKIM-verified
+inbound mail and optional human-in-the-loop approval on outbound messages.
 
 ## Use cases
 
-- **Give agents their own inboxes**: Provision dedicated email addresses
-  (e.g. `support-bot@your-domain.com`) and let agents send and receive
-  mail just like a teammate.
+- **Give agents their own inboxes**: Provision dedicated email addresses (e.g.
+  `support-bot@your-domain.com`) and let agents send and receive mail just like
+  a teammate.
 
-- **Authenticated inbound**: Every incoming message arrives with SPF and
-  DKIM verification results so your agent knows whether the sender is who
-  they claim to be.
+- **Authenticated inbound**: Every incoming message arrives with SPF and DKIM
+  verification results so your agent knows whether the sender is who they claim
+  to be.
 
-- **Human-in-the-loop approval**: Configure HITL on any agent and
-  outbound messages are held in a pending queue until a reviewer
-  approves them — optionally with edits to subject, body, or recipients
-  before sending.
+- **Human-in-the-loop approval**: Configure HITL on any agent and outbound
+  messages are held in a pending queue until a reviewer approves them,
+  optionally with edits to subject, body, or recipients before sending.
 
-- **Automate threaded conversations**: Reply to received emails with
-  proper In-Reply-To and References headers preserved, so threads stay
-  intact across multiple turns.
+- **Automate threaded conversations**: Reply to received emails with proper
+  In-Reply-To and References headers preserved, so threads stay intact across
+  multiple turns.
 
 ## Prerequisites
 
-- A free [e2a account](https://e2a.dev) and an API key from the dashboard.
-- For the **local MCP server**: Node.js 18+ on the machine running the
-  agent (the server is distributed via `npx -y @e2a/mcp-server`).
-- For the **hosted MCP server**: nothing else — connect to
-  `https://mcp.e2a.dev/mcp` with your API key in the `Authorization`
-  header. This path is what you want when deploying ADK agents to
-  Cloud Run (which does not support stdio MCP servers).
+- A free [e2a account](https://e2a.dev) and an API key from the dashboard
+- Node.js 18+ (only required for the local MCP server)
 
 ## Use with agent
 
@@ -200,21 +195,17 @@ Tool | Description
 ---- | -----------
 `whoami` | Return the default agent's full record (requires `E2A_AGENT_EMAIL` when the account has more than one agent)
 `list_agents` | List every agent inbox owned by the authenticated user
-`create_agent` | Register a new inbox using a slug on the shared domain; defaults to `local` mode so the agent receives mail by polling — no webhook required
+`create_agent` | Register a new inbox using a slug on the shared domain; defaults to `local` mode so the agent receives mail by polling and no webhook is required
 `update_agent` | Update an existing agent's webhook URL, mode, or HITL setting
 `delete_agent` | Permanently delete an agent (requires `confirm: true`) and stop accepting mail for that address
 
 !!! warning "Cloud-mode agents must verify webhook signatures"
 
-    When you create an agent with `agent_mode: "cloud"`, e2a HMAC-signs every
-    webhook delivery against your account's webhook signing secret
-    (`E2A_WEBHOOK_SECRET`, shown in the [e2a dashboard](https://e2a.dev)).
-    Your webhook handler must verify the signature on every request —
-    the e2a SDK exposes `parseWebhook(body, secret)` which parses and
-    verifies in one call. Local-mode agents (the default) avoid this
-    entirely by polling via `list_messages`. A complete runnable
-    cloud-mode + ADK example with proper signature verification lives
-    at [github.com/Mnexa-AI/e2a/tree/main/examples/adk-cloud-webhook](https://github.com/Mnexa-AI/e2a/tree/main/examples/adk-cloud-webhook).
+    Agents created with `agent_mode: "cloud"` receive mail via webhooks instead
+    of polling. Your webhook handler must verify the HMAC signature on every
+    delivery. See the [cloud-mode webhook
+    example](https://github.com/Mnexa-AI/e2a/tree/main/examples/adk-cloud-webhook)
+    for a complete setup with signature verification.
 
 ### Messages
 
@@ -248,9 +239,9 @@ Tool | Description
 
 Variable | Required | Default | Description
 -------- | -------- | ------- | -----------
-`E2A_API_KEY` | Yes | — | Your e2a API key (long-lived, from the dashboard). Pass via env for stdio, or via `Authorization: Bearer …` for hosted.
-`E2A_AGENT_EMAIL` | No | — | Default agent inbox; scopes tools so the LLM doesn't repeat the address on every call. Single-agent accounts on the hosted endpoint resolve this automatically at session init.
-`E2A_BASE_URL` | No | `https://e2a.dev` | Self-hosted e2a backend URL. Read by the stdio launcher and by anyone running their own MCP server; has no effect when an agent connects to the public hosted endpoint at `https://mcp.e2a.dev/mcp`.
+`E2A_API_KEY` | Yes | — | Your e2a API key
+`E2A_AGENT_EMAIL` | No | — | Default agent inbox; scopes tools so the LLM doesn't need to specify it on every call
+`E2A_BASE_URL` | No | `https://e2a.dev` | Self-hosted deployment URL (local MCP server only)
 
 ## Additional resources
 

--- a/docs/integrations/e2a.md
+++ b/docs/integrations/e2a.md
@@ -91,15 +91,13 @@ your agent. Outbound mail can be held for human approval before it ships.
     === "Remote MCP Server"
 
         ```python
-        import os
-
         from google.adk.agents import Agent
         from google.adk.tools.mcp_tool import McpToolset
         from google.adk.tools.mcp_tool.mcp_session_manager import (
             StreamableHTTPConnectionParams,
         )
 
-        E2A_API_KEY = os.environ["E2A_API_KEY"]
+        E2A_API_KEY = "YOUR_E2A_API_KEY"
 
         root_agent = Agent(
             model="gemini-flash-latest",
@@ -165,7 +163,7 @@ your agent. Outbound mail can be held for human approval before it ships.
         ```typescript
         import { LlmAgent, MCPToolset } from "@google/adk";
 
-        const E2A_API_KEY = process.env.E2A_API_KEY!;
+        const E2A_API_KEY = "YOUR_E2A_API_KEY";
 
         const rootAgent = new LlmAgent({
             model: "gemini-flash-latest",

--- a/docs/integrations/e2a.md
+++ b/docs/integrations/e2a.md
@@ -259,6 +259,5 @@ Variable | Required | Default | Description
 - [e2a MCP Server source](https://github.com/Mnexa-AI/e2a/tree/main/mcp)
 - [Runnable ADK example](https://github.com/Mnexa-AI/e2a/tree/main/mcp/examples/adk)
 - [Cloud-mode webhook example](https://github.com/Mnexa-AI/e2a/tree/main/examples/adk-cloud-webhook)
-- [Hosted MCP endpoint](https://mcp.e2a.dev/mcp)
 - [e2a documentation](https://e2a.dev)
 - [npm package](https://www.npmjs.com/package/@e2a/mcp-server)

--- a/docs/integrations/e2a.md
+++ b/docs/integrations/e2a.md
@@ -38,8 +38,12 @@ your agent. Outbound mail can be held for human approval before it ships.
 ## Prerequisites
 
 - A free [e2a account](https://e2a.dev) and an API key from the dashboard.
-- Node.js 18+ on the machine running the agent (the MCP server is
-  distributed via `npx -y @e2a/mcp-server`).
+- For the **local MCP server**: Node.js 18+ on the machine running the
+  agent (the server is distributed via `npx -y @e2a/mcp-server`).
+- For the **hosted MCP server**: nothing else — connect to
+  `https://mcp.e2a.dev/mcp` with your API key in the `Authorization`
+  header. This path is what you want when deploying ADK agents to
+  Cloud Run (which does not support stdio MCP servers).
 
 ## Use with agent
 
@@ -84,6 +88,41 @@ your agent. Outbound mail can be held for human approval before it ships.
         )
         ```
 
+    === "Hosted MCP Server"
+
+        ```python
+        import os
+
+        from google.adk.agents import Agent
+        from google.adk.tools.mcp_tool import McpToolset
+        from google.adk.tools.mcp_tool.mcp_session_manager import (
+            StreamableHTTPConnectionParams,
+        )
+
+        E2A_API_KEY = os.environ["E2A_API_KEY"]
+
+        root_agent = Agent(
+            model="gemini-flash-latest",
+            name="e2a_agent",
+            instruction=(
+                "You manage email through the e2a tools. Call whoami once "
+                "to find your inbox address. Use list_messages and "
+                "get_message to read; use reply_to_message (not "
+                "send_email) when replying to an existing thread so "
+                "threading headers are preserved."
+            ),
+            tools=[
+                McpToolset(
+                    connection_params=StreamableHTTPConnectionParams(
+                        url="https://mcp.e2a.dev/mcp",
+                        headers={"Authorization": f"Bearer {E2A_API_KEY}"},
+                        timeout=30,
+                    ),
+                )
+            ],
+        )
+        ```
+
 === "TypeScript"
 
     === "Local MCP Server"
@@ -121,15 +160,51 @@ your agent. Outbound mail can be held for human approval before it ships.
         export { rootAgent };
         ```
 
+    === "Hosted MCP Server"
+
+        ```typescript
+        import { LlmAgent, MCPToolset } from "@google/adk";
+
+        const E2A_API_KEY = process.env.E2A_API_KEY!;
+
+        const rootAgent = new LlmAgent({
+            model: "gemini-flash-latest",
+            name: "e2a_agent",
+            instruction:
+                "You manage email through the e2a tools. Call whoami once " +
+                "to find your inbox address. Use list_messages and " +
+                "get_message to read; use reply_to_message (not " +
+                "send_email) when replying to an existing thread so " +
+                "threading headers are preserved.",
+            tools: [
+                new MCPToolset({
+                    type: "StreamableHTTPConnectionParams",
+                    url: "https://mcp.e2a.dev/mcp",
+                    transportOptions: {
+                        requestInit: {
+                            headers: {
+                                Authorization: `Bearer ${E2A_API_KEY}`,
+                            },
+                        },
+                    },
+                }),
+            ],
+        });
+
+        export { rootAgent };
+        ```
+
 ## Available tools
 
 ### Identity
 
 Tool | Description
 ---- | -----------
-`whoami` | Return the default agent's full record (requires `E2A_AGENT_EMAIL`)
+`whoami` | Return the default agent's full record (requires `E2A_AGENT_EMAIL` when the account has more than one agent)
 `list_agents` | List every agent inbox owned by the authenticated user
 `create_agent` | Register a new inbox using a slug on the shared domain; defaults to `local` mode so the agent receives mail by polling — no webhook required
+`update_agent` | Update an existing agent's webhook URL, mode, or HITL setting
+`delete_agent` | Permanently delete an agent (requires `confirm: true`) and stop accepting mail for that address
 
 !!! warning "Cloud-mode agents must verify webhook signatures"
 
@@ -151,6 +226,7 @@ Tool | Description
 `reply_to_message` | Reply to an inbound message; preserves In-Reply-To and References headers
 `list_messages` | List inbound mail with `status` filter (unread / read / all) and pagination
 `get_message` | Fetch full body, headers, and attachment metadata for one message
+`get_attachment_data` | Download an attachment's bytes by message id and 0-based attachment index (returned as base64)
 
 ### Human-in-the-loop approval
 
@@ -161,17 +237,28 @@ Tool | Description
 `approve_pending_message` | Send a held message, optionally with reviewer edits (subject / body / recipients)
 `reject_pending_message` | Discard a held message; optional `reason` stored for audit
 
+### Domains
+
+Tool | Description
+---- | -----------
+`list_domains` | List every custom domain registered to the authenticated user, with verification state
+`register_domain` | Add a custom domain and receive the DNS records needed to prove ownership
+`verify_domain` | Re-run DNS verification on a registered domain after the records are in place
+`delete_domain` | Remove a custom domain (requires `confirm: true`; agents on the shared domain are unaffected)
+
 ## Configuration
 
 Variable | Required | Default | Description
 -------- | -------- | ------- | -----------
-`E2A_API_KEY` | Yes | — | Your e2a API key
-`E2A_AGENT_EMAIL` | No | — | Default agent inbox; scopes tools so the LLM doesn't repeat the address on every call
-`E2A_BASE_URL` | No | `https://e2a.dev` | Self-hosted deployment URL
+`E2A_API_KEY` | Yes | — | Your e2a API key (long-lived, from the dashboard). Pass via env for stdio, or via `Authorization: Bearer …` for hosted.
+`E2A_AGENT_EMAIL` | No | — | Default agent inbox; scopes tools so the LLM doesn't repeat the address on every call. Single-agent accounts on the hosted endpoint resolve this automatically at session init.
+`E2A_BASE_URL` | No | `https://e2a.dev` | Self-hosted e2a backend URL. Read by the stdio launcher and by anyone running their own MCP server; has no effect when an agent connects to the public hosted endpoint at `https://mcp.e2a.dev/mcp`.
 
 ## Additional resources
 
 - [e2a MCP Server source](https://github.com/Mnexa-AI/e2a/tree/main/mcp)
 - [Runnable ADK example](https://github.com/Mnexa-AI/e2a/tree/main/mcp/examples/adk)
+- [Cloud-mode webhook example](https://github.com/Mnexa-AI/e2a/tree/main/examples/adk-cloud-webhook)
+- [Hosted MCP endpoint](https://mcp.e2a.dev/mcp)
 - [e2a documentation](https://e2a.dev)
 - [npm package](https://www.npmjs.com/package/@e2a/mcp-server)


### PR DESCRIPTION
## Summary

The e2a integration page has drifted from what the e2a MCP server actually ships. Two concrete gaps:

1. **Hosted MCP endpoint isn't documented.** e2a runs a hosted Streamable HTTP MCP at `https://mcp.e2a.dev/mcp` that accepts an API key in the `Authorization` header. The current page only shows the stdio path (`npx -y @e2a/mcp-server`), which doesn't work for ADK agents deployed to Cloud Run since Cloud Run [doesn't host stdio MCP servers](https://docs.cloud.google.com/run/docs/host-mcp-servers). This PR adds a **"Hosted MCP Server"** tab to both the Python and TypeScript code examples using `StreamableHTTPConnectionParams`.

2. **7 tools are missing from the table.** The e2a MCP server now registers 18 tools (verified against [`mcp/tests/http.test.ts`'s `lists every registered tool after initialize` test](https://github.com/Mnexa-AI/e2a/blob/main/mcp/tests/http.test.ts#L193-L217)). The current page lists 11. This PR adds:

   | Section | Added |
   |---|---|
   | Identity | `update_agent`, `delete_agent` |
   | Messages | `get_attachment_data` |
   | Domains *(new section)* | `list_domains`, `register_domain`, `verify_domain`, `delete_domain` |

## Minor description fixes

- `whoami`: notes `E2A_AGENT_EMAIL` is only required when the account has more than one agent (the hosted endpoint auto-resolves the sole agent at session init).
- `delete_agent` / `delete_domain`: flag the `confirm: true` required argument.
- `get_attachment_data`: corrected from "attachment id" to "0-based attachment index" (the actual schema field is `attachment_index: z.number()`).
- `E2A_BASE_URL`: clarified that the variable has no effect when connecting to the public hosted endpoint.

## What's not changing

- Frontmatter: `catalog_title`, `catalog_description`, `catalog_icon`, `catalog_tags: ["mcp"]` — all preserved verbatim.
- Use-cases bullets and the cloud-mode webhook warning — preserved.
- Existing stdio code blocks — preserved as the first tab under each language.

## Verification

- Tool list count (18) matches the MCP server's actual `registerTool` calls across [`mcp/src/tools/agents.ts`](https://github.com/Mnexa-AI/e2a/blob/main/mcp/src/tools/agents.ts), [`messages.ts`](https://github.com/Mnexa-AI/e2a/blob/main/mcp/src/tools/messages.ts), [`domains.ts`](https://github.com/Mnexa-AI/e2a/blob/main/mcp/src/tools/domains.ts), and [`hitl.ts`](https://github.com/Mnexa-AI/e2a/blob/main/mcp/src/tools/hitl.ts).
- TypeScript hosted code block uses `transportOptions.requestInit.headers` (matches the `@google/adk` `StreamableHTTPConnectionParams` type definition; the top-level `header` field is deprecated).
- Python hosted code block verified against `google.adk.tools.mcp_tool.mcp_session_manager.StreamableHTTPConnectionParams`.
- Hosted endpoint reachable: `curl https://mcp.e2a.dev/healthz` → 200, `/.well-known/oauth-protected-resource` returns valid metadata.