### PR TITLE
fix: correct undefined variable names in state output_key example

### DIFF
--- a/docs/sessions/state.md
+++ b/docs/sessions/state.md
@@ -350,7 +350,7 @@ This is the simplest method for saving an agent's final text response directly i
           print(f"Agent responded.") # Response text is also in event.content
 
     # --- Check Updated State ---
-    updated_session = await session_service.get_session(app_name=APP_NAME, user_id=USER_ID, session_id=session_id)
+    updated_session = await session_service.get_session(app_name=app_name, user_id=user_id, session_id=session_id)
     print(f"State after agent run: {updated_session.state}")
     # Expected output might include: {'last_greeting': 'Hello there! How can I help you today?'}
     ```


### PR DESCRIPTION
Variables app_name and user_id were defined lowercase but referenced as APP_NAME and USER_ID (uppercase), causing NameError at runtime.## Summary

This PR fixes undefined variable references in the Python `output_key` example on the State documentation page.

The example defines `app_name` and `user_id` but later references `APP_NAME` and `USER_ID`, which are not defined and result in a `NameError` when the example is executed.

This change replaces the undefined uppercase variables with the correctly defined lowercase variables, making the example consistent and executable.
