### PR TITLE
Fix jsonschema tags in ADK Go 2.0.0 graph snippets

### DIFF
--- a/examples/go/snippets/graphs/data-handling/main.go
+++ b/examples/go/snippets/graphs/data-handling/main.go
@@ -315,15 +315,15 @@ func stateScopes(ctx agent.Context) error {
 // these structs into *jsonschema.Schema automatically — no hand-built schema
 // construction needed.
 type FlightSearchInput struct {
-	Origin        string `json:"origin"         jsonschema:"description=Departure airport code e.g. SFO"`
-	Destination   string `json:"destination"    jsonschema:"description=Arrival airport code e.g. CDG"`
-	DepartureDate string `json:"departure_date" jsonschema:"description=Travel date in YYYY-MM-DD format"`
+	Origin        string `json:"origin"         jsonschema:"Departure airport code e.g. SFO"`
+	Destination   string `json:"destination"    jsonschema:"Arrival airport code e.g. CDG"`
+	DepartureDate string `json:"departure_date" jsonschema:"Travel date in YYYY-MM-DD format"`
 }
 
 // FlightSearchOutput is the typed output schema for the flight-search agent node.
 type FlightSearchOutput struct {
-	CheapestPrice string `json:"cheapest_price" jsonschema:"description=Cheapest available fare e.g. $450"`
-	FlightCount   string `json:"flight_count"   jsonschema:"description=Number of matching flights found"`
+	CheapestPrice string `json:"cheapest_price" jsonschema:"Cheapest available fare e.g. $450"`
+	FlightCount   string `json:"flight_count"   jsonschema:"Number of matching flights found"`
 }
 
 // newSchemaAgentPipeline demonstrates workflow.NewAgentNodeTyped, which infers

--- a/examples/go/snippets/graphs/human-input/main.go
+++ b/examples/go/snippets/graphs/human-input/main.go
@@ -195,7 +195,7 @@ func newItineraryReviewWorkflow() (agent.Agent, error) {
 // --8<-- [start:simple-hitl]
 // DoubleNumberArgs holds the input for the doubleNumber tool.
 type DoubleNumberArgs struct {
-	Number int `json:"number" jsonschema:"description=The number to double."`
+	Number int `json:"number" jsonschema:"The number to double."`
 }
 
 // DoubleNumberResults holds the output of the doubleNumber tool.
@@ -245,9 +245,9 @@ func newSimpleHITLAgent(ctx context.Context) (agent.Agent, error) {
 // --8<-- [start:hitl-with-hint]
 // BookFlightArgs holds the input for the bookFlight tool.
 type BookFlightArgs struct {
-	Origin      string `json:"origin"      jsonschema:"description=Departure airport code."`
-	Destination string `json:"destination" jsonschema:"description=Arrival airport code."`
-	Date        string `json:"date"        jsonschema:"description=Travel date in YYYY-MM-DD format."`
+	Origin      string `json:"origin"      jsonschema:"Departure airport code."`
+	Destination string `json:"destination" jsonschema:"Arrival airport code."`
+	Date        string `json:"date"        jsonschema:"Travel date in YYYY-MM-DD format."`
 }
 
 // BookFlightResults holds the outcome of the bookFlight tool.


### PR DESCRIPTION
Followup for the ADK Go 2.0.0 release in #1870.

The graph snippets infer JSON schemas from struct tags at runtime, but `google/jsonschema-go` rejects `jsonschema` tags beginning with `WORD=` (e.g. `description=`) since the tag value is itself the description, which caused the data-handling and human-input snippets to fail at execution. This strips the `description=` prefix so inference succeeds.

Example failure:

```
❯ go run ./snippets/graphs/human-input/
go: downloading google.golang.org/adk/v2 v2.0.0-20260630132642-893e4a403a8d
2026/06/30 10:53:37 Created graph HITL workflow: root_agent
2026/06/30 10:53:37 Created itinerary review workflow: concierge_workflow
2026/06/30 10:53:37 Failed to create simple HITL agent: failed to create tool: failed to infer input schema: For[main.DoubleNumberArgs](): tag must not begin with 'WORD=': "description=The number to double."
exit status 1
```

After this fix:

```
❯ go run ./snippets/graphs/human-input/
2026/06/30 10:56:55 Created graph HITL workflow: root_agent
2026/06/30 10:56:55 Created itinerary review workflow: concierge_workflow
2026/06/30 10:56:55 Created simple HITL agent: double_number_agent
2026/06/30 10:56:55 Created hint HITL agent: flight_booking_agent
```