### PR TITLE
docs: fix type annotation error and missing imports in function tools snippet

### DIFF
--- a/examples/python/snippets/tools/function-tools/human_in_the_loop.py
+++ b/examples/python/snippets/tools/function-tools/human_in_the_loop.py
@@ -13,15 +13,16 @@
 # limitations under the License.
 
 import asyncio
-from typing import Any
 from google.adk.agents import Agent
 from google.adk.events import Event
 from google.adk.runners import Runner
-from google.adk.tools import LongRunningFunctionTool
 from google.adk.sessions import InMemorySessionService
 from google.genai import types
 
 # --8<-- [start:define_long_running_function]
+
+from typing import Any
+from google.adk.tools import LongRunningFunctionTool
 
 # 1. Define the long running function
 def ask_for_approval(
@@ -32,7 +33,7 @@ def ask_for_approval(
     # Send a notification to the approver with the link of the ticket
     return {'status': 'pending', 'approver': 'Sean Zhou', 'purpose' : purpose, 'amount': amount, 'ticket-id': 'approval-ticket-1'}
 
-def reimburse(purpose: str, amount: float) -> str:
+def reimburse(purpose: str, amount: float) -> dict[str, Any]:
     """Reimburse the amount of money to the employee."""
     # send the reimbrusement request to payment vendor
     return {'status': 'ok'}


### PR DESCRIPTION
## Why

Two content bugs in the `human_in_the_loop.py` snippet used by the Function Tools docs page:

1. **Type error** — `reimburse()` annotated `-> str` but returns `{'status': 'ok'}` (a `dict`). Type checkers will flag this.

2. **Import error** — `from typing import Any` and `from google.adk.tools import LongRunningFunctionTool` are placed above the `[start:define_long_running_function]` snippet tag. The docs site only renders lines inside the tag, so the code block shown to readers is missing these imports. Copy-pasting the example causes `NameError`.

## Fix

- Changed `-> str` to `-> dict[str, Any]` on `reimburse()`
- Moved the two import lines inside the snippet region so they appear in the rendered code block

## Verification

- The example is syntactically valid Python 3.10+
- Total change: +4/−3 lines in one file. No behavioral impact.