### PR TITLE
Docs/fix: correct syntax/NameError in authentication.md and standardize internal imports to public API across docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,5 @@ docs/site
 # Compiled Go example binaries (accidentally committed build artifacts)
 /examples/go/index
 /examples/go/main
+
+# Playwright MCP.playwright-mcp/

--- a/.gitignore
+++ b/.gitignore
@@ -203,5 +203,3 @@ docs/site
 # Compiled Go example binaries (accidentally committed build artifacts)
 /examples/go/index
 /examples/go/main
-
-# Playwright MCP.playwright-mcp/

--- a/docs/a2a/quickstart-consuming.md
+++ b/docs/a2a/quickstart-consuming.md
@@ -181,7 +181,7 @@ prime_agent = RemoteA2aAgent(
 Then, you can simply use the `RemoteA2aAgent` in your agent. In this case, `prime_agent` is used as one of the sub-agents in the `root_agent` below:
 
 ```python title="a2a_basic/agent.py"
-from google.adk.agents.llm_agent import Agent
+from google.adk.agents import Agent
 from google.genai import types
 
 root_agent = Agent(

--- a/docs/agents/llm-agents.md
+++ b/docs/agents/llm-agents.md
@@ -721,7 +721,7 @@ import asyncio
 import os
 
 from google.genai import types
-from google.adk.agents.llm_agent import LlmAgent
+from google.adk.agents import LlmAgent
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.adk.artifacts.in_memory_artifact_service import InMemoryArtifactService # Optional

--- a/docs/agents/models/google-gemini.md
+++ b/docs/agents/models/google-gemini.md
@@ -157,7 +157,7 @@ snippet:
 === "Python"
 
     ```python
-    from google.adk.agents.llm_agent import Agent
+    from google.adk.agents import Agent
     from google.adk.models.google_llm import Gemini
     from google.adk.tools.google_search_tool import GoogleSearchTool
 

--- a/docs/apps/index.md
+++ b/docs/apps/index.md
@@ -56,7 +56,7 @@ sample code:
 === "Python"
 
     ```python title="agent.py"
-    from google.adk.agents.llm_agent import Agent
+    from google.adk.agents import Agent
     from google.adk.apps import App
 
     root_agent = Agent(

--- a/docs/artifacts/index.md
+++ b/docs/artifacts/index.md
@@ -931,7 +931,7 @@ artifact in a later turn.
     === "Python"
 
         ```python
-        from google.adk.tools.tool_context import ToolContext
+        from google.adk.tools import ToolContext
 
         def list_user_files_py(tool_context: ToolContext) -> str:
             """Tool to list available artifacts for the user."""

--- a/docs/get-started/python.md
+++ b/docs/get-started/python.md
@@ -70,7 +70,7 @@ use. Update the generated `agent.py` code to include a `get_current_time` tool
 for use by the agent, as shown in the following code:
 
 ```python
-from google.adk.agents.llm_agent import Agent
+from google.adk.agents import Agent
 
 # Mock tool implementation
 def get_current_time(city: str) -> dict:

--- a/docs/integrations/a2ui.md
+++ b/docs/integrations/a2ui.md
@@ -83,7 +83,7 @@ instruction = schema_manager.generate_system_prompt(
 Use the generated instruction as the agent's system prompt:
 
 ```python
-from google.adk.agents.llm_agent import LlmAgent
+from google.adk.agents import LlmAgent
 
 agent = LlmAgent(
     model="gemini-flash-latest",

--- a/docs/integrations/adk-connector.md
+++ b/docs/integrations/adk-connector.md
@@ -76,7 +76,7 @@ messaging channels.
     ```python
     import os
     from dotenv import load_dotenv
-    from google.adk.agents.llm_agent import Agent
+    from google.adk.agents import Agent
     from adk_connectors.telegram import TelegramConnector
 
     # Load environment variables
@@ -108,7 +108,7 @@ messaging channels.
     ```python
     import os
     from dotenv import load_dotenv
-    from google.adk.agents.llm_agent import Agent
+    from google.adk.agents import Agent
     from adk_connectors.discord import DiscordConnector
 
     # Load environment variables

--- a/docs/integrations/agent-registry.md
+++ b/docs/integrations/agent-registry.md
@@ -80,7 +80,7 @@ The primary way to use the Agent Registry integration within an ADK agent is to
 dynamically fetch remote agents or toolsets using the AgentRegistry client.
 
 ```py
-from google.adk.agents.llm_agent import LlmAgent
+from google.adk.agents import LlmAgent
 from google.adk.integrations.agent_registry import AgentRegistry
 import os
 

--- a/docs/integrations/api-registry.md
+++ b/docs/integrations/api-registry.md
@@ -67,7 +67,7 @@ API Registry. This agent is designed to interact with BigQuery:
 
 ```python
 import os
-from google.adk.agents.llm_agent import LlmAgent
+from google.adk.agents import LlmAgent
 from google.adk.tools.api_registry import ApiRegistry
 
 # Configure with your Google Cloud Project ID and registered MCP server name

--- a/docs/integrations/apigee-api-hub.md
+++ b/docs/integrations/apigee-api-hub.md
@@ -100,7 +100,7 @@ you only need to follow a subset of these steps.
    definition:
 
     ```py
-    from google.adk.agents.llm_agent import LlmAgent
+    from google.adk.agents import LlmAgent
     from .tools import sample_toolset
 
     root_agent = LlmAgent(

--- a/docs/integrations/application-integration.md
+++ b/docs/integrations/application-integration.md
@@ -223,7 +223,7 @@ To create an Application Integration Toolset for Integration Connectors, follow 
 2. Update the `agent.py` file and add tool to your agent:
 
     ```py
-    from google.adk.agents.llm_agent import LlmAgent
+    from google.adk.agents import LlmAgent
     from .tools import connector_tool
 
     root_agent = LlmAgent(
@@ -329,7 +329,7 @@ workflow as a tool for your agent or create a new one.
     To update the `agent.py` file and add the tool to your agent, use the following code:
 
       ```py
-          from google.adk.agents.llm_agent import LlmAgent
+          from google.adk.agents import LlmAgent
           from .tools import integration_tool, connector_tool
 
           root_agent = LlmAgent(

--- a/docs/integrations/code-exec-agent-runtime.md
+++ b/docs/integrations/code-exec-agent-runtime.md
@@ -50,7 +50,7 @@ To use the Code Execution tool with your ADK agent:
     resource name you created.
 
 ```python
-from google.adk.agents.llm_agent import Agent
+from google.adk.agents import Agent
 from google.adk.code_executors.agent_engine_sandbox_code_executor import AgentEngineSandboxCodeExecutor
 
 root_agent = Agent(
@@ -158,7 +158,7 @@ the operating guidelines for code execution. This instruction clause is
 optional, but strongly recommended for getting the best results from this tool.
 
 ```python
-from google.adk.agents.llm_agent import Agent
+from google.adk.agents import Agent
 from google.adk.code_executors.agent_engine_sandbox_code_executor import AgentEngineSandboxCodeExecutor
 
 def base_system_instruction():

--- a/docs/integrations/gcs.md
+++ b/docs/integrations/gcs.md
@@ -132,7 +132,7 @@ storage toolset with write access enabled.
 
 ```python
 import google.auth
-from google.adk.agents.llm_agent import LlmAgent
+from google.adk.agents import LlmAgent
 from google.adk.integrations.gcs import GCSToolset
 from google.adk.integrations.gcs.settings import GCSToolSettings, Capabilities
 from google.adk.integrations.gcs.gcs_credentials import GCSCredentialsConfig

--- a/docs/integrations/synap.md
+++ b/docs/integrations/synap.md
@@ -54,7 +54,7 @@ demand.
 ```python
 import os
 
-from google.adk.agents.llm_agent import Agent
+from google.adk.agents import Agent
 from maximem_synap import MaximemSynapSDK
 from synap_google_adk import create_synap_tools
 

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -271,7 +271,7 @@ a simple ADK agent.
     ```py
     from google.adk.runners import InMemoryRunner
     from google.adk import Agent
-    from google.adk.tools.tool_context import ToolContext
+    from google.adk.tools import ToolContext
     from google.genai import types
     import asyncio
 

--- a/docs/streaming/streaming-tools.md
+++ b/docs/streaming/streaming-tools.md
@@ -30,7 +30,7 @@ Now let's define an agent that can monitor stock price changes and monitor the v
     from typing import AsyncGenerator
 
     from google.adk.agents import LiveRequestQueue
-    from google.adk.agents.llm_agent import Agent
+    from google.adk.agents import Agent
     from google.adk.tools.function_tool import FunctionTool
     from google.genai import Client
     from google.genai import types as genai_types

--- a/docs/tools-custom/authentication.md
+++ b/docs/tools-custom/authentication.md
@@ -263,7 +263,7 @@ Pass the scheme and credential during toolset initialization. The toolset applie
       auth_scheme = OpenIdConnectWithConfig(
           authorization_endpoint=OAUTH2_AUTH_ENDPOINT_URL,
           token_endpoint=OAUTH2_TOKEN_ENDPOINT_URL,
-          scopes=['openid', 'YOUR_OAUTH_SCOPES"]
+          scopes=['openid', 'YOUR_OAUTH_SCOPES']
       )
       auth_credential = AuthCredential(
           auth_type=AuthCredentialTypes.OPEN_ID_CONNECT,
@@ -296,7 +296,7 @@ client_secret = "YOUR_GOOGLE_OAUTH_CLIENT_SECRET"
 
 # Use the specific configure method for this toolset type
 calendar_tool_set.configure_auth(
-    client_id=oauth_client_id, client_secret=oauth_client_secret
+    client_id=client_id, client_secret=client_secret
 )
 
 # agent = LlmAgent(..., tools=calendar_tool_set.get_tool('calendar_tool_set'))

--- a/docs/tools-custom/mcp-tools.md
+++ b/docs/tools-custom/mcp-tools.md
@@ -323,7 +323,7 @@ Modify your `agent.py` file (e.g., in `./adk_agent_samples/mcp_agent/agent.py`).
 ```python
 # ./adk_agent_samples/mcp_agent/agent.py
 import os
-from google.adk.agents.llm_agent import Agent
+from google.adk.agents import Agent
 from google.adk.tools.mcp_tool import McpToolset
 from google.adk.tools.mcp_tool.mcp_session_manager import StreamableHTTPConnectionParams
 
@@ -762,7 +762,7 @@ import os
 import asyncio
 from dotenv import load_dotenv
 from google.genai import types
-from google.adk.agents.llm_agent import LlmAgent
+from google.adk.agents import LlmAgent
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.adk.artifacts.in_memory_artifact_service import InMemoryArtifactService # Optional
@@ -861,7 +861,7 @@ When deploying ADK agents that use MCP tools to production environments like Clo
 ```python
 # ✅ CORRECT: Synchronous agent definition for deployment
 import os
-from google.adk.agents.llm_agent import LlmAgent
+from google.adk.agents import LlmAgent
 from google.adk.tools.mcp_tool import McpToolset
 from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
 from mcp import StdioServerParameters

--- a/docs/tutorials/agent-team.md
+++ b/docs/tutorials/agent-team.md
@@ -998,7 +998,7 @@ Now, we create a new version of the weather tool. Its key feature is accepting `
 
 
 ```python
-from google.adk.tools.tool_context import ToolContext
+from google.adk.tools import ToolContext
 
 def get_weather_stateful(city: str, tool_context: ToolContext) -> dict:
     """Retrieves weather, converts temp unit based on session state."""
@@ -1615,7 +1615,7 @@ This function targets the `get_weather_stateful` tool. It checks the `city` argu
 
 # Ensure necessary imports are available
 from google.adk.tools.base_tool import BaseTool
-from google.adk.tools.tool_context import ToolContext
+from google.adk.tools import ToolContext
 from typing import Optional, Dict, Any # For type hints
 
 def block_paris_tool_guardrail(


### PR DESCRIPTION
## What

Fixes 2 categories of issues across 19 files:

1.  **Broken Python code** — SyntaxError (mismatched quotes) and NameError
    (undefined variables) in `docs/tools-custom/authentication.md`.
2.  **Internal module imports** — 19 files import from
    `google.adk.agents.llm_agent` or `google.adk.tools.tool_context` instead of
    the public API (`google.adk.agents`, `google.adk.tools`).

## Fix

-   `'YOUR_OAUTH_SCOPES"` → `'YOUR_OAUTH_SCOPES'`
-   `oauth_client_id` → `client_id`, `oauth_client_secret` → `client_secret`
-   All `from google.adk.agents.llm_agent import X` → `from google.adk.agents import X`
-   All `from google.adk.tools.tool_context import ToolContext` → `from google.adk.tools import ToolContext`

## Verification

Grep confirms zero remaining instances of the internal import patterns in
`docs/`.