### PR TITLE
Clean up ADK Go 2.0.0 quickstart and snippet docs

### DIFF
--- a/docs/get-started/go.md
+++ b/docs/get-started/go.md
@@ -172,7 +172,7 @@ go run agent.go web api webui
 ```
 
 This command starts a web server with a chat interface for your agent. You can
-access the web interface at (http://localhost:8080). Select your agent at the
+access the web interface at `http://localhost:8080`. Select your agent at the
 upper left corner and type a request.
 
 ![adk-web-dev-ui-chat.png](/assets/adk-web-dev-ui-chat.png)

--- a/docs/get-started/java.md
+++ b/docs/get-started/java.md
@@ -269,7 +269,7 @@ mvn compile exec:java \
 ```
 
 This command starts a web server with a chat interface for your agent. You can
-access the web interface at (http://localhost:8000). Select your agent at the
+access the web interface at `http://localhost:8000`. Select your agent at the
 upper left corner and type a request.
 
 ![adk-web-dev-ui-chat.png](/assets/adk-web-dev-ui-chat.png)

--- a/docs/get-started/kotlin.md
+++ b/docs/get-started/kotlin.md
@@ -279,7 +279,7 @@ gradle run -PmainClass=com.example.agent.WebMainKt
 ```
 
 This command starts a web server with a chat interface for your agent. You can
-access the web interface at (http://localhost:8080). Select your agent at the
+access the web interface at `http://localhost:8080`. Select your agent at the
 upper left corner and type a request.
 
 ![adk-web-dev-ui-chat.png](/assets/adk-web-dev-ui-chat.png)

--- a/docs/get-started/python.md
+++ b/docs/get-started/python.md
@@ -150,7 +150,7 @@ adk web --port 8000
     run `adk web` from the `agents/` directory.
 
 This command starts a web server with a chat interface for your agent. You can
