### PR TITLE
Docs/fix broken template variable in instruction examples

### DIFF
--- a/docs/a2a/quickstart-consuming.md
+++ b/docs/a2a/quickstart-consuming.md
@@ -168,7 +168,7 @@ prime_agent = RemoteA2aAgent(
 Then, you can simply use the `RemoteA2aAgent` in your agent. In this case, `prime_agent` is used as one of the sub-agents in the `root_agent` below:
 
 ```python title="a2a_basic/agent.py"
-from google.adk.agents.llm_agent import Agent
+from google.adk.agents import Agent
 from google.genai import types
 
 root_agent = Agent(

--- a/docs/agents/llm-agents.md
+++ b/docs/agents/llm-agents.md
@@ -141,7 +141,7 @@ tells the agent:
     1. Identify the country name from the user's query.
     2. Use the `get_capital_city` tool to find the capital.
     3. Respond clearly to the user, stating the capital city.
-    Example Query: "What's the capital of {country}?"
+    Example Query: "What's the capital of {{country}}?"
     Example Response: "The capital of France is Paris."
     """,
         # tools will be added next
@@ -161,7 +161,7 @@ tells the agent:
             1. Identify the country name from the user's query.
             2. Use the \`getCapitalCity\` tool to find the capital.
             3. Respond clearly to the user, stating the capital city.
-            Example Query: "What's the capital of {country}?"
+            Example Query: "What's the capital of {{country}}?"
             Example Response: "The capital of France is Paris."
             `,
         // tools will be added next
@@ -190,7 +190,7 @@ tells the agent:
                 1. Identify the country name from the user's query.
                 2. Use the `get_capital_city` tool to find the capital.
                 3. Respond clearly to the user, stating the capital city.
-                Example Query: "What's the capital of {country}?"
+                Example Query: "What's the capital of {{country}}?"
                 Example Response: "The capital of France is Paris."
                 """)
             // tools will be added next
@@ -721,7 +721,7 @@ import asyncio
 import os
 
 from google.genai import types
-from google.adk.agents.llm_agent import LlmAgent
+from google.adk.agents import LlmAgent
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.adk.artifacts.in_memory_artifact_service import InMemoryArtifactService # Optional

--- a/docs/agents/models/google-gemini.md
+++ b/docs/agents/models/google-gemini.md
@@ -157,7 +157,7 @@ snippet:
 === "Python"
 
     ```python
-    from google.adk.agents.llm_agent import Agent
+    from google.adk.agents import Agent
     from google.adk.models.google_llm import Gemini
     from google.adk.tools.google_search_tool import GoogleSearchTool
 

--- a/docs/apps/index.md
+++ b/docs/apps/index.md
@@ -56,7 +56,7 @@ sample code:
 === "Python"
 
     ```python title="agent.py"
-    from google.adk.agents.llm_agent import Agent
+    from google.adk.agents import Agent
     from google.adk.apps import App
 
     root_agent = Agent(

--- a/docs/artifacts/index.md
+++ b/docs/artifacts/index.md
@@ -931,7 +931,7 @@ artifact in a later turn.
     === "Python"
 
         ```python
-        from google.adk.tools.tool_context import ToolContext
+        from google.adk.tools import ToolContext
 
         def list_user_files_py(tool_context: ToolContext) -> str:
             """Tool to list available artifacts for the user."""

--- a/docs/get-started/python.md
+++ b/docs/get-started/python.md
@@ -70,7 +70,7 @@ use. Update the generated `agent.py` code to include a `get_current_time` tool
 for use by the agent, as shown in the following code:
 
 ```python
-from google.adk.agents.llm_agent import Agent
+from google.adk.agents import Agent
 
 # Mock tool implementation
 def get_current_time(city: str) -> dict:

--- a/docs/integrations/a2ui.md
+++ b/docs/integrations/a2ui.md
@@ -83,7 +83,7 @@ instruction = schema_manager.generate_system_prompt(
 Use the generated instruction as the agent's system prompt:
 
 ```python
-from google.adk.agents.llm_agent import LlmAgent
+from google.adk.agents import LlmAgent
 
 agent = LlmAgent(
     model="gemini-flash-latest",

--- a/docs/integrations/adk-connector.md
+++ b/docs/integrations/adk-connector.md
@@ -76,7 +76,7 @@ messaging channels.
     ```python
     import os
     from dotenv import load_dotenv
-    from google.adk.agents.llm_agent import Agent
+    from google.adk.agents import Agent
     from adk_connectors.telegram import TelegramConnector
 
     # Load environment variables
@@ -108,7 +108,7 @@ messaging channels.
     ```python
     import os
     from dotenv import load_dotenv
-    from google.adk.agents.llm_agent import Agent
+    from google.adk.agents import Agent
     from adk_connectors.discord import DiscordConnector
 
     # Load environment variables

--- a/docs/integrations/agent-registry.md
+++ b/docs/integrations/agent-registry.md
@@ -80,7 +80,7 @@ The primary way to use the Agent Registry integration within an ADK agent is to
 dynamically fetch remote agents or toolsets using the AgentRegistry client.
 
 ```py
-from google.adk.agents.llm_agent import LlmAgent
+from google.adk.agents import LlmAgent
 from google.adk.integrations.agent_registry import AgentRegistry
 import os
 

--- a/docs/integrations/api-registry.md
+++ b/docs/integrations/api-registry.md
@@ -67,7 +67,7 @@ API Registry. This agent is designed to interact with BigQuery:
 
 ```python
 import os
-from google.adk.agents.llm_agent import LlmAgent
+from google.adk.agents import LlmAgent
 from google.adk.tools.api_registry import ApiRegistry
 
 # Configure with your Google Cloud Project ID and registered MCP server name

--- a/docs/integrations/apigee-api-hub.md
+++ b/docs/integrations/apigee-api-hub.md
@@ -100,7 +100,7 @@ you only need to follow a subset of these steps.
    definition:
 
     ```py
-    from google.adk.agents.llm_agent import LlmAgent
+    from google.adk.agents import LlmAgent
     from .tools import sample_toolset
 
     root_agent = LlmAgent(

--- a/docs/integrations/application-integration.md
+++ b/docs/integrations/application-integration.md
@@ -223,7 +223,7 @@ To create an Application Integration Toolset for Integration Connectors, follow 
 2. Update the `agent.py` file and add tool to your agent:
 
     ```py
-    from google.adk.agents.llm_agent import LlmAgent
+    from google.adk.agents import LlmAgent
     from .tools import connector_tool
 
     root_agent = LlmAgent(
@@ -329,7 +329,7 @@ workflow as a tool for your agent or create a new one.
     To update the `agent.py` file and add the tool to your agent, use the following code:
 
       ```py
-          from google.adk.agents.llm_agent import LlmAgent
+          from google.adk.agents import LlmAgent
           from .tools import integration_tool, connector_tool
 
           root_agent = LlmAgent(

--- a/docs/integrations/code-exec-agent-runtime.md
+++ b/docs/integrations/code-exec-agent-runtime.md
@@ -50,7 +50,7 @@ To use the Code Execution tool with your ADK agent:
     resource name you created.
 
 ```python
-from google.adk.agents.llm_agent import Agent
+from google.adk.agents import Agent
 from google.adk.code_executors.agent_engine_sandbox_code_executor import AgentEngineSandboxCodeExecutor
 
 root_agent = Agent(
@@ -158,7 +158,7 @@ the operating guidelines for code execution. This instruction clause is
 optional, but strongly recommended for getting the best results from this tool.
 
 ```python
-from google.adk.agents.llm_agent import Agent
+from google.adk.agents import Agent
 from google.adk.code_executors.agent_engine_sandbox_code_executor import AgentEngineSandboxCodeExecutor
 
 def base_system_instruction():

--- a/docs/integrations/gcs.md
+++ b/docs/integrations/gcs.md
@@ -132,7 +132,7 @@ storage toolset with write access enabled.
 
 ```python
 import google.auth
-from google.adk.agents.llm_agent import LlmAgent
+from google.adk.agents import LlmAgent
 from google.adk.integrations.gcs import GCSToolset
 from google.adk.integrations.gcs.settings import GCSToolSettings, Capabilities
 from google.adk.integrations.gcs.gcs_credentials import GCSCredentialsConfig

--- a/docs/integrations/synap.md
+++ b/docs/integrations/synap.md
@@ -54,7 +54,7 @@ demand.
 ```python
 import os
 
-from google.adk.agents.llm_agent import Agent
+from google.adk.agents import Agent
 from maximem_synap import MaximemSynapSDK
 from synap_google_adk import create_synap_tools
 

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -271,7 +271,7 @@ a simple ADK agent.
     ```py
     from google.adk.runners import InMemoryRunner
     from google.adk import Agent
-    from google.adk.tools.tool_context import ToolContext
+    from google.adk.tools import ToolContext
     from google.genai import types
     import asyncio
 

--- a/docs/streaming/streaming-tools.md
+++ b/docs/streaming/streaming-tools.md
@@ -30,7 +30,7 @@ Now let's define an agent that can monitor stock price changes and monitor the v
     from typing import AsyncGenerator
 
     from google.adk.agents import LiveRequestQueue
-    from google.adk.agents.llm_agent import Agent
+    from google.adk.agents import Agent
     from google.adk.tools.function_tool import FunctionTool
     from google.genai import Client
     from google.genai import types as genai_types

--- a/docs/tools-custom/authentication.md
+++ b/docs/tools-custom/authentication.md
@@ -263,7 +263,7 @@ Pass the scheme and credential during toolset initialization. The toolset applie
       auth_scheme = OpenIdConnectWithConfig(
           authorization_endpoint=OAUTH2_AUTH_ENDPOINT_URL,
           token_endpoint=OAUTH2_TOKEN_ENDPOINT_URL,
-          scopes=['openid', 'YOUR_OAUTH_SCOPES"]
+           scopes=['openid', 'YOUR_OAUTH_SCOPES']
       )
       auth_credential = AuthCredential(
           auth_type=AuthCredentialTypes.OPEN_ID_CONNECT,
@@ -296,7 +296,7 @@ client_secret = "YOUR_GOOGLE_OAUTH_CLIENT_SECRET"
 
 # Use the specific configure method for this toolset type
 calendar_tool_set.configure_auth(
-    client_id=oauth_client_id, client_secret=oauth_client_secret
+    client_id=client_id, client_secret=client_secret
 )
 
 # agent = LlmAgent(..., tools=calendar_tool_set.get_tool('calendar_tool_set'))

--- a/docs/tools-custom/mcp-tools.md
+++ b/docs/tools-custom/mcp-tools.md
@@ -323,7 +323,7 @@ Modify your `agent.py` file (e.g., in `./adk_agent_samples/mcp_agent/agent.py`).
 ```python
 # ./adk_agent_samples/mcp_agent/agent.py
 import os
-from google.adk.agents.llm_agent import Agent
+from google.adk.agents import Agent
 from google.adk.tools.mcp_tool import McpToolset
 from google.adk.tools.mcp_tool.mcp_session_manager import StreamableHTTPConnectionParams
 
@@ -762,7 +762,7 @@ import os
 import asyncio
 from dotenv import load_dotenv
 from google.genai import types
-from google.adk.agents.llm_agent import LlmAgent
+from google.adk.agents import LlmAgent
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.adk.artifacts.in_memory_artifact_service import InMemoryArtifactService # Optional
@@ -861,7 +861,7 @@ When deploying ADK agents that use MCP tools to production environments like Clo
 ```python
 # ✅ CORRECT: Synchronous agent definition for deployment
 import os
-from google.adk.agents.llm_agent import LlmAgent
+from google.adk.agents import LlmAgent
 from google.adk.tools.mcp_tool import McpToolset
 from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
 from mcp import StdioServerParameters

--- a/docs/tutorials/agent-team.md
+++ b/docs/tutorials/agent-team.md
@@ -998,7 +998,7 @@ Now, we create a new version of the weather tool. Its key feature is accepting `
 
 
 ```python
-from google.adk.tools.tool_context import ToolContext
+from google.adk.tools import ToolContext
 
 def get_weather_stateful(city: str, tool_context: ToolContext) -> dict:
     """Retrieves weather, converts temp unit based on session state."""
@@ -1615,7 +1615,7 @@ This function targets the `get_weather_stateful` tool. It checks the `city` argu
 
 # Ensure necessary imports are available
 from google.adk.tools.base_tool import BaseTool
-from google.adk.tools.tool_context import ToolContext
+from google.adk.tools import ToolContext
 from typing import Optional, Dict, Any # For type hints
 
 def block_paris_tool_guardrail(

--- a/examples/go/snippets/agents/llm-agents/snippets/main.go
+++ b/examples/go/snippets/agents/llm-agents/snippets/main.go
@@ -64,7 +64,7 @@ When a user asks for the capital of a country:
 1. Identify the country name from the user's query.
 2. Use the 'get_capital_city' tool to find the capital.
 3. Respond clearly to the user, stating the capital city.
-Example Query: "What's the capital of {country}?"
+Example Query: "What's the capital of {{country}}?"
 Example Response: "The capital of France is Paris."`,
 		// tools will be added next
 	})

--- a/examples/kotlin/snippets/agents/llm-agent/CapitalAgent.kt
+++ b/examples/kotlin/snippets/agents/llm-agent/CapitalAgent.kt
@@ -51,7 +51,7 @@ fun main() =
                         1. Identify the country name from the user's query.
                         2. Use the `getCapitalCity` tool to find the capital.
                         3. Respond clearly to the user, stating the capital city.
-                        Example Query: "What's the capital of {country}?"
+                        Example Query: "What's the capital of {{country}}?"
                         Example Response: "The capital of France is Paris."
                         """.trimIndent(),
                     ),

