### PR TITLE
feat(integrations): add Mimir Memory — persistent cross-session memory for ADK

### DIFF
--- a/docs/integrations/assets/mimir.svg
+++ b/docs/integrations/assets/mimir.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0c0814"/>
+      <stop offset="100%" stop-color="#1a1030"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="16" fill="url(#bg)"/>
+  <text x="64" y="78" font-family="monospace" font-size="52" font-weight="bold" fill="#a78bfa" text-anchor="middle">M</text>
+  <path d="M34 96 L54 96 L44 84 Z" fill="#7c3aed" opacity="0.6"/>
+  <path d="M94 96 L74 96 L84 84 Z" fill="#7c3aed" opacity="0.6"/>
+</svg>

--- a/docs/integrations/mimir.md
+++ b/docs/integrations/mimir.md
@@ -1,27 +1,34 @@
 ---
 catalog_title: Mimir Memory
-catalog_description: Persistent, local, encrypted cross-session memory for ADK agents — backed by Mimir
+catalog_description: Add persistent, local, encrypted cross-session memory to ADK agents
 catalog_icon: /integrations/assets/mimir.svg
+catalog_tags: ["data"]
 ---
 
-# Mimir Memory — Persistent Cross-Session Memory for ADK
+# Mimir Memory integration for ADK
 
 <div class="language-support-tag">
   <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
 </div>
 
