### PR TITLE
docs(mimir): matched icon + add "mcp" catalog tag

### DIFF
--- a/docs/integrations/assets/mimir.svg
+++ b/docs/integrations/assets/mimir.svg
@@ -1,12 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
-  <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0c0814"/>
-      <stop offset="100%" stop-color="#1a1030"/>
-    </linearGradient>
-  </defs>
-  <rect width="128" height="128" rx="16" fill="url(#bg)"/>
-  <text x="64" y="78" font-family="monospace" font-size="52" font-weight="bold" fill="#a78bfa" text-anchor="middle">M</text>
-  <path d="M34 96 L54 96 L44 84 Z" fill="#7c3aed" opacity="0.6"/>
-  <path d="M94 96 L74 96 L84 84 Z" fill="#7c3aed" opacity="0.6"/>
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Mimir">
+  <rect width="128" height="128" rx="30" fill="#161420"></rect>
+  <rect x="32" y="33" width="64" height="10" rx="5" fill="#8B5CF6"></rect>
+  <rect x="32" y="50" width="64" height="10" rx="5" fill="#8B5CF6" fill-opacity="0.8"></rect>
+  <rect x="32" y="67" width="64" height="10" rx="5" fill="#8B5CF6" fill-opacity="0.62"></rect>
+  <rect x="32" y="84" width="64" height="10" rx="5" fill="#8B5CF6" fill-opacity="0.46"></rect>
 </svg>

--- a/docs/integrations/mimir.md
+++ b/docs/integrations/mimir.md
@@ -2,7 +2,7 @@
 catalog_title: Mimir Memory
 catalog_description: Add persistent, local, encrypted cross-session memory to ADK agents
 catalog_icon: /integrations/assets/mimir.svg
-catalog_tags: ["data", "mcp"]
+catalog_tags: ["data"]
 ---
 
 # Mimir Memory integration for ADK

--- a/docs/integrations/mimir.md
+++ b/docs/integrations/mimir.md
@@ -2,7 +2,7 @@
 catalog_title: Mimir Memory
 catalog_description: Add persistent, local, encrypted cross-session memory to ADK agents
 catalog_icon: /integrations/assets/mimir.svg
-catalog_tags: ["data"]
+catalog_tags: ["data", "mcp"]
 ---
 
 # Mimir Memory integration for ADK


### PR DESCRIPTION
Two small updates to the existing Mimir Memory integration page:

1. **New icon** — replaces the placeholder with a flat, professionally designed mark (fading memory layers, violet `#8B5CF6` on `#161420`). It's one of a matched pair with the Perseus icon (proposed in #1891), so the two companion integrations read as a coherent set on the catalog grid. Renders crisply at tile size (no gradients).

2. **Adds `"mcp"` to `catalog_tags`** (`["data"]` → `["data", "mcp"]`). Mimir is an MCP (stdio) server — the `adk-mimir-memory` service speaks MCP JSON-RPC to the `mimir` binary — so it belongs under the catalog's MCP filter, where it also surfaces alongside its companion Perseus.

No prose or code changes; the page already documents the integration. Single-author commits under the signed CLA.

_Note: a reciprocal catalog link from this page to the Perseus integration page will follow once #1891 (which adds `docs/integrations/perseus.md`) is merged — kept out of this PR to avoid a dead internal link in the build._