--- a/examples/python/snippets/tools/function-tools/human_in_the_loop.py
+++ b/examples/python/snippets/tools/function-tools/human_in_the_loop.py
@@ -13,15 +13,16 @@
 # limitations under the License.
 
 import asyncio
-from typing import Any
 from google.adk.agents import Agent
 from google.adk.events import Event
 from google.adk.runners import Runner
-from google.adk.tools import LongRunningFunctionTool
 from google.adk.sessions import InMemorySessionService
 from google.genai import types
 
 # --8<-- [start:define_long_running_function]
+
+from typing import Any
+from google.adk.tools import LongRunningFunctionTool
 
 # 1. Define the long running function
 def ask_for_approval(
@@ -32,7 +33,7 @@ def ask_for_approval(
     # Send a notification to the approver with the link of the ticket
     return {'status': 'pending', 'approver': 'Sean Zhou', 'purpose' : purpose, 'amount': amount, 'ticket-id': 'approval-ticket-1'}
 
-def reimburse(purpose: str, amount: float) -> str:
+def reimburse(purpose: str, amount: float) -> dict[str, Any]:
     """Reimburse the amount of money to the employee."""
     # send the reimbrusement request to payment vendor
     return {'status': 'ok'}


### PR DESCRIPTION
## What

Instruction strings across all 5 language examples in `docs/agents/llm-agents.md`
and the corresponding snippet files contain `{country}` as a documentation
placeholder inside the example query.

## Why

ADK's template engine treats `{var}` as a state variable injection token. The
docs themselves state (line 127-128): "If the state variable ... does not exist,
the agent will raise an error." Since `country` is never set as a state variable
in any of these examples, running the code as-written fails with a template
resolution error.

## Fix

Replace `{country}` with `{{country}}` in all instruction strings across Python,
TypeScript, Java (inline in `docs/agents/llm-agents.md`), Go
(`examples/go/snippets/agents/llm-agents/snippets/main.go`), and Kotlin
(`examples/kotlin/snippets/agents/llm-agent/CapitalAgent.kt`). Double-braces
escape ADK's template engine, rendering a literal `{country}` in the LLM
instruction — which is what the example intends.

## Verification

Confirmed that `{var}` is documented as state variable syntax on the same page
(lines 123-128). The fix preserves the displayed output while preventing template
engine errors. Python f-strings containing `{country}` in actual code (e.g., line
239) were left untouched.