### PR TITLE
Docs/fix template variable in instruction examples

### DIFF
--- a/docs/agents/llm-agents.md
+++ b/docs/agents/llm-agents.md
@@ -141,7 +141,7 @@ tells the agent:
     1. Identify the country name from the user's query.
     2. Use the `get_capital_city` tool to find the capital.
     3. Respond clearly to the user, stating the capital city.
-    Example Query: "What's the capital of {country}?"
+    Example Query: "What's the capital of {{country}}?"
     Example Response: "The capital of France is Paris."
     """,
         # tools will be added next
@@ -161,7 +161,7 @@ tells the agent:
             1. Identify the country name from the user's query.
             2. Use the \`getCapitalCity\` tool to find the capital.
             3. Respond clearly to the user, stating the capital city.
-            Example Query: "What's the capital of {country}?"
+            Example Query: "What's the capital of {{country}}?"
             Example Response: "The capital of France is Paris."
             `,
         // tools will be added next
@@ -190,7 +190,7 @@ tells the agent:
                 1. Identify the country name from the user's query.
                 2. Use the `get_capital_city` tool to find the capital.
                 3. Respond clearly to the user, stating the capital city.
-                Example Query: "What's the capital of {country}?"
+                Example Query: "What's the capital of {{country}}?"
                 Example Response: "The capital of France is Paris."
                 """)
             // tools will be added next

--- a/examples/go/snippets/agents/llm-agents/snippets/main.go
+++ b/examples/go/snippets/agents/llm-agents/snippets/main.go
@@ -64,7 +64,7 @@ When a user asks for the capital of a country:
 1. Identify the country name from the user's query.
 2. Use the 'get_capital_city' tool to find the capital.
 3. Respond clearly to the user, stating the capital city.
-Example Query: "What's the capital of {country}?"
+Example Query: "What's the capital of {{country}}?"
 Example Response: "The capital of France is Paris."`,
 		// tools will be added next
 	})

--- a/examples/kotlin/snippets/agents/llm-agent/CapitalAgent.kt
+++ b/examples/kotlin/snippets/agents/llm-agent/CapitalAgent.kt
@@ -51,7 +51,7 @@ fun main() =
                         1. Identify the country name from the user's query.
                         2. Use the `getCapitalCity` tool to find the capital.
                         3. Respond clearly to the user, stating the capital city.
-                        Example Query: "What's the capital of {country}?"
+                        Example Query: "What's the capital of {{country}}?"
                         Example Response: "The capital of France is Paris."
                         """.trimIndent(),
                     ),

--- a/examples/python/snippets/tools/function-tools/human_in_the_loop.py
+++ b/examples/python/snippets/tools/function-tools/human_in_the_loop.py
@@ -13,15 +13,16 @@
 # limitations under the License.
 
 import asyncio
-from typing import Any
 from google.adk.agents import Agent
 from google.adk.events import Event
 from google.adk.runners import Runner
-from google.adk.tools import LongRunningFunctionTool
 from google.adk.sessions import InMemorySessionService
 from google.genai import types
 
 # --8<-- [start:define_long_running_function]
+
+from typing import Any
+from google.adk.tools import LongRunningFunctionTool
 
 # 1. Define the long running function
 def ask_for_approval(
@@ -32,7 +33,7 @@ def ask_for_approval(
     # Send a notification to the approver with the link of the ticket
     return {'status': 'pending', 'approver': 'Sean Zhou', 'purpose' : purpose, 'amount': amount, 'ticket-id': 'approval-ticket-1'}
 
-def reimburse(purpose: str, amount: float) -> str:
+def reimburse(purpose: str, amount: float) -> dict[str, Any]:
     """Reimburse the amount of money to the employee."""
     # send the reimbrusement request to payment vendor
     return {'status': 'ok'}


### PR DESCRIPTION
## What
Instruction strings across all 5 language examples in docs/agents/llm-agents.md
and the corresponding snippet files contain {country} as a documentation
placeholder inside the example query.

## Why
ADK's template engine treats {var} as a state variable injection token. The
docs themselves state (line 127-128): "If the state variable ... does not exist,
the agent will raise an error." Since country is never set as a state variable
in any of these examples, running the code as-written fails with a template
resolution error.

## Fix
Replace {country} with {{country}} in all instruction strings across Python,
TypeScript, Java (inline in docs/agents/llm-agents.md), Go
(examples/go/snippets/agents/llm-agents/snippets/main.go), and Kotlin
(examples/kotlin/snippets/agents/llm-agent/CapitalAgent.kt). Double-braces
escape ADK's template engine, rendering a literal {country} in the LLM
instruction — which is what the example intends.

## Verification
Confirmed that {var} is documented as state variable syntax on the same page
(lines 123-128). The fix preserves the displayed output while preventing template
engine errors. Python f-strings containing {country} in actual code (e.g., line
239) were left untouched.