### PR TITLE
Secure CI workflows with zizmor ahead of enforced rollout

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -21,12 +21,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: 3.x
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -17,6 +17,9 @@ name: Build Docs
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/feature-matrix-updater.yaml
+++ b/.github/workflows/feature-matrix-updater.yaml
@@ -9,10 +9,12 @@ jobs:
       pull-requests: write
     steps:
     - name: Checkout adk-docs repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: '1.22'
 
@@ -27,7 +29,7 @@ jobs:
         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v8
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       with:
         token: ${{ secrets.ADK_BOT_GITHUB_TOKEN }}
         commit-message: "feat: propose update to feature matrix"

--- a/.github/workflows/go-fmt.yaml
+++ b/.github/workflows/go-fmt.yaml
@@ -20,10 +20,13 @@ jobs:
         with:
           go-version: '1.25'
       - name: Run gofmt on changed files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # List changed Go files in the pull request.
           # The `|| true` is to prevent the command from failing if no go files are found
-          changed_files=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | grep '\.go$' || true)
+          changed_files=$(git diff --name-only --diff-filter=ACMRT "${BASE_SHA}..${HEAD_SHA}" | grep '\.go$' || true)
 
           if [ -z "$changed_files" ]; then
             echo "No Go files changed in this PR."

--- a/.github/workflows/go-fmt.yaml
+++ b/.github/workflows/go-fmt.yaml
@@ -9,10 +9,11 @@ jobs:
   gofmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Fetch all history for all tags and branches
-      - uses: actions/setup-go@v6
+          persist-credentials: false
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.25'
       - name: Run gofmt on changed files

--- a/.github/workflows/go-fmt.yaml
+++ b/.github/workflows/go-fmt.yaml
@@ -5,6 +5,9 @@ on:
     paths:
       - '**.go'
 
+permissions:
+  contents: read
+
 jobs:
   gofmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-snippets-pr-check.yaml
+++ b/.github/workflows/go-snippets-pr-check.yaml
@@ -30,18 +30,19 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         # Fetch the entire history to compare branches in the PR.
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version: '1.25'
 
     - name: Cache Go modules
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -72,7 +73,9 @@ jobs:
       if: github.event_name == 'pull_request' && steps.changed-files.outputs.changed_files != ''
       run: |
         echo "Building only the changed Go files..."
-        ./tools/go-snippets/runner.sh build ${{ steps.changed-files.outputs.changed_files }}
+        ./tools/go-snippets/runner.sh build ${STEPS_CHANGED_FILES_OUTPUTS_CHANGED_FILES}
+      env:
+        STEPS_CHANGED_FILES_OUTPUTS_CHANGED_FILES: ${{ steps.changed-files.outputs.changed_files }}
 
     # --- Scheduled Checks ---
     # These steps only run on the weekly schedule.

--- a/.github/workflows/go-snippets-pr-check.yaml
+++ b/.github/workflows/go-snippets-pr-check.yaml
@@ -64,11 +64,14 @@ jobs:
     - name: Get changed Go snippet files (PR only)
       if: github.event_name == 'pull_request'
       id: changed-files
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
         # This command gets the list of changed .go files in the snippets directory
         # between the PR's head and the base branch.
         # The output is an escaped, space-separated string suitable for shell commands.
-        CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -- 'examples/go/snippets/**/*.go' | xargs)
+        CHANGED_FILES=$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" -- 'examples/go/snippets/**/*.go' | xargs)
         echo "changed_files=${CHANGED_FILES}" >> $GITHUB_OUTPUT
         echo "Detected changes in: ${CHANGED_FILES}"
 

--- a/.github/workflows/go-snippets-pr-check.yaml
+++ b/.github/workflows/go-snippets-pr-check.yaml
@@ -23,6 +23,9 @@ on:
   schedule:
     - cron: '0 3 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   # This job builds and runs the Go snippets.
   test:

--- a/.github/workflows/kotlin-snippets-pr-check.yaml
+++ b/.github/workflows/kotlin-snippets-pr-check.yaml
@@ -56,10 +56,13 @@ jobs:
     - name: Get changed Kotlin snippet files (PR only)
       if: github.event_name == 'pull_request'
       id: changed-files
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
         # This command gets the list of changed .kt files in the snippets directory
         # between the PR's head and the base branch.
-        CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -- 'examples/kotlin/snippets/**/*.kt' | xargs)
+        CHANGED_FILES=$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" -- 'examples/kotlin/snippets/**/*.kt' | xargs)
         echo "changed_files=${CHANGED_FILES}" >> $GITHUB_OUTPUT
         echo "Detected changes in: ${CHANGED_FILES}"
 

--- a/.github/workflows/kotlin-snippets-pr-check.yaml
+++ b/.github/workflows/kotlin-snippets-pr-check.yaml
@@ -26,19 +26,20 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         # Fetch the entire history to compare branches in the PR.
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         java-version: '17'
         distribution: 'temurin'
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
 
     # --- PR-Specific Checks ---
     # These steps only run for pull request events.
@@ -63,10 +64,14 @@ jobs:
       if: github.event_name == 'pull_request' && steps.changed-files.outputs.changed_files != ''
       run: |
         echo "Building only the changed Kotlin files..."
-        ./tools/kotlin-snippets/runner.sh build ${{ steps.changed-files.outputs.changed_files }}
+        ./tools/kotlin-snippets/runner.sh build ${STEPS_CHANGED_FILES_OUTPUTS_CHANGED_FILES}
+      env:
+        STEPS_CHANGED_FILES_OUTPUTS_CHANGED_FILES: ${{ steps.changed-files.outputs.changed_files }}
 
     - name: Lint changed Kotlin snippets (PR only)
       if: github.event_name == 'pull_request' && steps.changed-files.outputs.changed_files != ''
       run: |
         echo "Linting only the changed Kotlin files..."
-        ./tools/kotlin-snippets/runner.sh lint ${{ steps.changed-files.outputs.changed_files }}
+        ./tools/kotlin-snippets/runner.sh lint ${STEPS_CHANGED_FILES_OUTPUTS_CHANGED_FILES}
+      env:
+        STEPS_CHANGED_FILES_OUTPUTS_CHANGED_FILES: ${{ steps.changed-files.outputs.changed_files }}

--- a/.github/workflows/kotlin-snippets-pr-check.yaml
+++ b/.github/workflows/kotlin-snippets-pr-check.yaml
@@ -19,6 +19,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   # This job builds the Kotlin snippets.
   test:

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -20,6 +20,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -24,10 +24,12 @@ jobs:
   link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
 
     - name: Check links
-      uses: lycheeverse/lychee-action@v2
+      uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
       with:
         args: >-
           --verbose

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -26,16 +26,18 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: 3.x
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -32,6 +32,9 @@ on:
   schedule:
     - cron: "0 0 * * 0"
 
+permissions:
+  contents: read
+
 jobs:
   get_sample_dirs:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-lint.yaml
