### PR TITLE
docs: update Unstructured Transform MCP tool names and cover the extraction tools

### DIFF
--- a/docs/integrations/unstructured.md
+++ b/docs/integrations/unstructured.md
@@ -96,11 +96,11 @@ the agent pause between status checks, because parsing jobs run asynchronously:
             name="transform_agent",
             instruction=(
                 "You parse documents with the Unstructured Transform MCP server. "
-                "Pass public https:// file URLs straight to transform_files. It "
-                "returns a job_id; poll with check_transform_status, calling "
+                "Pass public https:// file URLs straight to start_transform_job. It "
+                "returns a job_id; poll with check_job_status, calling "
                 "wait_seconds(30) between checks (jobs take 30 seconds to a few "
-                "minutes). When the job completes, call get_transform_results and "
-                "report the parsed content back to the user. transform_files "
+                "minutes). When the job completes, call get_job_results and "
+                "report the parsed content back to the user. start_transform_job "
                 "accepts an optional stages config; it auto-selects a parse "
                 "strategy by default, but if the output looks low quality "
                 "(garbled text or lost tables), re-run the file with a hi_res "
@@ -121,9 +121,9 @@ the agent pause between status checks, because parsing jobs run asynchronously:
                     ),
                     tool_filter=[
                         "request_file_upload_url",
-                        "transform_files",
-                        "check_transform_status",
-                        "get_transform_results",
+                        "start_transform_job",
+                        "check_job_status",
+                        "get_job_results",
                     ],
                 )
             ],
@@ -132,9 +132,9 @@ the agent pause between status checks, because parsing jobs run asynchronously:
 
 !!! note
 
-    Transforming a document is asynchronous: `transform_files` starts a job,
-    the agent polls `check_transform_status`, and `get_transform_results`
-    returns pre-signed download URLs for the output. Instruct your agent to
+    Transforming a document is asynchronous: `start_transform_job` starts a
+    job, the agent polls `check_job_status`, and `get_job_results` returns
+    pre-signed download URLs for the output. Instruct your agent to
     pause between status checks, as shown above, so a polling loop does not
     burn through model rate limits.
 
@@ -150,9 +150,9 @@ the agent pause between status checks, because parsing jobs run asynchronously:
 Tool | Description
 ---- | -----------
 `request_file_upload_url` | Returns a pre-signed upload URL and file reference for a local file.
-`transform_files` | Starts a parsing job for uploaded files or public HTTP(S) URLs; returns a `job_id`.
-`check_transform_status` | Reports whether a job is `SCHEDULED`, `IN_PROGRESS`, or `COMPLETED`.
-`get_transform_results` | Returns the parsed output and pre-signed download URLs for a completed job.
+`start_transform_job` | Starts a parsing job for uploaded files or public HTTP(S) URLs; returns a `job_id`.
+`check_job_status` | Reports whether a job is `SCHEDULED`, `IN_PROGRESS`, or `COMPLETED`.
+`get_job_results` | Returns the parsed output and pre-signed download URLs for a completed job.
 
 ## Resources
 

--- a/docs/integrations/unstructured.md
+++ b/docs/integrations/unstructured.md
@@ -35,6 +35,10 @@ to install or run locally.
 - **OCR at agent runtime**: Extract text and structure from images and scanned
   documents as a step inside a larger agent workflow.
 
