### PR TITLE
docs: fix .env file path in Python Quickstart

### DIFF
--- a/docs/get-started/python.md
+++ b/docs/get-started/python.md
@@ -97,19 +97,19 @@ In a terminal window, write your API key into an `.env` file as an environment v
 === "MacOS / Linux"
 
     ```bash title="Update: my_agent/.env"
-    echo 'GOOGLE_API_KEY="YOUR_API_KEY"' > .env
+    echo 'GOOGLE_API_KEY="YOUR_API_KEY"' > my_agent/.env
     ```
 
 === "Windows PowerShell"
 
     ```console title="Update: my_agent/.env"
-    echo 'GOOGLE_API_KEY="YOUR_API_KEY"' > .env
+    echo 'GOOGLE_API_KEY="YOUR_API_KEY"' > my_agent/.env
     ```
 
 === "Windows Command Prompt"
 
     ```console title="Update: my_agent/.env"
-    echo GOOGLE_API_KEY="YOUR_API_KEY" > .env
+    echo GOOGLE_API_KEY="YOUR_API_KEY" > my_agent/.env
     ```
 
 ??? tip "Using other AI models with ADK"


### PR DESCRIPTION
## Summary

Fix the `.env` file path in the Python Quickstart.

## Problem

After running:

```sh
adk create my_agent
```

the guide instructs users to create the API key file with:

```sh
echo 'GOOGLE_API_KEY="YOUR_API_KEY"' > .env
```

At this point, the user is still in the parent directory, so the command creates `./.env`.

However, the project structure shown earlier in the guide and the code block title (`Update: my_agent/.env`) indicate that the file should be located at `my_agent/.env`.

## Solution

Update the commands for:

- macOS / Linux
- Windows PowerShell
- Windows Command Prompt

to write the file to:

```text
my_agent/.env
```

This keeps the commands consistent with the documented project structure while preserving the existing Quickstart workflow.

## Verification

The `.env` creation command now matches:

- the project structure shown in the guide, and
- the `Update: my_agent/.env` code block title.