-Mimir provides persistent, encrypted, cross-session memory for ADK agents.
-Backed by a single Rust binary with an embedded SQLite database, it requires
-**zero cloud dependencies** — everything runs locally. Memory is encrypted at
-rest with AES-256-GCM, and search combines FTS5 keyword matching with dense
-vector retrieval.
+The [`adk-mimir-memory`](https://github.com/Perseus-Computing-LLC/adk-mimir-memory)
+integration connects your ADK agent to
+[Mimir](https://github.com/Perseus-Computing-LLC/mimir), a persistent,
+cross-session memory backend. Backed by a single Rust binary with an embedded
+SQLite database, it requires **zero cloud dependencies**, and everything runs
+locally. Memory is encrypted at rest with AES-256-GCM, and search combines FTS5
+keyword matching with dense vector retrieval.
 
 ## Use cases
 
-- **Persistent agent memory across restarts**: Sessions survive process restarts — agents recall past conversations automatically
-- **Private, air-gapped deployments**: No cloud dependency — Mimir runs entirely on your machine with optional AES-256-GCM encryption
-- **Hybrid search across memories**: Combine keyword (FTS5/BM25) and semantic (dense vector) search to find relevant past interactions
-- **Workspace-aware agents**: Pair with Perseus for agents that know about your project files, git state, and configuration
+- **Persistent agent memory across restarts**: Sessions survive process
+  restarts, and agents recall past conversations automatically
+- **Private, air-gapped deployments**: No cloud dependency, and Mimir runs
+  entirely on your machine with optional AES-256-GCM encryption
+- **Hybrid search across memories**: Combine keyword (FTS5/BM25) and semantic
+  (dense vector) search to find relevant past interactions
+- **Workspace-aware agents**: Pair with Perseus for agents that know about your
+  project files, git state, and configuration
 
 ## Prerequisites
 
@@ -35,8 +42,9 @@ vector retrieval.
 pip install adk-mimir-memory
 ```
 
-Then download the `mimir` binary from the [Mimir releases page](https://github.com/Perseus-Computing-LLC/mimir/releases),
-or build from source:
+Then download the `mimir` binary from the [Mimir releases
+page](https://github.com/Perseus-Computing-LLC/mimir/releases), or build from
+source:
 
 ```bash
 cargo install mimir
@@ -50,7 +58,7 @@ from adk_mimir_memory import MimirMemoryService
 
 agent = Agent(
     name="my_agent",
-    model="gemini-2.5-flash",
+    model="gemini-flash-latest",
     instruction="You are a helpful assistant with persistent memory.",
     memory_service=MimirMemoryService(
         db_path="~/.adk/mimir.db",

--- a/docs/integrations/mimir.md
+++ b/docs/integrations/mimir.md
@@ -1,0 +1,118 @@
+---
+catalog_title: Mimir Memory
+catalog_description: Persistent, local, encrypted cross-session memory for ADK agents — backed by Mimir
+catalog_icon: /integrations/assets/mimir.svg
+---
+
+# Mimir Memory — Persistent Cross-Session Memory for ADK
+
+<div class="language-support-tag">
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
+</div>
+
+Mimir provides persistent, encrypted, cross-session memory for ADK agents.
+Backed by a single Rust binary with an embedded SQLite database, it requires
+**zero cloud dependencies** — everything runs locally. Memory is encrypted at
+rest with AES-256-GCM, and search combines FTS5 keyword matching with dense
+vector retrieval.
+
+## Use cases
+
+- **Persistent agent memory across restarts**: Sessions survive process restarts — agents recall past conversations automatically
+- **Private, air-gapped deployments**: No cloud dependency — Mimir runs entirely on your machine with optional AES-256-GCM encryption
+- **Hybrid search across memories**: Combine keyword (FTS5/BM25) and semantic (dense vector) search to find relevant past interactions
+- **Workspace-aware agents**: Pair with Perseus for agents that know about your project files, git state, and configuration
+
+## Prerequisites
+
+- Python 3.10+
+- The `mimir` binary (see [Installation](#installation))
+- `google-adk>=1.0.0`
+
+## Installation
+
+```bash
+pip install adk-mimir-memory
+```
+
+Then download the `mimir` binary from the [Mimir releases page](https://github.com/Perseus-Computing-LLC/mimir/releases),
+or build from source:
+
+```bash
+cargo install mimir
+```
+
+## Use with agent
+
+```python
+from google.adk.agents import Agent
+from adk_mimir_memory import MimirMemoryService
+
+agent = Agent(
+    name="my_agent",
+    model="gemini-2.5-flash",
+    instruction="You are a helpful assistant with persistent memory.",
+    memory_service=MimirMemoryService(
+        db_path="~/.adk/mimir.db",
+    ),
+)
+```
+
+### Perseus Live Context (Optional)
+
+For live workspace awareness, install the `perseus` extra:
+
+```bash
+pip install adk-mimir-memory[perseus]
+```
+
+```python
+from adk_mimir_memory.perseus_context import perseus_context_agent
+
+# The agent resolves @file, @search, @memory directives at inference time
+runner.run_async(
+    user_id="user",
+    session_id="session",
+    new_message=types.Content(role="user", parts=[types.Part.from_text(
+        text="What does the README say about deployment?"
+    )]),
+    agent=perseus_context_agent,
+)
+```
+
+Set Perseus directives via session state:
+
+```python
+session = await runner.session_service.create_session(
+    app_name="my_app",
+    user_id="user",
+    state={
+        "_perseus_directives": "@file AGENTS.md @file README.md @memory deployment",
+        "_perseus_workspace": "/path/to/project",
+    },
+)
+```
+
+## Available memory operations
+
+| Method | Description |
+|---|---|
+| `add_session_to_memory(session)` | Persist a full session's events |
+| `add_events_to_memory(...)` | Append incremental event deltas |
+| `add_memory(...)` | Store explicit memory entries |
+| `search_memory(...)` | FTS5 keyword search across memories |
+
+## Backend comparison
+
+| Backend | Dependencies | Encryption | Hybrid Search | Local |
+|---|---|---|---|---|
+| **InMemoryMemoryService** | None | ❌ | ❌ | ✅ |
+| **VertexAiMemoryBankService** | GCP + Gemini | ❌ | Gemini-driven | ❌ |
+| **VertexAiRagMemoryService** | GCP + RAG | ❌ | GCP vector | ❌ |
+| **MimirMemoryService** | Single binary | ✅ AES-256 | ✅ BM25+FTS5+Dense | ✅ |
+
+## Resources
+
+- [adk-mimir-memory on GitHub](https://github.com/Perseus-Computing-LLC/adk-mimir-memory)
+- [Mimir (backing service)](https://github.com/Perseus-Computing-LLC/mimir)
+- [Perseus (context engine)](https://github.com/Perseus-Computing-LLC/perseus)

--- a/docs/integrations/mimir.md
+++ b/docs/integrations/mimir.md
@@ -143,5 +143,6 @@ session = await runner.session_service.create_session(
 ## Resources
 
 - [adk-mimir-memory on GitHub](https://github.com/Perseus-Computing-LLC/adk-mimir-memory)
+- [adk-mimir-memory on PyPI](https://pypi.org/project/adk-mimir-memory/)
 - [Mimir (backing service)](https://github.com/Perseus-Computing-LLC/mimir)
 - [Perseus (context engine)](https://github.com/Perseus-Computing-LLC/perseus)

--- a/docs/integrations/mimir.md
+++ b/docs/integrations/mimir.md
@@ -38,35 +38,50 @@ keyword matching with dense vector retrieval.
 
 ## Installation
 
+Install the Python package:
+
 ```bash
 pip install adk-mimir-memory
 ```
 
-Then download the `mimir` binary from the [Mimir releases
-page](https://github.com/Perseus-Computing-LLC/mimir/releases), or build from
-source:
-
-```bash
-cargo install mimir
-```
+Then install the `mimir` binary: download the build for your platform from the
+[Mimir releases page](https://github.com/Perseus-Computing-LLC/mimir/releases)
+and place it on your `PATH`. The service looks for `mimir` by default, or pass
+`mimir_binary="/absolute/path/to/mimir"` to `MimirMemoryService`.
 
 ## Use with agent
 
+Create the `MimirMemoryService`, pass it to your `Runner`, and give the agent
+the `load_memory` tool so it can recall past sessions:
+
 ```python
-from google.adk.agents import Agent
 from adk_mimir_memory import MimirMemoryService
+from google.adk.agents import Agent
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.adk.tools import load_memory
 
 agent = Agent(
-    name="my_agent",
+    name="memory_assistant",
     model="gemini-flash-latest",
-    instruction="You are a helpful assistant with persistent memory.",
-    memory_service=MimirMemoryService(
-        db_path="~/.adk/mimir.db",
-    ),
+    instruction="You are a helpful assistant with long-term memory.",
+    tools=[load_memory],
+)
+
+runner = Runner(
+    agent=agent,
+    app_name="mimir_app",
+    session_service=InMemorySessionService(),
+    memory_service=MimirMemoryService(db_path="~/.adk/mimir.db"),
 )
 ```
 
-### Perseus Live Context (Optional)
+After a session completes, call
+`await memory_service.add_session_to_memory(session)` to persist it. The agent
+recalls relevant memories in later sessions through the `load_memory` tool. See
+[ADK memory](/sessions/memory/) for the full ingest-and-recall flow.
+
+### Perseus live context (optional)
 
 For live workspace awareness, install the `perseus` extra:
 
@@ -74,25 +89,31 @@ For live workspace awareness, install the `perseus` extra:
 pip install adk-mimir-memory[perseus]
 ```
 
+Then use the prebuilt `perseus_context_agent`, which resolves `@file`,
+`@search`, and `@memory` directives at inference time:
+
 ```python
 from adk_mimir_memory.perseus_context import perseus_context_agent
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
 
-# The agent resolves @file, @search, @memory directives at inference time
-runner.run_async(
-    user_id="user",
-    session_id="session",
-    new_message=types.Content(role="user", parts=[types.Part.from_text(
-        text="What does the README say about deployment?"
-    )]),
+# The pre-built agent ships without a model; set one before use.
+perseus_context_agent.model = "gemini-flash-latest"
+
+runner = Runner(
     agent=perseus_context_agent,
+    app_name="perseus_app",
+    session_service=InMemorySessionService(),
+    memory_service=MimirMemoryService(db_path="~/.adk/mimir.db"),
 )
 ```
 
-Set Perseus directives via session state:
+Set Perseus directives via session state when creating the session (inside an
+async function):
 
 ```python
 session = await runner.session_service.create_session(
-    app_name="my_app",
+    app_name="perseus_app",
     user_id="user",
     state={
         "_perseus_directives": "@file AGENTS.md @file README.md @memory deployment",
@@ -112,12 +133,12 @@ session = await runner.session_service.create_session(
 
 ## Backend comparison
 
-| Backend | Dependencies | Encryption | Hybrid Search | Local |
+| Backend | Dependencies | At-rest encryption | Search | Hosting |
 |---|---|---|---|---|
-| **InMemoryMemoryService** | None | ❌ | ❌ | ✅ |
-| **VertexAiMemoryBankService** | GCP + Gemini | ❌ | Gemini-driven | ❌ |
-| **VertexAiRagMemoryService** | GCP + RAG | ❌ | GCP vector | ❌ |
-| **MimirMemoryService** | Single binary | ✅ AES-256 | ✅ BM25+FTS5+Dense | ✅ |
+| **InMemoryMemoryService** | None | Not persisted | Keyword | Local (ephemeral) |
+| **VertexAiMemoryBankService** | Google Cloud | Google-managed (CMEK optional) | Semantic (Gemini) | Google Cloud |
+| **VertexAiRagMemoryService** | Google Cloud | Google-managed (CMEK optional) | Vector similarity | Google Cloud |
+| **MimirMemoryService** | `mimir` binary | Local AES-256-GCM (optional) | Hybrid (FTS5 + dense) | Local |
 
 ## Resources
 

--- a/docs/integrations/phoenix.md
+++ b/docs/integrations/phoenix.md
@@ -11,7 +11,7 @@ catalog_tags: ["observability", "evaluation"]
   <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
 </div>
 
-[Phoenix](https://arize.com/docs/phoenix) is an open-source, self-hosted observability platform for monitoring, debugging, and improving LLM applications and AI Agents at scale. It provides comprehensive tracing and evaluation capabilities for your Google ADK applications. To get started, sign up for a [free account](https://phoenix.arize.com/).
+[Phoenix](https://arize.com/docs/phoenix) is an open-source, self-hosted observability platform for monitoring, debugging, and improving LLM applications and AI Agents at scale. It provides comprehensive tracing and evaluation capabilities for your Google ADK applications. To get started, sign up for a [free account](https://arize.com/phoenix/).
 
 
 ## Overview
@@ -37,7 +37,7 @@ pip install openinference-instrumentation-google-adk google-adk arize-phoenix-ot
 
 These instructions show you how to use Phoenix Cloud. You can also [launch Phoenix](https://arize.com/docs/phoenix/integrations/llm-providers/google-gen-ai/google-adk-tracing) in a notebook, from your terminal, or self-host it using a container.
 
-1. Sign up for a [free Phoenix account](https://phoenix.arize.com/).
+1. Sign up for a [free Phoenix account](https://arize.com/phoenix/).
 2. From the Settings page of your new Phoenix Space, create your API key
 3. Copy your endpoint which should look like: https://app.phoenix.arize.com/s/[your-space-name]
 


### PR DESCRIPTION
Adds integration documentation for [**Mimir Memory**](https://github.com/Perseus-Computing-LLC/adk-mimir-memory) — a persistent, local, encrypted cross-session memory backend for ADK agents.

### What this integration provides

- **`MimirMemoryService`**: drop-in replacement for `InMemoryMemoryService` with persistent SQLite storage
- **AES-256-GCM encryption**: memory data encrypted at rest
- **Hybrid search**: FTS5 keyword + dense vector retrieval
- **Zero cloud dependencies**: single Rust binary, fully local
- **Perseus live context**: optional workspace-aware agent sample

### Backend comparison

| Backend | Encryption | Hybrid Search | Local |
|---|---|---|---|
| InMemoryMemoryService | ❌ | ❌ | ✅ |
| VertexAiMemoryBankService | ❌ | Gemini-driven | ❌ |
| VertexAiRagMemoryService | ❌ | GCP vector | ❌ |
| **MimirMemoryService** | ✅ AES-256 | ✅ BM25+FTS5+Dense | ✅ |

### Installation

```bash
pip install adk-mimir-memory
```

### References

- Package: https://github.com/Perseus-Computing-LLC/adk-mimir-memory
- Backing service (Mimir): https://github.com/Perseus-Computing-LLC/mimir
- Original ADK PR (closed — migrated to standalone): https://github.com/google/adk-python/pull/6169
