### PR TITLE
docs: update more Go documentation and examples to ADK Go v2

### DIFF
--- a/docs/_includes/homepage/_hero.md
+++ b/docs/_includes/homepage/_hero.md
@@ -40,7 +40,7 @@ agent = <span class="fn">Agent</span>(
 
 </pre></div>
 
-<div class="code-content" id="code-go" style="display:none"><pre><span class="kw">import</span> <span class="str">"google.golang.org/adk/agent/llmagent"</span>
+<div class="code-content" id="code-go" style="display:none"><pre><span class="kw">import</span> <span class="str">"google.golang.org/adk/v2/agent/llmagent"</span>
 
 model, _ := gemini.<span class="fn">NewModel</span>(context.<span class="fn">Background</span>(), <span class="str">"gemini-flash-latest"</span>, <span class="kw">nil</span>)
 a, _ := llmagent.<span class="fn">New</span>(llmagent.<span class="fn">Config</span>{
@@ -86,8 +86,8 @@ a, _ := llmagent.<span class="fn">New</span>(llmagent.<span class="fn">Config</s
       </div>
       <div class="install-info" id="install-go" style="display:none">
         <div class="install-cmd">
-          <code>go get google.golang.org/adk</code>
-          <button class="copy-btn" data-copy="go get google.golang.org/adk" title="Copy to clipboard">📋</button>
+          <code>go get google.golang.org/adk/v2</code>
+          <button class="copy-btn" data-copy="go get google.golang.org/adk/v2" title="Copy to clipboard">📋</button>
         </div>
       </div>
       <div class="install-info" id="install-java" style="display:none">

--- a/docs/agents/custom-agents.md
+++ b/docs/agents/custom-agents.md
@@ -348,8 +348,8 @@ The foundation for structuring multi-agent systems is the parent-child relations
 
     ```go
     import (
-        "google.golang.org/adk/agent"
-        "google.golang.org/adk/agent/llmagent"
+        "google.golang.org/adk/v2/agent"
+        "google.golang.org/adk/v2/agent/llmagent"
     )
 
     --8<-- "examples/go/snippets/agents/multi-agent/main.go:hierarchy"
@@ -426,9 +426,9 @@ ADK includes specialized agents derived from `BaseAgent` that don't perform task
 
     ```go
     import (
-        "google.golang.org/adk/agent"
-        "google.golang.org/adk/agent/llmagent"
-        "google.golang.org/adk/agent/workflowagents/sequentialagent"
+        "google.golang.org/adk/v2/agent"
+        "google.golang.org/adk/v2/agent/llmagent"
+        "google.golang.org/adk/v2/agent/workflowagents/sequentialagent"
     )
 
     --8<-- "examples/go/snippets/agents/multi-agent/main.go:sequential-pipeline"
@@ -490,9 +490,9 @@ ADK includes specialized agents derived from `BaseAgent` that don't perform task
 
     ```go
     import (
-        "google.golang.org/adk/agent"
-        "google.golang.org/adk/agent/llmagent"
-        "google.golang.org/adk/agent/workflowagents/parallelagent"
+        "google.golang.org/adk/v2/agent"
+        "google.golang.org/adk/v2/agent/llmagent"
+        "google.golang.org/adk/v2/agent/workflowagents/parallelagent"
     )
 
     --8<-- "examples/go/snippets/agents/multi-agent/main.go:parallel-execution"
@@ -600,10 +600,10 @@ ADK includes specialized agents derived from `BaseAgent` that don't perform task
     ```go
     import (
         "iter"
-        "google.golang.org/adk/agent"
-        "google.golang.org/adk/agent/llmagent"
-        "google.golang.org/adk/agent/workflowagents/loopagent"
-        "google.golang.org/adk/session"
+        "google.golang.org/adk/v2/agent"
+        "google.golang.org/adk/v2/agent/llmagent"
+        "google.golang.org/adk/v2/agent/workflowagents/loopagent"
+        "google.golang.org/adk/v2/session"
     )
 
     --8<-- "examples/go/snippets/agents/multi-agent/main.go:loop-with-condition"
@@ -704,9 +704,9 @@ The most fundamental way for agents operating within the same invocation (and th
 
     ```go
     import (
-        "google.golang.org/adk/agent"
-        "google.golang.org/adk/agent/llmagent"
-        "google.golang.org/adk/agent/workflowagents/sequentialagent"
+        "google.golang.org/adk/v2/agent"
+        "google.golang.org/adk/v2/agent/llmagent"
+        "google.golang.org/adk/v2/agent/workflowagents/sequentialagent"
     )
 
     --8<-- "examples/go/snippets/agents/multi-agent/main.go:output-key-state"
@@ -804,7 +804,7 @@ Leverages an [`LlmAgent`](llm-agents.md)'s understanding to dynamically route ta
 
     ```go
     import (
-        "google.golang.org/adk/agent/llmagent"
+        "google.golang.org/adk/v2/agent/llmagent"
     )
 
     --8<-- "examples/go/snippets/agents/multi-agent/main.go:llm-transfer"
@@ -947,12 +947,12 @@ Allows an [`LlmAgent`](llm-agents.md) to treat another `BaseAgent` instance as a
     import (
         "fmt"
         "iter"
-        "google.golang.org/adk/agent"
-        "google.golang.org/adk/agent/llmagent"
-        "google.golang.org/adk/model"
-        "google.golang.org/adk/session"
-        "google.golang.org/adk/tool"
-        "google.golang.org/adk/tool/agenttool"
+        "google.golang.org/adk/v2/agent"
+        "google.golang.org/adk/v2/agent/llmagent"
+        "google.golang.org/adk/v2/model"
+        "google.golang.org/adk/v2/session"
+        "google.golang.org/adk/v2/tool"
+        "google.golang.org/adk/v2/tool/agenttool"
         "google.golang.org/genai"
     )
 

--- a/docs/agents/llm-agents.md
+++ b/docs/agents/llm-agents.md
@@ -527,7 +527,7 @@ Control whether the agent receives the prior conversation history.
 === "Go"
 
     ```go
-    import "google.golang.org/adk/agent/llmagent"
+    import "google.golang.org/adk/v2/agent/llmagent"
 
     --8<-- "examples/go/snippets/agents/llm-agents/snippets/main.go:include_contents"
     ```

--- a/docs/agents/models/google-gemini.md
+++ b/docs/agents/models/google-gemini.md
@@ -51,8 +51,8 @@ in your agents:
 
     ```go
     import (
-    	"google.golang.org/adk/agent/llmagent"
-    	"google.golang.org/adk/model/gemini"
+    	"google.golang.org/adk/v2/agent/llmagent"
+    	"google.golang.org/adk/v2/model/gemini"
     	"google.golang.org/genai"
     )
 

--- a/docs/context/index.md
+++ b/docs/context/index.md
@@ -172,8 +172,8 @@ Here are the primary context flavors you will encounter:
 
         ```go
         import (
-        	"google.golang.org/adk/agent"
-        	"google.golang.org/adk/session"
+        	"google.golang.org/adk/v2/agent"
+        	"google.golang.org/adk/v2/session"
         )
 
         --8<-- "examples/go/snippets/context/main.go:invocation_context_agent"
@@ -239,7 +239,7 @@ Here are the primary context flavors you will encounter:
     === "Go"
 
         ```go
-        import "google.golang.org/adk/agent"
+        import "google.golang.org/adk/v2/agent"
 
         --8<-- "examples/go/snippets/context/main.go:readonly_context_instruction"
         ```
@@ -314,8 +314,8 @@ Here are the primary context flavors you will encounter:
 
         ```go
         import (
-        	"google.golang.org/adk/agent"
-        	"google.golang.org/adk/model"
+        	"google.golang.org/adk/v2/agent"
+        	"google.golang.org/adk/v2/model"
         )
 
         --8<-- "examples/go/snippets/context/main.go:callback_context_callback"
@@ -413,7 +413,7 @@ Here are the primary context flavors you will encounter:
     === "Go"
 
         ```go
-        import "google.golang.org/adk/tool"
+        import "google.golang.org/adk/v2/tool"
 
         --8<-- "examples/go/snippets/context/main.go:tool_context_tool"
         ```
@@ -518,9 +518,9 @@ You'll frequently need to read information stored within the context.
 
         ```go
         import (
-        	"google.golang.org/adk/agent"
-        	"google.golang.org/adk/session"
-            "google.golang.org/adk/tool"
+        	"google.golang.org/adk/v2/agent"
+        	"google.golang.org/adk/v2/session"
+            "google.golang.org/adk/v2/tool"
         	"google.golang.org/genai"
         )
 
@@ -593,7 +593,7 @@ You'll frequently need to read information stored within the context.
     === "Go"
 
         ```go
-        import "google.golang.org/adk/tool"
+        import "google.golang.org/adk/v2/tool"
 
         --8<-- "examples/go/snippets/context/main.go:accessing_ids"
         ```
@@ -656,7 +656,7 @@ You'll frequently need to read information stored within the context.
 
         ```go
         import (
-        	"google.golang.org/adk/agent"
+        	"google.golang.org/adk/v2/agent"
         	"google.golang.org/genai"
         )
 
@@ -742,7 +742,7 @@ State is crucial for memory and data flow. When you modify state using `Callback
     === "Go"
 
         ```go
-        import "google.golang.org/adk/tool"
+        import "google.golang.org/adk/v2/tool"
 
         --8<-- "examples/go/snippets/context/main.go:passing_data_tool1"
 
@@ -810,7 +810,7 @@ State is crucial for memory and data flow. When you modify state using `Callback
     === "Go"
 
         ```go
-        import "google.golang.org/adk/tool"
+        import "google.golang.org/adk/v2/tool"
 
         --8<-- "examples/go/snippets/context/main.go:updating_preferences"
         ```
@@ -894,7 +894,7 @@ Use artifacts to handle files or large data blobs associated with the session. C
 
             ```go
             import (
-            	"google.golang.org/adk/tool"
+            	"google.golang.org/adk/v2/tool"
             	"google.golang.org/genai"
             )
 
@@ -1039,7 +1039,7 @@ Use artifacts to handle files or large data blobs associated with the session. C
         === "Go"
 
             ```go
-            import "google.golang.org/adk/tool"
+            import "google.golang.org/adk/v2/tool"
 
             --8<-- "examples/go/snippets/context/main.go:artifacts_summarize"
             ```
@@ -1134,7 +1134,7 @@ Use artifacts to handle files or large data blobs associated with the session. C
     === "Go"
 
         ```go
-        import "google.golang.org/adk/tool"
+        import "google.golang.org/adk/v2/tool"
 
         --8<-- "examples/go/snippets/context/main.go:artifacts_list"
         ```

--- a/docs/deploy/gke.md
+++ b/docs/deploy/gke.md
@@ -256,13 +256,13 @@ We will reference the `capital_agent` example defined on the [LLM agents](../age
             "os"
             "strings"
 
-            "google.golang.org/adk/agent"
-            "google.golang.org/adk/agent/llmagent"
-            "google.golang.org/adk/cmd/launcher"
-            "google.golang.org/adk/cmd/launcher/full"
-            "google.golang.org/adk/model/gemini"
-            "google.golang.org/adk/tool"
-            "google.golang.org/adk/tool/functiontool"
+            "google.golang.org/adk/v2/agent"
+            "google.golang.org/adk/v2/agent/llmagent"
+            "google.golang.org/adk/v2/cmd/launcher"
+            "google.golang.org/adk/v2/cmd/launcher/full"
+            "google.golang.org/adk/v2/model/gemini"
+            "google.golang.org/adk/v2/tool"
+            "google.golang.org/adk/v2/tool/functiontool"
             "google.golang.org/genai"
         )
 

--- a/docs/integrations/cloud-trace.md
+++ b/docs/integrations/cloud-trace.md
@@ -157,7 +157,7 @@ For fully customized agent runtimes, you can enable cloud tracing by using the b
     	"log"
     	"time"
 
-    	"google.golang.org/adk/telemetry"
+    	"google.golang.org/adk/v2/telemetry"
     )
 
     func main() {

--- a/docs/integrations/mcp-toolbox-for-databases.md
+++ b/docs/integrations/mcp-toolbox-for-databases.md
@@ -248,7 +248,7 @@ documentation:
     	"fmt"
 
     	"github.com/googleapis/mcp-toolbox-sdk-go/tbadk"
-    	"google.golang.org/adk/agent/llmagent"
+    	"google.golang.org/adk/v2/agent/llmagent"
     )
 
     func main() {

--- a/docs/integrations/reflect-and-retry.md
+++ b/docs/integrations/reflect-and-retry.md
@@ -48,8 +48,8 @@ ADK project's App object, as shown below:
 
     ```go
     import (
-    	"google.golang.org/adk/plugin/retryandreflect"
-    	"google.golang.org/adk/runner"
+    	"google.golang.org/adk/v2/plugin/retryandreflect"
+    	"google.golang.org/adk/v2/runner"
     )
 
     // ... create rootAgent and sessionService ...

--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -199,7 +199,7 @@ To get detailed logs of agent activity (user messages, model requests/responses,
 
 ### Go programmatic setup
 
-In Go, ADK uses the `google.golang.org/adk/telemetry` package for OpenTelemetry
+In Go, ADK uses the `google.golang.org/adk/v2/telemetry` package for OpenTelemetry
 configuration and the standard `log` package for general events.
 
 #### Capture prompt content
@@ -211,7 +211,7 @@ package main
 
 import (
 	"context"
-	"google.golang.org/adk/telemetry"
+	"google.golang.org/adk/v2/telemetry"
 )
 
 func main() {
@@ -243,7 +243,7 @@ package main
 
 import (
 	"context"
-	"google.golang.org/adk/telemetry"
+	"google.golang.org/adk/v2/telemetry"
 )
 
 func main() {

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -210,10 +210,10 @@ methods, as shown in the following code example:
     import (
     	"fmt"
 
-    	"google.golang.org/adk/agent"
-    	"google.golang.org/adk/agent/llmagent"
-    	"google.golang.org/adk/model"
-    	"google.golang.org/adk/plugin"
+    	"google.golang.org/adk/v2/agent"
+    	"google.golang.org/adk/v2/agent/llmagent"
+    	"google.golang.org/adk/v2/model"
+    	"google.golang.org/adk/v2/plugin"
         "google.golang.org/genai"
     )
 
@@ -474,14 +474,14 @@ a simple ADK agent.
     	"fmt"
     	"log"
 
-    	"google.golang.org/adk/agent"
-    	"google.golang.org/adk/agent/llmagent"
-    	"google.golang.org/adk/model/gemini"
-    	"google.golang.org/adk/plugin"
-    	"google.golang.org/adk/runner"
-    	"google.golang.org/adk/session"
-    	"google.golang.org/adk/tool"
-    	"google.golang.org/adk/tool/functiontool"
+    	"google.golang.org/adk/v2/agent"
+    	"google.golang.org/adk/v2/agent/llmagent"
+    	"google.golang.org/adk/v2/model/gemini"
+    	"google.golang.org/adk/v2/plugin"
+    	"google.golang.org/adk/v2/runner"
+    	"google.golang.org/adk/v2/session"
+    	"google.golang.org/adk/v2/tool"
+    	"google.golang.org/adk/v2/tool/functiontool"
     	"google.golang.org/genai"
     )
 

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -34,8 +34,8 @@ Use the following command to run your agent in an ADK API server:
 
     ```go title="main.go"
     import (
-        "google.golang.org/adk/cmd/launcher"
-        "google.golang.org/adk/cmd/launcher/full"
+        "google.golang.org/adk/v2/cmd/launcher"
+        "google.golang.org/adk/v2/cmd/launcher/full"
     )
 
     func main() {

--- a/docs/runtime/command-line.md
+++ b/docs/runtime/command-line.md
@@ -35,8 +35,8 @@ Use the following command to run your agent in the ADK command line interface:
 
     ```go title="main.go"
     import (
-        "google.golang.org/adk/cmd/launcher"
-        "google.golang.org/adk/cmd/launcher/full"
+        "google.golang.org/adk/v2/cmd/launcher"
+        "google.golang.org/adk/v2/cmd/launcher/full"
     )
 
     func main() {

--- a/docs/runtime/event-loop.md
+++ b/docs/runtime/event-loop.md
@@ -103,7 +103,7 @@ The `Runner` acts as the central coordinator for a single user invocation. Its r
         return func(yield func(*Event, error) bool) {
             // 1. Append new_query to session event history (via SessionService)
             // ...
-            userEvent := session.NewEvent(ctx.InvocationID()) // Simplified for conceptual view
+            userEvent := session.NewEvent(ctx, ctx.InvocationID()) // Simplified for conceptual view
             userEvent.Author = "user"
             userEvent.LLMResponse = model.LLMResponse{Content: newQuery}
 
@@ -528,7 +528,7 @@ Understanding a few key aspects of how the ADK Runtime handles state, streaming,
 
           // 1. Determine a change or output is needed, construct the event
           updateData := map[string]interface{}{"field_1": "value_2"}
-          eventWithStateChange := session.NewEvent(ctx.InvocationID())
+          eventWithStateChange := session.NewEvent(ctx, ctx.InvocationID())
           eventWithStateChange.Author = a.Name()
           eventWithStateChange.Actions = &session.EventActions{StateDelta: updateData}
           // ... other event fields ...
@@ -554,7 +554,7 @@ Understanding a few key aspects of how the ADK Runtime handles state, streaming,
           // of the *next* `Run` invocation in a subsequent turn.
 
           // ... subsequent code continues, potentially yielding more events ...
-          finalEvent := session.NewEvent(ctx.InvocationID())
+          finalEvent := session.NewEvent(ctx, ctx.InvocationID())
           finalEvent.Author = a.Name()
           // ...
           yield(finalEvent, nil)

--- a/docs/runtime/runconfig.md
+++ b/docs/runtime/runconfig.md
@@ -39,7 +39,7 @@ to `runner.run_async()` or `runner.run_live()` to override default behavior.
 === "Go"
 
     ```go
-    import "google.golang.org/adk/agent"
+    import "google.golang.org/adk/v2/agent"
 
     config := agent.RunConfig{
         StreamingMode: agent.StreamingModeSSE,
@@ -138,7 +138,7 @@ execute function calls. CFC uses the Live API under the hood.
 === "Go"
 
     ```go
-    import "google.golang.org/adk/agent"
+    import "google.golang.org/adk/v2/agent"
 
     config := agent.RunConfig{
         StreamingMode: agent.StreamingModeSSE,

--- a/docs/runtime/web-interface/index.md
+++ b/docs/runtime/web-interface/index.md
@@ -50,8 +50,8 @@ Use the following command to start the ADK web interface:
 
     ```go title="main.go"
     import (
-        "google.golang.org/adk/cmd/launcher"
-        "google.golang.org/adk/cmd/launcher/full"
+        "google.golang.org/adk/v2/cmd/launcher"
+        "google.golang.org/adk/v2/cmd/launcher/full"
     )
 
     func main() {

--- a/docs/safety/index.md
+++ b/docs/safety/index.md
@@ -226,7 +226,7 @@ During the tool execution, [**`Tool Context`**](../tools-custom/index.md#tool-co
     	"fmt"
     	"strings"
 
-    	"google.golang.org/adk/tool"
+    	"google.golang.org/adk/v2/tool"
     )
 
     func query(ctx tool.Context, args QueryArgs) (map[string]any, error) {
@@ -351,7 +351,7 @@ Gemini models come with in-built safety mechanisms that can be leveraged to impr
 
     ```go
     import (
-    	"google.golang.org/adk/agent/llmagent"
+    	"google.golang.org/adk/v2/agent/llmagent"
     	"google.golang.org/genai"
     )
 
@@ -464,8 +464,8 @@ When modifications to the tools to add guardrails aren't possible, the [**`Befor
     import (
     	"fmt"
 
-    	"google.golang.org/adk/agent/llmagent"
-    	"google.golang.org/adk/tool"
+    	"google.golang.org/adk/v2/agent/llmagent"
+    	"google.golang.org/adk/v2/tool"
     )
 
     // Hypothetical callback function

--- a/docs/sessions/memory.md
+++ b/docs/sessions/memory.md
@@ -60,8 +60,8 @@ The `InMemoryMemoryService` stores session information in the application's memo
 === "Go"
     ```go
     import (
-      "google.golang.org/adk/memory"
-      "google.golang.org/adk/session"
+      "google.golang.org/adk/v2/memory"
+      "google.golang.org/adk/v2/session"
     )
 
     // Services must be shared across runners to share state and memory.
@@ -382,9 +382,9 @@ When a memory service is configured, your agent can use a tool or callback to re
 === "Go"
     ```go
     import (
-        "google.golang.org/adk/agent/llmagent"
-        "google.golang.org/adk/tool"
-        "google.golang.org/adk/tool/preloadmemorytool"
+        "google.golang.org/adk/v2/agent/llmagent"
+        "google.golang.org/adk/v2/tool"
+        "google.golang.org/adk/v2/tool/preloadmemorytool"
     )
 
     agent, _ := llmagent.New(llmagent.Config{
@@ -457,11 +457,11 @@ To extract memories from your session, you need to call `add_session_to_memory`.
     ```go
     import (
         "context"
-        "google.golang.org/adk/agent"
-        "google.golang.org/adk/agent/llmagent"
-        "google.golang.org/adk/session"
-        "google.golang.org/adk/tool"
-        "google.golang.org/adk/tool/loadmemorytool"
+        "google.golang.org/adk/v2/agent"
+        "google.golang.org/adk/v2/agent/llmagent"
+        "google.golang.org/adk/v2/session"
+        "google.golang.org/adk/v2/tool"
+        "google.golang.org/adk/v2/tool/loadmemorytool"
     )
 
     func autoSaveSessionToMemoryCallback(ctx agent.CallbackContext, s session.Session) (*genai.Content, error) {

--- a/docs/sessions/session/index.md
+++ b/docs/sessions/session/index.md
@@ -215,7 +215,7 @@ the storage backend that best suits your needs:
 === "Go"
 
       ```go
-        import "google.golang.org/adk/session"
+        import "google.golang.org/adk/v2/session"
         inMemoryService := session.InMemoryService()
       ```
 
@@ -273,7 +273,7 @@ the storage backend that best suits your needs:
 === "Go"
 
     ```go
-    import "google.golang.org/adk/session"
+    import "google.golang.org/adk/v2/session"
 
     // 2. VertexAIService
     // Before running, ensure your environment is authenticated:

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -72,10 +72,10 @@ You can define [skills in code](#inline-skills) or load
         "context"
         "os"
 
-        "google.golang.org/adk/agent/llmagent"
-        "google.golang.org/adk/tool/skilltoolset/skill"
-        "google.golang.org/adk/tool/skilltoolset"
-        "google.golang.org/adk/tool"
+        "google.golang.org/adk/v2/agent/llmagent"
+        "google.golang.org/adk/v2/tool/skilltoolset/skill"
+        "google.golang.org/adk/v2/tool/skilltoolset"
+        "google.golang.org/adk/v2/tool"
     )
 
     mySkillToolset, err := skilltoolset.New(ctx, skilltoolset.Config{
@@ -205,7 +205,7 @@ You can define Skills within the code of your agent, as shown below.
         "slices"
         "strings"
 
-        "google.golang.org/adk/tool/skilltoolset/skill"
+        "google.golang.org/adk/v2/tool/skilltoolset/skill"
     )
 
     // Example implementation of a static in-memory skill.Source:
@@ -288,8 +288,8 @@ You can define Skills within the code of your agent, as shown below.
     import (
         "os"
 
-        "google.golang.org/adk/tool/skilltoolset/skill"
-        "google.golang.org/adk/tool/skilltoolset"
+        "google.golang.org/adk/v2/tool/skilltoolset/skill"
+        "google.golang.org/adk/v2/tool/skilltoolset"
     )
 
     // ...

--- a/docs/tools-custom/function-tools.md
+++ b/docs/tools-custom/function-tools.md
@@ -265,13 +265,13 @@ A tool can write data to a `temp:` variable, and a subsequent tool can read it. 
 
         ```go
         import (
-            "google.golang.org/adk/agent"
-            "google.golang.org/adk/agent/llmagent"
-            "google.golang.org/adk/model/gemini"
-            "google.golang.org/adk/runner"
-            "google.golang.org/adk/session"
-            "google.golang.org/adk/tool"
-            "google.golang.org/adk/tool/functiontool"
+            "google.golang.org/adk/v2/agent"
+            "google.golang.org/adk/v2/agent/llmagent"
+            "google.golang.org/adk/v2/model/gemini"
+            "google.golang.org/adk/v2/runner"
+            "google.golang.org/adk/v2/session"
+            "google.golang.org/adk/v2/tool"
+            "google.golang.org/adk/v2/tool/functiontool"
             "google.golang.org/genai"
         )
 
@@ -373,11 +373,11 @@ Define your tool function and wrap it using the `LongRunningFunctionTool` class:
 
     ```go
     import (
-        "google.golang.org/adk/agent"
-        "google.golang.org/adk/agent/llmagent"
-        "google.golang.org/adk/model/gemini"
-        "google.golang.org/adk/tool"
-        "google.golang.org/adk/tool/functiontool"
+        "google.golang.org/adk/v2/agent"
+        "google.golang.org/adk/v2/agent/llmagent"
+        "google.golang.org/adk/v2/model/gemini"
+        "google.golang.org/adk/v2/tool"
+        "google.golang.org/adk/v2/tool/functiontool"
         "google.golang.org/genai"
     )
 
@@ -594,11 +594,11 @@ The `AgentTool` class provides the following attributes for customizing its beha
 
         ```go
         import (
-            "google.golang.org/adk/agent"
-            "google.golang.org/adk/agent/llmagent"
-            "google.golang.org/adk/model/gemini"
-            "google.golang.org/adk/tool"
-            "google.golang.org/adk/tool/agenttool"
+            "google.golang.org/adk/v2/agent"
+            "google.golang.org/adk/v2/agent/llmagent"
+            "google.golang.org/adk/v2/model/gemini"
+            "google.golang.org/adk/v2/tool"
+            "google.golang.org/adk/v2/tool/agenttool"
             "google.golang.org/genai"
         )
 

--- a/docs/tutorials/multi-tool-agent.md
+++ b/docs/tutorials/multi-tool-agent.md
@@ -82,7 +82,7 @@ entirely on your machine and is recommended for internal development.
     To add the ADK to your project, run the following command:
 
     ```bash
-    go get google.golang.org/adk
+    go get google.golang.org/adk/v2
     ```
 
     This will add the ADK as a dependency to your `go.mod` file.

--- a/docs/workflows/patterns.md
+++ b/docs/workflows/patterns.md
@@ -65,8 +65,8 @@ your project requirements before committing to a full implementation.
 
     ```go
     import (
-        "google.golang.org/adk/agent"
-        "google.golang.org/adk/agent/llmagent"
+        "google.golang.org/adk/v2/agent"
+        "google.golang.org/adk/v2/agent/llmagent"
     )
 
     --8<-- "examples/go/snippets/agents/multi-agent/main.go:coordinator-pattern"
@@ -162,9 +162,9 @@ your project requirements before committing to a full implementation.
 
     ```go
     import (
-        "google.golang.org/adk/agent"
-        "google.golang.org/adk/agent/llmagent"
-        "google.golang.org/adk/agent/workflowagents/sequentialagent"
+        "google.golang.org/adk/v2/agent"
+        "google.golang.org/adk/v2/agent/llmagent"
+        "google.golang.org/adk/v2/agent/workflowagents/sequentialagent"
     )
 
     --8<-- "examples/go/snippets/agents/multi-agent/main.go:sequential-pipeline-pattern"
@@ -284,10 +284,10 @@ your project requirements before committing to a full implementation.
 
     ```go
     import (
-        "google.golang.org/adk/agent"
-        "google.golang.org/adk/agent/llmagent"
-        "google.golang.org/adk/agent/workflowagents/parallelagent"
-        "google.golang.org/adk/agent/workflowagents/sequentialagent"
+        "google.golang.org/adk/v2/agent"
+        "google.golang.org/adk/v2/agent/llmagent"
+        "google.golang.org/adk/v2/agent/workflowagents/parallelagent"
+        "google.golang.org/adk/v2/agent/workflowagents/sequentialagent"
     )
 
     --8<-- "examples/go/snippets/agents/multi-agent/main.go:parallel-gather-pattern"
@@ -418,9 +418,9 @@ your project requirements before committing to a full implementation.
 
     ```go
     import (
-        "google.golang.org/adk/agent/llmagent"
-        "google.golang.org/adk/tool"
-        "google.golang.org/adk/tool/agenttool"
+        "google.golang.org/adk/v2/agent/llmagent"
+        "google.golang.org/adk/v2/tool"
+        "google.golang.org/adk/v2/tool/agenttool"
     )
 
     --8<-- "examples/go/snippets/agents/multi-agent/main.go:hierarchical-pattern"
@@ -550,9 +550,9 @@ your project requirements before committing to a full implementation.
 
     ```go
     import (
-        "google.golang.org/adk/agent"
-        "google.golang.org/adk/agent/llmagent"
-        "google.golang.org/adk/agent/workflowagents/sequentialagent"
+        "google.golang.org/adk/v2/agent"
+        "google.golang.org/adk/v2/agent/llmagent"
+        "google.golang.org/adk/v2/agent/workflowagents/sequentialagent"
     )
 
     --8<-- "examples/go/snippets/agents/multi-agent/main.go:generator-critic-pattern"
@@ -707,10 +707,10 @@ your project requirements before committing to a full implementation.
     ```go
     import (
         "iter"
-        "google.golang.org/adk/agent"
-        "google.golang.org/adk/agent/llmagent"
-        "google.golang.org/adk/agent/workflowagents/loopagent"
-        "google.golang.org/adk/session"
+        "google.golang.org/adk/v2/agent"
+        "google.golang.org/adk/v2/agent/llmagent"
+        "google.golang.org/adk/v2/agent/workflowagents/loopagent"
+        "google.golang.org/adk/v2/session"
     )
 
     --8<-- "examples/go/snippets/agents/multi-agent/main.go:iterative-refinement-pattern"
@@ -903,10 +903,10 @@ your project requirements before committing to a full implementation.
 
     ```go
     import (
-        "google.golang.org/adk/agent"
-        "google.golang.org/adk/agent/llmagent"
-        "google.golang.org/adk/agent/workflowagents/sequentialagent"
-        "google.golang.org/adk/tool"
+        "google.golang.org/adk/v2/agent"
+        "google.golang.org/adk/v2/agent/llmagent"
+        "google.golang.org/adk/v2/agent/workflowagents/sequentialagent"
+        "google.golang.org/adk/v2/tool"
     )
 
     --8<-- "examples/go/snippets/agents/multi-agent/main.go:human-in-loop-pattern"


### PR DESCRIPTION
This PR updates the documentation to use ADK Go v2.

### Changes
- Updated Go import paths from `google.golang.org/adk/...` to `google.golang.org/adk/v2/...` across 22
  documentation files to align with the v2 release.
- Updated Go installation commands to reference `v2`.
- Fixed `session.NewEvent` API calls in `docs/runtime/event-loop.md` to include the required `context.Context`
  argument as introduced in v2.
- Verified that all Go examples in the repository compile and pass tests with ADK Go v2.

### Exceptions Preserved
- Kept references to `v1` in the 2.0 migration guide, installation tips for v1 users, and reference links to v1
  API docs