-access the web interface at (http://localhost:8000). Select the agent at the
+access the web interface at `http://localhost:8000`. Select the agent at the
 upper left corner and type a request.
 
 ![adk-web-dev-ui-chat.png](/assets/adk-web-dev-ui-chat.png)

--- a/docs/get-started/typescript.md
+++ b/docs/get-started/typescript.md
@@ -139,7 +139,7 @@ npx adk web
 ```
 
 This command starts a web server with a chat interface for your agent. You can
-access the web interface at (http://localhost:8000). Select your agent at the
+access the web interface at `http://localhost:8000`. Select your agent at the
 upper right corner and type a request.
 
 ![adk-web-dev-ui-chat.png](/assets/adk-web-dev-ui-chat.png)

--- a/examples/go/snippets/graphs/data-handling/main.go
+++ b/examples/go/snippets/graphs/data-handling/main.go
@@ -15,7 +15,7 @@
 // Package main demonstrates data-handling patterns for ADK Go v2 workflow agents.
 //
 // NOTE: This file requires google.golang.org/adk/v2 (the workflow package),
-// available in ADK Go v2.0.0 and later.
+// available in ADK Go v2.0.0 and higher.
 //
 // # Data flow in ADK Go v2
 //

--- a/examples/go/snippets/graphs/data-handling/main.go
+++ b/examples/go/snippets/graphs/data-handling/main.go
@@ -14,7 +14,7 @@
 
 // Package main demonstrates data-handling patterns for ADK Go v2 workflow agents.
 //
-// NOTE: This file requires google.golang.org/adk (the workflow package),
+// NOTE: This file requires google.golang.org/adk/v2 (the workflow package),
 // available in ADK Go v2.0.0 and later.
 //
 // # Data flow in ADK Go v2

--- a/examples/go/snippets/graphs/dynamic/main.go
+++ b/examples/go/snippets/graphs/dynamic/main.go
@@ -14,7 +14,7 @@
 // Package main demonstrates dynamic workflow patterns in ADK Go v2.
 //
 // NOTE: This file requires the google.golang.org/adk/v2/workflow package,
-// which is available in ADK Go v2.0.0 and later. The workflow package is
+// which is available in ADK Go v2.0.0 and higher. The workflow package is
 // not present in v1.x releases. The snippets in this file are based on the
 // examples found in https://github.com/google/adk-go/tree/main/examples/workflow.
 //

--- a/examples/go/snippets/graphs/dynamic/main.go
+++ b/examples/go/snippets/graphs/dynamic/main.go
@@ -13,10 +13,10 @@
 // limitations under the License.
 // Package main demonstrates dynamic workflow patterns in ADK Go v2.
 //
-// NOTE: This file requires the google.golang.org/adk/workflow package,
+// NOTE: This file requires the google.golang.org/adk/v2/workflow package,
 // which is available in ADK Go v2.0.0 and later. The workflow package is
 // not present in v1.x releases. The snippets in this file are based on the
-// examples found in https://github.com/google/adk-go/releases/tag/v2.0.0/examples/workflow/.
+// examples found in https://github.com/google/adk-go/tree/main/examples/workflow.
 //
 // Key types and functions used in this file:
 //

--- a/examples/go/snippets/graphs/human-input/main.go
+++ b/examples/go/snippets/graphs/human-input/main.go
@@ -15,7 +15,7 @@
 // Package main demonstrates Human-in-the-Loop (HITL) patterns in ADK Go v2.
 //
 // NOTE: This file requires google.golang.org/adk/v2, available in ADK Go
-// v2.0.0 and later.
+// v2.0.0 and higher.
 //
 // # Graph HITL (primary pattern for /graphs/ pages)
 //

--- a/examples/go/snippets/graphs/index/main.go
+++ b/examples/go/snippets/graphs/index/main.go
@@ -15,7 +15,7 @@
 // Package main provides snippet examples for graph-based workflow agents in ADK Go v2.
 //
 // NOTE: This file requires google.golang.org/adk/v2 (the workflow package),
-// available in ADK Go v2.0.0 and later.
+// available in ADK Go v2.0.0 and higher.
 //
 // Both snippets use the v2 graph engine (workflow.NewFunctionNode +
 // workflowagent.New) rather than the prebuilt workflow agents from v1.x.

--- a/examples/go/snippets/graphs/index/main.go
+++ b/examples/go/snippets/graphs/index/main.go
@@ -14,7 +14,7 @@
 
 // Package main provides snippet examples for graph-based workflow agents in ADK Go v2.
 //
-// NOTE: This file requires google.golang.org/adk (the workflow package),
+// NOTE: This file requires google.golang.org/adk/v2 (the workflow package),
 // available in ADK Go v2.0.0 and later.
 //
 // Both snippets use the v2 graph engine (workflow.NewFunctionNode +

--- a/examples/go/snippets/graphs/routes/main.go
+++ b/examples/go/snippets/graphs/routes/main.go
@@ -17,7 +17,7 @@
 // workflow.Concat, workflow.NewEdgeBuilder, workflow.NewJoinNode, and
 // workflowagent.New.
 //
-// NOTE: This file requires google.golang.org/adk (the workflow package),
+// NOTE: This file requires google.golang.org/adk/v2 (the workflow package),
 // available in ADK Go v2.0.0 and later.
 //
 // This file contains five snippet regions used in docs/graphs/routes.md:

--- a/examples/go/snippets/graphs/routes/main.go
+++ b/examples/go/snippets/graphs/routes/main.go
@@ -18,7 +18,7 @@
 // workflowagent.New.
 //
 // NOTE: This file requires google.golang.org/adk/v2 (the workflow package),
-// available in ADK Go v2.0.0 and later.
+// available in ADK Go v2.0.0 and higher.
 //
 // This file contains five snippet regions used in docs/graphs/routes.md:
 //

--- a/examples/go/snippets/workflows/collaboration/main.go
+++ b/examples/go/snippets/workflows/collaboration/main.go
@@ -15,7 +15,7 @@
 // Package main demonstrates collaborative agent team patterns in ADK Go v2.
 //
 // NOTE: This file requires google.golang.org/adk/v2, available in ADK Go
-// v2.0.0 and later.
+// v2.0.0 and higher.
 //
 // # Agent collaboration modes in ADK Go v2
 //

--- a/examples/go/snippets/workflows/collaboration/main.go
+++ b/examples/go/snippets/workflows/collaboration/main.go
@@ -15,9 +15,7 @@
 // Package main demonstrates collaborative agent team patterns in ADK Go v2.
 //
 // NOTE: This file requires google.golang.org/adk/v2, available in ADK Go
-// v2.0.0 and later. It carries //go:build ignore so it is excluded from the
-// current examples/go module (which is still on the v1 path) until examples/go
-// is migrated to google.golang.org/adk at the v2.0.0 release.
+// v2.0.0 and later.
 //
 // # Agent collaboration modes in ADK Go v2
 //


### PR DESCRIPTION
Followup for the ADK Go 2.0.0 release in #1870.

Docs-only cleanup: format the local web-interface URLs as inline code in the five quickstart pages, and fix snippet comment NOTEs (correct `google.golang.org/adk/v2` paths, drop a stale build-ignore note, repoint a broken example link).