### PR TITLE
fix: add missing await to create_session calls in callback examples

### DIFF
--- a/examples/python/snippets/callbacks/after_agent_callback.py
+++ b/examples/python/snippets/callbacks/after_agent_callback.py
@@ -98,7 +98,7 @@ async def main():
     session_service = runner.session_service
 
     # Create session 1: Agent output will be used as is (default empty state)
-    session_service.create_session(
+    await session_service.create_session(
         app_name=app_name,
         user_id=user_id,
         session_id=session_id_normal,
@@ -107,7 +107,7 @@ async def main():
     # print(f"Session '{session_id_normal}' created with default state.")
 
     # Create session 2: Agent output will be replaced by the callback
-    session_service.create_session(
+    await session_service.create_session(
         app_name=app_name,
         user_id=user_id,
         session_id=session_id_modify,

--- a/examples/python/snippets/callbacks/before_agent_callback.py
+++ b/examples/python/snippets/callbacks/before_agent_callback.py
@@ -97,7 +97,7 @@ async def main():
     session_service = runner.session_service
 
     # Create session 1: Agent will run (default empty state)
-    session_service.create_session(
+    await session_service.create_session(
         app_name=app_name,
         user_id=user_id,
         session_id=session_id_run,
@@ -105,7 +105,7 @@ async def main():
     )
 
     # Create session 2: Agent will be skipped (state has skip_llm_agent=True)
-    session_service.create_session(
+    await session_service.create_session(
         app_name=app_name,
         user_id=user_id,
         session_id=session_id_skip,


### PR DESCRIPTION
InMemorySessionService.create_session is async def, but the before_agent_callback.py and after_agent_callback.py examples call it without await. This returns an unawaited coroutine — the session is never created, and subsequent runner.run_async() fails with SessionNotFoundError.
Fixed by adding await to both create_session calls in both files.