### PR TITLE
ci: Keep persisted credentials for mkdocs gh-deploy CI workflow

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -26,9 +26,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 # zizmor: ignore[artipacked] - gh-deploy needs the persisted GITHUB_TOKEN to push to gh-pages
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]


### PR DESCRIPTION
Fix for the `Publish Docs` CI workflow, which broke on `main` after #1872 was merged.

#1872's zizmor `artipacked` auto-fix added `persist-credentials: false` to every checkout. That's correct everywhere except the deploy job: `mkdocs gh-deploy` does `git push origin gh-pages`, which needs those persisted credentials when the CI workflow runs.

Fix: Drop `persist-credentials: false` on the deploy checkout and document the intentional exception inline:

`# zizmor: ignore[artipacked] - gh-deploy needs the persisted GITHUB_TOKEN to push to gh-pages`