### PR TITLE
docs(agents): add Managed Agents page (Managed Agents API x ADK)

### DIFF
--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -97,6 +97,9 @@ dive deeper into how they work and how to use them effectively:
 * [**Simple agents:**](/agents/llm-agents/) Explore how to configure agents
   powered by AI models, including setting instructions, providing tools, and
   enabling advanced features like planning and code execution.
+* [**Managed agents:**](/agents/managed-agents/) Use Google's first-party,
+  out-of-the-box agents (backed by the Managed Agents API) directly in your ADK
+  flows, with built-in server-side tools like web search and code execution.
 * [**Graph workflows:**](/graphs/) Discover how evolve your agents from
   plain language instructions to composable, reliable execution paths that
   combine AI reasoning with deterministic code logic.

--- a/docs/agents/managed-agents.md
+++ b/docs/agents/managed-agents.md
@@ -4,8 +4,8 @@
   <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
 </div>
 
-Managed agents let you use Google's first-party, out-of-the-box agents—backed by
-the Managed Agents API (`interactions.create`)—from within your ADK flows. The
+Managed agents let you use Google's first-party, out-of-the-box agents, backed by
+the Managed Agents API (`interactions.create`), from within your ADK flows. The
 `ManagedAgent` class connects to a managed agent (such as the Antigravity agent)
 that runs in a specialized, server-side execution environment, so you get
 powerful built-in capabilities without managing sandboxes or writing client-side
@@ -29,7 +29,7 @@ This gives you:
 *   **First-party, out-of-the-box agents.** Connect to ready-made agents (for
     example, the Antigravity agent) by referencing their `agent_id`.
 *   **Built-in, server-side execution.** Capabilities such as web search and code
-    execution run in a managed sandbox on the server—no local sandbox to
+    execution run in a managed sandbox on the server, with no local sandbox to
     provision or secure.
 *   **No client-side function declarations.** Server-side tools are configured on
     the managed agent, so you don't declare or execute them locally.
