### PR TITLE
docs: add DaoXE OpenAI-compatible gateway example for LiteLLM

### DIFF
--- a/docs/agents/models/litellm.md
+++ b/docs/agents/models/litellm.md
@@ -99,3 +99,45 @@ agent_claude_direct = LlmAgent(
     # ... other agent parameters
 )
 ```
+
+## DaoXE (OpenAI-compatible gateway)
+
+[DaoXE](https://daoxe.com) is a multi-model multi-protocol API gateway with an
+OpenAI-compatible Chat Completions endpoint. It also exposes other protocols
+(such as Anthropic Messages) for other clients; with ADK you use the LiteLLM
+OpenAI-compatible path below.
+
+1. Create an API key in the [DaoXE dashboard](https://daoxe.com).
+2. Use an exact model ID from your DaoXE account catalog (`GET /v1/models` or
+   your account UI). Prefer live account IDs over hard-coded public lists.
+   DaoXE is not available in mainland China.
+
+Set the key LiteLLM reads for OpenAI-compatible endpoints:
+
+```shell
+export OPENAI_API_KEY="YOUR_DAOXE_API_KEY"
+```
+
+Then point `LiteLlm` at DaoXE with `api_base` and the `openai/` model prefix:
+
+```python
+from google.adk.agents import LlmAgent
+from google.adk.models.lite_llm import LiteLlm
+
+agent_daoxe = LlmAgent(
+    model=LiteLlm(
+        model="openai/YOUR_DAOXE_MODEL_ID",  # exact ID from your DaoXE account
+        api_base="https://daoxe.com/v1",
+        # Or pass the key explicitly instead of OPENAI_API_KEY:
+        # api_key="YOUR_DAOXE_API_KEY",
+    ),
+    name="daoxe_agent",
+    instruction="You are a helpful assistant routed through DaoXE.",
+    # ... other agent parameters
+)
+```
+
+For more on OpenAI-compatible providers in LiteLLM, see the
+[LiteLLM OpenAI-compatible providers](https://docs.litellm.ai/docs/providers/openai_compatible)
+documentation. Client setup examples:
+[DaoXE-AI](https://github.com/seven7763/DaoXE-AI).


### PR DESCRIPTION
## Summary

- Document [DaoXE](https://daoxe.com) as an example of using LiteLLM with a custom OpenAI-compatible gateway in `docs/agents/models/litellm.md`.
- Example uses `LiteLlm(model="openai/YOUR_DAOXE_MODEL_ID", api_base="https://daoxe.com/v1")` with `OPENAI_API_KEY` (or optional `api_key=`), matching existing `api_base` patterns (e.g. vLLM).
- Model IDs are account-scoped placeholders — no hard-coded public model/price list.

DaoXE is a multi-model multi-protocol API gateway. This docs-only change covers the OpenAI Chat Completions path that ADK already supports via LiteLLM; no new connector class or static model table.

I am a DaoXE maintainer. Client setup examples: https://github.com/seven7763/DaoXE-AI

## Checklist

- [x] Docs only
- [x] Follows existing LiteLLM / OpenAI-compatible `api_base` patterns
- [x] No hardcoded public model price list
- [x] Signed-off-by included

## Test plan

- [ ] Review rendered section under LiteLLM model connector page
- [ ] Confirm code sample matches `LiteLlm` kwargs used elsewhere in this repo