### PR TITLE
Fix interactive input for Kotlin quickstart gradle run

### DIFF
--- a/docs/get-started/kotlin.md
+++ b/docs/get-started/kotlin.md
@@ -144,6 +144,10 @@ dependencies {
                 ?: "com.example.agent.MainKt"
         )
     }
+
+    tasks.named<JavaExec>("run") {
+        standardInput = System.`in`
+    }
     ```
 
 ### Set your API key


### PR DESCRIPTION
For ADK Kotlin, the `ReplRunner` REPL exits immediately when run via `gradle run` because Gradle's `JavaExec` task doesn't forward stdin by default.

This PR Adds `standardInput = System.in` to the complete `build.gradle.kts` example in the Kotlin quickstart.