@@ -55,8 +55,8 @@ The Gemini Enterprise Agents Platform (GEAP) was formerly known as Vertex.
 
 *   **Authentication.** GEAP requires Google Cloud credentials. Follow the
     [GEAP setup instructions](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/managed-agents/create-manage#before-you-begin)
-    to authenticate your local environment—for example, with
-    `gcloud auth application-default login`.
+    to authenticate your local environment (for example, with
+    `gcloud auth application-default login`).
 *   **Location.** The Managed Agents API is served only from the `global`
     location. `ManagedAgent` enforces a connection to `global` on the GEAP
     backend.
@@ -112,26 +112,23 @@ mostly a trade-off between out-of-the-box power and fine-grained control.
     fine-grained control over the model, instructions, tools (including custom
     function tools and MCP tools), and where execution happens.
 
-Use the following table as a starting point:
-
-| Scenario | Recommended path |
-| --- | --- |
-| You need web-grounded answers or server-side code execution with no tool or sandbox setup | Managed agent |
-| You want to use a first-party, out-of-the-box agent (such as Antigravity) as-is | Managed agent |
-| You need custom Python function tools, callables, or MCP tools | Build your own ADK agent |
-| You need custom instructions, a specific model, or client-side tool execution | Build your own ADK agent |
-| You need a regional (non-`global`) deployment on GEAP | Build your own ADK agent |
-
 ## How it works
 
-`ManagedAgent` implements the `BaseAgent` contract but bypasses standard
-`generate_content` calls. Instead, it sends interactions via
-`_create_interactions` with `background=True` and streams partial and terminal
-events back to the ADK `Runner` or parent flow in real time. On the GEAP backend
-it enforces a connection to the `global` location, since the Managed Agents API
-is only available globally. Tools are translated into standard `ToolParam`
-formats; any raw `google.genai.types.Tool` configs are passed through to the
-backend, enabling server-side code execution or web search.
+When you invoke a `ManagedAgent`, ADK sends your request to the managed agent via
+the [Interactions API](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/managed-agents/interact-with-agents)
+and streams the results, both partial and final, back into your ADK flow in real
+time. The reasoning, tools, and execution all run in Google's managed environment
+rather than in your ADK process.
+
+!!! note "How `ManagedAgent` maps to the Managed Agents API"
+    An ADK `ManagedAgent` does not create or register a new managed agent
+    resource. It connects to an agent that already exists on the backend (the one
+    named by `agent_id`) and applies its configuration (such as `tools` and
+    `environment`) as per-interaction overrides at runtime. In Managed Agents API
+    terms, ADK works entirely on the *data plane* (the Interactions API) and
+    leaves the *control plane* (the Agents API, which creates and manages agent
+    resources) untouched. For how these two planes differ, see the
+    [Managed Agents API system architecture](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/managed-agents).
 
 ### Local session vs. remote state
 
@@ -141,8 +138,8 @@ values on the events it emits: the `previous_interaction_id` and the sandbox
 session events, then reuses them so the conversation and its sandbox continue.
 
 Everything else lives server-side. The Managed Agents API owns the sandbox
-environment and the full interaction history, and that remote interaction—not the
-local session—is the source of truth for continuing a conversation. Response text
+environment and the full interaction history, and that remote interaction, not the
+local session, is the source of truth for continuing a conversation. Response text
 appears in both the local ADK events and the remote interaction history, but ADK
 stores only the IDs it needs to recover and reuse the remote state; it never
 re-sends prior turns.

--- a/docs/agents/managed-agents.md
+++ b/docs/agents/managed-agents.md
@@ -121,3 +121,57 @@ Use the following table as a starting point:
 | You need custom Python function tools, callables, or MCP tools | Build your own ADK agent |
 | You need custom instructions, a specific model, or client-side tool execution | Build your own ADK agent |
 | You need a regional (non-`global`) deployment on GEAP | Build your own ADK agent |
+
+## How it works
+
+`ManagedAgent` implements the `BaseAgent` contract but bypasses standard
+`generate_content` calls. Instead, it sends interactions via
+`_create_interactions` with `background=True` and streams partial and terminal
+events back to the ADK `Runner` or parent flow in real time. On the GEAP backend
+it enforces a connection to the `global` location, since the Managed Agents API
+is only available globally. Tools are translated into standard `ToolParam`
+formats; any raw `google.genai.types.Tool` configs are passed through to the
+backend, enabling server-side code execution or web search.
+
+### Local session vs. remote state
+
+`ManagedAgent` keeps almost no state locally. The ADK session persists only two
+values on the events it emits: the `previous_interaction_id` and the sandbox
+`environment_id`. On each new turn the agent recovers both by scanning prior
+session events, then reuses them so the conversation and its sandbox continue.
+
+Everything else lives server-side. The Managed Agents API owns the sandbox
+environment and the full interaction history, and that remote interaction—not the
+local session—is the source of truth for continuing a conversation. Response text
+appears in both the local ADK events and the remote interaction history, but ADK
+stores only the IDs it needs to recover and reuse the remote state; it never
+re-sends prior turns.
+
+## Limitations and notes
+
+*   **Location pinned (GEAP only).** For the GEAP backend, the Managed Agents API
+    is currently served only from the `global` location. Regional endpoints raise
+    an error.
+*   **Server-side tools only.** Client-executed tools (Python functions,
+    callables) and MCP tools are not supported and raise a `NotImplementedError`.
+*   **Streaming only.** The agent uses streaming interactions (`stream=True`).
+    Background-polling execution and strictly non-streaming connections are not
+    yet fully supported.
+*   **Backend differences.** The Gemini API and GEAP backends currently exhibit
+    slightly different behavioral patterns. Test against the specific backend you
+    intend to use.
+
+## Related resources
+
+*   **Samples:**
+    [Managed Agent Basic](https://github.com/google/adk-python/tree/main/contributing/samples/managed_agent/basic)
+    and
+    [Managed Agent Code Execution](https://github.com/google/adk-python/tree/main/contributing/samples/managed_agent/code_execution).
+*   **Backend documentation:**
+    [Gemini API Agents](https://ai.google.dev/gemini-api/docs/agents)
+    and
+    [GEAP Managed Agents](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/managed-agents).
+*   **Related ADK topics:**
+    [Models for agents](/agents/models/),
+    [Multi-agent workflows](/workflows/), and
+    [Custom tools](/tools-custom/).

--- a/docs/agents/managed-agents.md
+++ b/docs/agents/managed-agents.md
@@ -1,0 +1,65 @@
+# Managed agents
+
+<div class="language-support-tag">
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
+</div>
+
+Managed agents let you use Google's first-party, out-of-the-box agents—backed by
+the Managed Agents API (`interactions.create`)—from within your ADK flows. The
+`ManagedAgent` class connects to a managed agent (such as the Antigravity agent)
+that runs in a specialized, server-side execution environment, so you get
+powerful built-in capabilities without managing sandboxes or writing client-side
+function declarations.
+
+`ManagedAgent` implements the same `BaseAgent` contract as other ADK agents, so
+you can use it standalone or drop it directly into an ADK flow. It is a good fit
+when you want a robust, server-hosted agent with specialized built-in tools
+rather than building and operating that environment yourself.
+
+## What are managed agents?
+
+A *managed agent* is an agent whose reasoning, tools, and execution environment
+are hosted and operated by Google through the Managed Agents API, rather than run
+by your own ADK process. Instead of issuing standard `generate_content` calls,
+`ManagedAgent` creates server-side *interactions* and streams the results back
+into your ADK flow.
+
+This gives you:
+
+*   **First-party, out-of-the-box agents.** Connect to ready-made agents (for
+    example, the Antigravity agent) by referencing their `agent_id`.
+*   **Built-in, server-side execution.** Capabilities such as web search and code
+    execution run in a managed sandbox on the server—no local sandbox to
+    provision or secure.
+*   **No client-side function declarations.** Server-side tools are configured on
+    the managed agent, so you don't declare or execute them locally.
+
+## Backends and setup
+
+`ManagedAgent` supports two backends. Complete the prerequisites for the backend
+you plan to use: obtain credentials and an `agent_id`.
+
+### Gemini API backend
+
+*   **Authentication.** Obtain a Gemini API key and set it as the
+    `GEMINI_API_KEY` environment variable.
+*   **Agent ID.** You need an `agent_id` to connect to. You can either:
+    *   Create a new agent by following the
+        [Gemini API Agents documentation](https://ai.google.dev/gemini-api/docs/agents).
+    *   Use an out-of-the-box agent ID, such as `antigravity-preview-05-2026`,
+        which is used in the examples below.
+
+### Gemini Enterprise Agents Platform (GEAP) backend
+
+The Gemini Enterprise Agents Platform (GEAP) was formerly known as Vertex.
+
+*   **Authentication.** GEAP requires Google Cloud credentials. Follow the
+    [GEAP setup instructions](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/managed-agents/create-manage#before-you-begin)
+    to authenticate your local environment—for example, with
+    `gcloud auth application-default login`.
+*   **Location.** The Managed Agents API is served only from the `global`
+    location. `ManagedAgent` enforces a connection to `global` on the GEAP
+    backend.
+*   **Agent ID.** As with the Gemini API, you need an `agent_id`. Create one via
+    the [GEAP Managed Agents guide](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/managed-agents),
+    or use an out-of-the-box agent ID available to your project.

--- a/docs/agents/managed-agents.md
+++ b/docs/agents/managed-agents.md
@@ -115,7 +115,7 @@ mostly a trade-off between out-of-the-box power and fine-grained control.
 ## How it works
 
 When you invoke a `ManagedAgent`, ADK sends your request to the managed agent via
-the [Interactions API](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/managed-agents/interact-with-agents)
+the [Interactions API](https://ai.google.dev/gemini-api/docs/interactions-overview)
 and streams the results, both partial and final, back into your ADK flow in real
 time. The reasoning, tools, and execution all run in Google's managed environment
 rather than in your ADK process.

--- a/docs/agents/managed-agents.md
+++ b/docs/agents/managed-agents.md
@@ -63,3 +63,61 @@ The Gemini Enterprise Agents Platform (GEAP) was formerly known as Vertex.
 *   **Agent ID.** As with the Gemini API, you need an `agent_id`. Create one via
     the [GEAP Managed Agents guide](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/managed-agents),
     or use an out-of-the-box agent ID available to your project.
+
+## Get started
+
+The following example creates two managed agents: one that answers questions
+using web search, and one that solves computational questions by running code
+server-side. Both run their tools in the managed environment
+(`environment={'type': 'remote'}`).
+
+=== "Python"
+
+    ```python
+    import os
+    from google.adk.agents import ManagedAgent
+    from google.adk.tools import google_search
+    from google.genai import types
+
+    # Ensure you have the MANAGED_AGENT_ID and the proper environment config
+    _AGENT_ID = os.environ.get('MANAGED_AGENT_ID', 'antigravity-preview-05-2026')
+
+    managed_search_agent = ManagedAgent(
+        name='managed_search_agent',
+        description='Answers questions that need fresh, grounded information from the web.',
+        agent_id=_AGENT_ID,
+        environment={'type': 'remote'},
+        tools=[google_search],
+    )
+
+    # A managed code execution agent using raw types.Tool
+    managed_code_execution_agent = ManagedAgent(
+        name='managed_code_execution_agent',
+        description='Solves computational questions by running code server-side.',
+        agent_id=_AGENT_ID,
+        environment={'type': 'remote'},
+        tools=[types.Tool(code_execution=types.ToolCodeExecution())],
+    )
+    ```
+
+## When to use managed agents vs. building your own
+
+Managed agents and ADK agents solve different problems. Choosing between them is
+mostly a trade-off between out-of-the-box power and fine-grained control.
+
+*   **Managed agents** give you a powerful agent out of the box, but with limited
+    flexibility. The toolset is predefined and server-side, the agent runs only
+    in the managed environment, and client-side or MCP tools are not supported.
+*   **ADK agents** (such as [`LlmAgent`](/agents/llm-agents/)) give you
+    fine-grained control over the model, instructions, tools (including custom
+    function tools and MCP tools), and where execution happens.
+
+Use the following table as a starting point:
+
+| Scenario | Recommended path |
+| --- | --- |
+| You need web-grounded answers or server-side code execution with no tool or sandbox setup | Managed agent |
+| You want to use a first-party, out-of-the-box agent (such as Antigravity) as-is | Managed agent |
+| You need custom Python function tools, callables, or MCP tools | Build your own ADK agent |
+| You need custom instructions, a specific model, or client-side tool execution | Build your own ADK agent |
+| You need a regional (non-`global`) deployment on GEAP | Build your own ADK agent |

--- a/docs/agents/managed-agents.md
+++ b/docs/agents/managed-agents.md
@@ -1,13 +1,16 @@
 # Managed agents
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v2.4.0</span><span class="lst-preview">Preview</span>
 </div>
 
-Managed agents let you use Google's first-party, out-of-the-box agents, backed by
-the Managed Agents API (`interactions.create`), from within your ADK flows. The
-`ManagedAgent` class connects to a managed agent (such as the Antigravity agent)
-that runs in a specialized, server-side execution environment, so you get
+Managed agents let you use Google's first-party, out-of-the-box agents, backed
+by the Managed Agents API, from within your ADK flows. Managed agents are
+available through the [Gemini API](https://ai.google.dev/gemini-api/docs/agents)
+and [Agent
+Platform](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/managed-agents).
+The `ManagedAgent` class connects to a managed agent (such as the Antigravity
+agent) that runs in a specialized, server-side execution environment, so you get
 powerful built-in capabilities without managing sandboxes or writing client-side
 function declarations.
 
@@ -19,50 +22,60 @@ rather than building and operating that environment yourself.
 ## What are managed agents?
 
 A *managed agent* is an agent whose reasoning, tools, and execution environment
-are hosted and operated by Google through the Managed Agents API, rather than run
-by your own ADK process. Instead of issuing standard `generate_content` calls,
-`ManagedAgent` creates server-side *interactions* and streams the results back
-into your ADK flow.
+are hosted and operated by Google through the Managed Agents API, rather than
+run by your own ADK process. Instead of issuing standard `generate_content`
+calls, `ManagedAgent` creates server-side *interactions* and streams the results
+back into your ADK flow. Managed agents provide several built-in advantages:
 
-This gives you:
+- **First-party, out-of-the-box agents:** Connect to ready-made agents (for
+  example, the Antigravity agent) by referencing their `agent_id`.
+- **Built-in, server-side execution:** Capabilities such as web search and code
+  execution run in a managed sandbox on the server, with no local sandbox to
+  provision or secure.
+- **No client-side function declarations:** Server-side tools are configured on
+  the managed agent, so you don't declare or execute them locally.
 
-*   **First-party, out-of-the-box agents.** Connect to ready-made agents (for
-    example, the Antigravity agent) by referencing their `agent_id`.
-*   **Built-in, server-side execution.** Capabilities such as web search and code
-    execution run in a managed sandbox on the server, with no local sandbox to
-    provision or secure.
-*   **No client-side function declarations.** Server-side tools are configured on
-    the managed agent, so you don't declare or execute them locally.
+## When to use managed agents vs. building your own
 
-## Backends and setup
+Managed agents and ADK agents solve different problems. Choosing between them is
+mostly a trade-off between out-of-the-box power and fine-grained control.
+
+- **Managed agents** give you a powerful agent out of the box, but with limited
+  flexibility. The toolset is predefined and server-side, the agent runs only in
+  the managed environment, and client-side or MCP tools are not supported.
+- **ADK agents** (such as [`LlmAgent`](/agents/llm-agents/)) give you
+  fine-grained control over the model, instructions, tools (including custom
+  function tools and MCP tools), and where execution happens.
+
+## Prerequisites
 
 `ManagedAgent` supports two backends. Complete the prerequisites for the backend
 you plan to use: obtain credentials and an `agent_id`.
 
 ### Gemini API backend
 
-*   **Authentication.** Obtain a Gemini API key and set it as the
-    `GEMINI_API_KEY` environment variable.
-*   **Agent ID.** You need an `agent_id` to connect to. You can either:
-    *   Create a new agent by following the
-        [Gemini API Agents documentation](https://ai.google.dev/gemini-api/docs/agents).
-    *   Use an out-of-the-box agent ID, such as `antigravity-preview-05-2026`,
-        which is used in the examples below.
+- **Authentication:** Obtain a Gemini API key and set it as the `GEMINI_API_KEY`
+  environment variable.
+- **Agent ID:** You need an `agent_id` to connect to. You can either:
+    - Create a new agent by following the [Gemini API Agents
+      documentation](https://ai.google.dev/gemini-api/docs/agents).
+    - Use an out-of-the-box agent ID, such as `antigravity-preview-05-2026`,
+      which is used in the examples below.
 
-### Gemini Enterprise Agents Platform (GEAP) backend
+### Agent Platform backend
 
-The Gemini Enterprise Agents Platform (GEAP) was formerly known as Vertex.
-
-*   **Authentication.** GEAP requires Google Cloud credentials. Follow the
-    [GEAP setup instructions](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/managed-agents/create-manage#before-you-begin)
-    to authenticate your local environment (for example, with
-    `gcloud auth application-default login`).
-*   **Location.** The Managed Agents API is served only from the `global`
-    location. `ManagedAgent` enforces a connection to `global` on the GEAP
-    backend.
-*   **Agent ID.** As with the Gemini API, you need an `agent_id`. Create one via
-    the [GEAP Managed Agents guide](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/managed-agents),
-    or use an out-of-the-box agent ID available to your project.
+- **Authentication:** Agent Platform requires Google Cloud credentials. Follow
+  the [Agent Platform setup
+  instructions](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/managed-agents/create-manage#before-you-begin)
+  to authenticate your local environment (for example, with `gcloud auth
+  application-default login`).
+- **Location:** The Managed Agents API is served only from the `global`
+  location. `ManagedAgent` enforces a connection to `global` on the Agent
+  Platform backend.
+- **Agent ID:** As with the Gemini API, you need an `agent_id`. Create one via
+  the [Agent Platform Managed Agents
+  guide](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/managed-agents),
+  or use an out-of-the-box agent ID available to your project.
 
 ## Get started
 
@@ -100,35 +113,26 @@ server-side. Both run their tools in the managed environment
     )
     ```
 
-## When to use managed agents vs. building your own
-
-Managed agents and ADK agents solve different problems. Choosing between them is
-mostly a trade-off between out-of-the-box power and fine-grained control.
-
-*   **Managed agents** give you a powerful agent out of the box, but with limited
-    flexibility. The toolset is predefined and server-side, the agent runs only
-    in the managed environment, and client-side or MCP tools are not supported.
-*   **ADK agents** (such as [`LlmAgent`](/agents/llm-agents/)) give you
-    fine-grained control over the model, instructions, tools (including custom
-    function tools and MCP tools), and where execution happens.
-
 ## How it works
 
-When you invoke a `ManagedAgent`, ADK sends your request to the managed agent via
-the [Interactions API](https://ai.google.dev/gemini-api/docs/interactions-overview)
-and streams the results, both partial and final, back into your ADK flow in real
-time. The reasoning, tools, and execution all run in Google's managed environment
-rather than in your ADK process.
+When you invoke a `ManagedAgent`, ADK sends your request to the managed agent
+via the [Interactions
+API](https://ai.google.dev/gemini-api/docs/interactions-overview) and streams
+the results, both partial and final, back into your ADK flow in real time. The
+reasoning, tools, and execution all run in Google's managed environment rather
+than in your ADK process.
 
 !!! note "How `ManagedAgent` maps to the Managed Agents API"
+
     An ADK `ManagedAgent` does not create or register a new managed agent
-    resource. It connects to an agent that already exists on the backend (the one
-    named by `agent_id`) and applies its configuration (such as `tools` and
-    `environment`) as per-interaction overrides at runtime. In Managed Agents API
-    terms, ADK works entirely on the *data plane* (the Interactions API) and
+    resource. It connects to an agent that already exists on the backend (the
+    one named by `agent_id`) and applies its configuration (such as `tools` and
+    `environment`) as per-interaction overrides at runtime. In Managed Agents
+    API terms, ADK works entirely on the *data plane* (the Interactions API) and
     leaves the *control plane* (the Agents API, which creates and manages agent
-    resources) untouched. For how these two planes differ, see the
-    [Managed Agents API system architecture](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/managed-agents).
+    resources) untouched. For how these two planes differ, see the [Managed
+    Agents API system
+    architecture](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/managed-agents).
 
 ### Local session vs. remote state
 
@@ -138,37 +142,35 @@ values on the events it emits: the `previous_interaction_id` and the sandbox
 session events, then reuses them so the conversation and its sandbox continue.
 
 Everything else lives server-side. The Managed Agents API owns the sandbox
-environment and the full interaction history, and that remote interaction, not the
-local session, is the source of truth for continuing a conversation. Response text
-appears in both the local ADK events and the remote interaction history, but ADK
-stores only the IDs it needs to recover and reuse the remote state; it never
-re-sends prior turns.
+environment and the full interaction history, and that remote interaction, not
+the local session, is the source of truth for continuing a conversation.
+Response text appears in both the local ADK events and the remote interaction
+history, but ADK stores only the IDs it needs to recover and reuse the remote
+state; it never re-sends prior turns.
 
-## Limitations and notes
+## Limitations
 
-*   **Location pinned (GEAP only).** For the GEAP backend, the Managed Agents API
-    is currently served only from the `global` location. Regional endpoints raise
-    an error.
-*   **Server-side tools only.** Client-executed tools (Python functions,
-    callables) and MCP tools are not supported and raise a `NotImplementedError`.
-*   **Streaming only.** The agent uses streaming interactions (`stream=True`).
-    Background-polling execution and strictly non-streaming connections are not
-    yet fully supported.
-*   **Backend differences.** The Gemini API and GEAP backends currently exhibit
-    slightly different behavioral patterns. Test against the specific backend you
-    intend to use.
+- **Location pinned (Agent Platform only):** For the Agent Platform backend, the
+  Managed Agents API is currently served only from the `global` location.
+  Regional endpoints raise an error.
+- **Server-side tools only:** Client-executed tools (Python functions,
+  callables) and MCP tools are not supported and raise a `NotImplementedError`.
+- **Streaming only:** The agent uses streaming interactions (`stream=True`).
+  Background-polling execution and strictly non-streaming connections are not
+  yet fully supported.
+- **Backend differences:** The Gemini API and Agent Platform backends currently
+  exhibit slightly different behavioral patterns. Test against the specific
+  backend you intend to use.
 
-## Related resources
+## Next steps
 
-*   **Samples:**
-    [Managed Agent Basic](https://github.com/google/adk-python/tree/main/contributing/samples/managed_agent/basic)
-    and
-    [Managed Agent Code Execution](https://github.com/google/adk-python/tree/main/contributing/samples/managed_agent/code_execution).
-*   **Backend documentation:**
-    [Gemini API Agents](https://ai.google.dev/gemini-api/docs/agents)
-    and
-    [GEAP Managed Agents](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/managed-agents).
-*   **Related ADK topics:**
-    [Models for agents](/agents/models/),
-    [Multi-agent workflows](/workflows/), and
-    [Custom tools](/tools-custom/).
+- **Samples:** [Managed Agent
+  Basic](https://github.com/google/adk-python/tree/main/contributing/samples/managed_agent/basic)
+  and [Managed Agent Code
+  Execution](https://github.com/google/adk-python/tree/main/contributing/samples/managed_agent/code_execution).
+- **Backend documentation:** [Gemini API
+  Agents](https://ai.google.dev/gemini-api/docs/agents) and [Agent Platform
+  Managed
+  Agents](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/managed-agents).
+- **Related ADK topics:** [Models for agents](/agents/models/), [Multi-agent
+  workflows](/workflows/), and [Custom tools](/tools-custom/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -289,6 +289,7 @@ nav:
     - Agents:
       - agents/index.md
       - Simple agents: agents/llm-agents.md
+      - Managed agents: agents/managed-agents.md
     - Graph Workflows:
       - graphs/index.md
       - Graph routes: graphs/routes.md


### PR DESCRIPTION
## Summary

Adds a new **Managed agents** page (`docs/agents/managed-agents.md`) documenting the `ManagedAgent` agent type and its integration with the Managed Agents API (`interactions.create`), and wires it into the nav under **Build Agents → Agents** (peer to *Simple agents*).

The content is a faithful port of the upstream minimal guide in `adk-python` ([docs/guides/agents/managed_agent/index.md](https://github.com/google/adk-python/blob/main/docs/guides/agents/managed_agent/index.md)), adapted to this repo's conventions (language-support tag, `## ` sections, `=== "Python"` code tab, root-relative internal links).

## What's included

The page has 7 sections:

- **What are managed agents?** — first-party, out-of-the-box agents (e.g. Antigravity) with built-in server-side execution; no client-side function declarations.
- **Backends and setup** — Gemini API (`GEMINI_API_KEY`) and Gemini Enterprise Agents Platform (GEAP, formerly Vertex) (`gcloud` ADC, `global`-only) prerequisites.
- **Get started** — minimal `ManagedAgent` example (managed search + managed code-execution).
- **When to use managed agents vs. building your own** — trade-off prose plus a decision table (net-new content).
- **How it works** — server-side streaming interactions and the local-session-vs-remote state model.
- **Limitations and notes** — location-pinned (GEAP), server-side tools only, streaming only, and a note that the two backends currently behave slightly differently.
- **Related resources** — adk-python samples, official backend docs, and cross-links to Models / Workflows / Custom tools.

## Notes

- `ManagedAgent` is currently Python-only, so the page carries a Python-only language-support tag.
- Per `CONTRIBUTING.md`, new documentation usually starts with an issue for discussion — happy to open one or adjust scope/placement based on maintainer preference.