+++ b/.github/workflows/python-lint.yaml
@@ -38,9 +38,10 @@ jobs:
     outputs:
       sample_dirs: ${{ steps.get_dirs.outputs.sample_dirs }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Get Sample Directories
         id: get_dirs
@@ -61,12 +62,13 @@ jobs:
       - get_sample_dirs
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -78,6 +80,8 @@ jobs:
 
       - name: Run Black and Flake8 Linting in ${{ matrix.sample_dir }}
         run: |
-          cd ${{ matrix.sample_dir }}
+          cd ${MATRIX_SAMPLE_DIR}
           black .
           flake8 .
+        env:
+          MATRIX_SAMPLE_DIR: ${{ matrix.sample_dir }}

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -32,6 +32,9 @@ on:
   schedule:
     - cron: "0 0 * * 0"
 
+permissions:
+  contents: read
+
 jobs:
   get_sample_dirs:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -38,9 +38,10 @@ jobs:
     outputs:
       sample_dirs: ${{ steps.get_dirs.outputs.sample_dirs }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Get Sample Directories
         id: get_dirs
@@ -61,12 +62,13 @@ jobs:
       fail-fast: false # Important: Don't stop if one matrix configuration fails
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -75,13 +77,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest coverage
-          pip install -r ${{ matrix.sample_dir }}/requirements.txt
-          pip install -r ${{ matrix.sample_dir }}/requirements-test.txt
+          pip install -r ${MATRIX_SAMPLE_DIR}/requirements.txt
+          pip install -r ${MATRIX_SAMPLE_DIR}/requirements-test.txt
+        env:
+          MATRIX_SAMPLE_DIR: ${{ matrix.sample_dir }}
 
       - name: Run pytest in ${{ matrix.sample_dir }}
         run: |
-          cd ${{ matrix.sample_dir }}
+          cd ${MATRIX_SAMPLE_DIR}
           pytest | tee pytest.txt
+        env:
+          MATRIX_SAMPLE_DIR: ${{ matrix.sample_dir }}
 
       - name: Show failed tests and overall summary
         run: |
@@ -93,7 +99,7 @@ jobs:
           fi
 
       - name: Upload pytest test results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pytest-results-${{ matrix.python-version }}-${{ matrix.sample_dir }}
           path: |

--- a/.github/workflows/update-python-docs.yaml
+++ b/.github/workflows/update-python-docs.yaml
@@ -14,6 +14,8 @@ on:
   issues:
     types: [opened, labeled]
 
+permissions: {}
+
 jobs:
   update-adk-python-docs-from-issue:
     if: contains(github.event.issue.labels.*.name, 'docs updates')

--- a/.github/workflows/update-python-docs.yaml
+++ b/.github/workflows/update-python-docs.yaml
@@ -68,5 +68,6 @@ jobs:
           CODE_REPO: 'adk-python'
           INTERACTIVE: 0
           PYTHONPATH: adk-python/contributing/samples/adk_team/adk_documentation
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run:
-          python -m adk_docs_updater.main --issue_number ${{ github.event.issue.number }}
+          python -m adk_docs_updater.main --issue_number "${ISSUE_NUMBER}"

--- a/.github/workflows/update-python-docs.yaml
+++ b/.github/workflows/update-python-docs.yaml
@@ -21,25 +21,26 @@ jobs:
 
     steps:
       - name: Checkout ADK Python repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: google/adk-python
           path: ./adk-python
           token: ${{ secrets.ADK_BOT_GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.11'
 
       - name: Authenticate to Google Cloud
         id: auth
-        uses: 'google-github-actions/auth@v3'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: '${{ secrets.ADK_GCP_SA_KEY }}'
 
       - name: Load adk-bot SSH Private Key
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
         with:
           ssh-private-key: ${{ secrets.ADK_BOT_SSH_PRIVATE_KEY }}
 


### PR DESCRIPTION
This PR hardens the GitHub Actions workflows using zizmor by remediating all medium+ findings from zizmor ahead of the org-wide rollout.

These changes lock our CI automation to exact, verified versions and give each workflow only the minimum permissions it needs, closing common supply-chain attack paths without changing what any workflow actually does.

### Result

- Gate scan (zizmor regular persona, medium+): 46 blocking findings to 0
  - 30 high (`unpinned-uses`), 16 medium (`excessive-permissions`, `template-injection`)
- Also cleared 12 low `artipacked` and all `template-injection` code smells.

### Changes (3 commits)

- `ci: pin actions to SHAs and harden workflows with zizmor auto-fixes`
- `ci: set least-privilege GITHUB_TOKEN permissions on workflows`
- `ci: move PR/issue context into env vars to prevent template injection`

### Verification

`uvx zizmor@latest .github/workflows/` → `No findings to report. Good job!`