### PR TITLE
Add link for evaluating agent performance

### DIFF
--- a/docs/evaluate/index.md
+++ b/docs/evaluate/index.md
@@ -6,7 +6,7 @@
 
 In traditional software development, unit tests and integration tests provide confidence that code functions as expected and remains stable through changes. These tests provide a clear "pass/fail" signal, guiding further development. However, LLM agents introduce a level of variability that makes traditional testing approaches insufficient.
 
-Due to the probabilistic nature of models, deterministic "pass/fail" assertions are often unsuitable for evaluating agent performance. Instead, we need qualitative evaluations of both the final output and the agent's trajectory \- the sequence of steps taken to reach the solution. This involves assessing the quality of the agent's decisions, its reasoning process, and the final result.
+Due to the probabilistic nature of models, deterministic "pass/fail" assertions are often unsuitable for evaluating agent performance. Instead, we need qualitative evaluations of both the final output and the agent's trajectory \- the sequence of steps taken to reach the solution. This involves [assessing the quality of the agent's decisions, its reasoning process, and the final result.](https://github.com/google/adk-docs/tree/main/docs/integrations)
 
 This may seem like a lot of extra work to set up, but the investment of automating evaluations pays off quickly. If you intend to progress beyond prototype, this is a highly recommended best practice.
 

--- a/docs/tools-custom/mcp-tools.md
+++ b/docs/tools-custom/mcp-tools.md
@@ -81,6 +81,32 @@ The `McpToolset` class is ADK's primary mechanism for integrating tools from an 
 4.  **Proxying Tool Calls:** When your `LlmAgent` decides to use one of these tools, `McpToolset` transparently proxies the call (using the `call_tool` MCP method) to the MCP server, sends the necessary arguments, and returns the server's response back to the agent.
 5.  **Filtering (Optional):** You can use the `tool_filter` parameter when creating an `McpToolset` to select a specific subset of tools from the MCP server, rather than exposing all of them to your agent.
 
+### Dynamic Headers with `header_provider`
+
+You can provide a `header_provider` to the `McpToolset` to dynamically generate headers for each request. This is useful for multi-tenancy or other scenarios where headers need to change based on the context.
+
+**Example:**
+```python
+from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
+from google.adk.tools.mcp_tool.mcp_session_manager import StreamableHTTPConnectionParams
+
+root_agent = LlmAgent(
+    model='gemini-2.0-flash',
+    name='tenant_agent',
+    instruction="...",
+    tools=[
+        McpToolset(
+            connection_params=StreamableHTTPConnectionParams(
+                url='http://localhost:3000/mcp',
+            ),
+            tool_filter=['get_tenant_data'],
+            header_provider=lambda ctx: {'X-Tenant-ID': 'tenant1'},
+        )
+    ],
+)
+```
+For a complete example, see the [mcp_dynamic_header_agent sample](https://github.com/google/adk-python/tree/main/contributing/samples/mcp/mcp_dynamic_header_agent).
+
 The following examples demonstrate how to use `McpToolset` within the `adk web` development environment. For scenarios where you need more fine-grained control over the MCP connection lifecycle or are not using `adk web`, refer to the "Using MCP Tools in your own Agent out of `adk web`" section later in this page.
 
 ### Example 1: File System MCP Server


### PR DESCRIPTION
* Updated the text to include a link for assessing agent performance. 
* Added a link to [file path where the agent_simulator.md](https://github.com/google/adk-docs/tree/main/docs/integrations)d would be