+- **Structured data extraction**: Pull named fields out of forms, invoices, and
+  contracts as JSON matching a schema, either one you supply or one the server
+  drafts from the document.
+
 ## Prerequisites
 
 - An [Unstructured account](https://transform.unstructured.io) and API key.
@@ -104,9 +108,20 @@ the agent pause between status checks, because parsing jobs run asynchronously:
                 "accepts an optional stages config; it auto-selects a parse "
                 "strategy by default, but if the output looks low quality "
                 "(garbled text or lost tables), re-run the file with a hi_res "
-                "partition strategy for a cleaner result. If asked to parse a "
-                "local file, explain that this requires the upload helper from the "
-                "Unstructured ADK guide."
+                "partition strategy for a cleaner result. If the user wants "
+                "specific fields rather than the whole document, extract "
+                "instead of just parsing. The extraction tools read the element "
+                "JSON a parse produces, so parse the file first and keep the "
+                "output_ref that get_job_results returns for it. Call "
+                "suggest_extraction_schema_for_file with that output_ref when "
+                "you need a schema, then start_extraction_job with "
+                "element_json_refs set to the output_refs and schema_to_extract "
+                "set to a JSON Schema passed as a JSON string. Poll and read an "
+                "extraction job with check_job_status and get_job_results like "
+                "any other job; its results come back inline, wrapped with the "
+                "source filename, so report that filename with each object. If "
+                "asked to parse a local file, explain that this requires the "
+                "upload helper from the Unstructured ADK guide."
             ),
             tools=[
                 wait_seconds,
@@ -122,6 +137,8 @@ the agent pause between status checks, because parsing jobs run asynchronously:
                     tool_filter=[
                         "request_file_upload_url",
                         "start_transform_job",
+                        "suggest_extraction_schema_for_file",
+                        "start_extraction_job",
                         "check_job_status",
                         "get_job_results",
                     ],
@@ -138,6 +155,12 @@ the agent pause between status checks, because parsing jobs run asynchronously:
     pause between status checks, as shown above, so a polling loop does not
     burn through model rate limits.
 
+    Structured-data extraction is a second asynchronous job that runs on the
+    element JSON of a completed parse, identified by the `output_ref` that
+    `get_job_results` returns for each file. A prompt that parses and then
+    extracts therefore runs two polling loops, so allow for the extra time and
+    model steps.
+
     To parse **local** files, the agent also needs a plain function tool that
     HTTP `PUT`s the file bytes to the pre-signed URL returned by
     `request_file_upload_url` (this upload is not an MCP call, and it must not
@@ -151,8 +174,10 @@ Tool | Description
 ---- | -----------
 `request_file_upload_url` | Returns a pre-signed upload URL and file reference for a local file.
 `start_transform_job` | Starts a parsing job for uploaded files or public HTTP(S) URLs; returns a `job_id`.
-`check_job_status` | Reports whether a job is `SCHEDULED`, `IN_PROGRESS`, or `COMPLETED`.
-`get_job_results` | Returns the parsed output and pre-signed download URLs for a completed job.
+`suggest_extraction_schema_for_file` | Drafts a JSON Schema from one parsed document's element JSON, for when you do not have a schema yet.
+`start_extraction_job` | Starts a structured-data extraction job over parsed element JSON against a JSON Schema; returns a `job_id`.
+`check_job_status` | Reports whether a job is `SCHEDULED`, `IN_PROGRESS`, or `COMPLETED`. Serves both parsing and extraction jobs.
+`get_job_results` | Returns a completed job's output: pre-signed download URLs for a parsing job, or the extracted data inline for an extraction job.
 
 ## Resources
 


### PR DESCRIPTION
The Unstructured Transform MCP server renamed three of its tools after the integration page landed (#1956), so the sample agent on that page no longer works. The `tool_filter` list is the breaking part: it names tools the server no longer exposes, so the toolset resolves to nothing and the agent gets no Transform tools at all.

- `transform_files` is now `start_transform_job`
- `check_transform_status` is now `check_job_status`
- `get_transform_results` is now `get_job_results`

`request_file_upload_url` is unchanged, and the tool behaviour and arguments are the same.

The same release added structured data extraction, which the page did not cover, so I have included it here rather than sending a second PR over the same file. Two new tools, `suggest_extraction_schema_for_file` and `start_extraction_job`, return named fields as JSON matching a schema. Because `tool_filter` is an allowlist, they have to be listed there or an agent cannot reach them at all, which is the same failure mode as the stale names above.

The one thing worth knowing when reviewing: extraction runs on the element JSON that a parse produces, not on a raw file, so it always follows a transform job and is driven by the `output_ref` that `get_job_results` returns for each file. The agent instruction, the note, and the tool table now say that. Extraction results also come back inline rather than behind a pre-signed download URL.

I verified both the names and the extraction flow against the live server (Unstructured Transform 0.7.2) rather than working from a changelog, including running a parse and then an extraction end to end. They match the rename on the Unstructured side (Unstructured-IO/docs#1004). I maintain the linked Unstructured guide, so if anything else on the page needs updating later I am happy to follow up.
