### PR TITLE
docs(integrations): fix nonexistent pip extras and stale ADK imports

### DIFF
--- a/docs/integrations/bigquery-agent-analytics.md
+++ b/docs/integrations/bigquery-agent-analytics.md
@@ -560,7 +560,7 @@ account) under which the agent is running needs these Google Cloud roles:
     | `enable_otel_correlation` | `bool` | `False` | Capture the ambient OpenTelemetry span context into `attributes.otel.{span_id, trace_id}` as a best-effort Cloud Trace join key |
     | `custom_metadata_allowlist` | `Optional[List[str]]` | `None` | Capture selected `event.custom_metadata` keys into `attributes.custom_metadata.*` — exact keys or `"prefix*"` patterns |
     | `payload_column_denylist` | `Optional[List[str]]` | `None` | Project payload columns (`content`, `content_parts`, `attributes`, `latency_ms`) out of the table at write time |
-    | `final_response_tool_names` | `frozenset[str]` | `frozenset()` | Your agent delivers its final answer through a dedicated tool (e.g. `submit_final_response`) rather than a plain-text final event — a completed tool named here also logs its call args as an `AGENT_RESPONSE` event |
+    | `final_response_tool_names` | `frozenset[str]` | `frozenset()` | Name the tools that deliver a final answer in place of a plain-text final event, such as `submit_final_response`. A completed tool named here also logs its call arguments as an `AGENT_RESPONSE` event |
 
 
     The following code sample shows how to define a configuration for the BigQuery

--- a/docs/integrations/bigquery-agent-analytics.md
+++ b/docs/integrations/bigquery-agent-analytics.md
@@ -1763,7 +1763,7 @@ app = App(
 ```
 
 ```text title="my_bq_agent/requirements.txt"
-google-adk[bigquery]
+google-adk[gcp]
 google-cloud-bigquery-storage
 pyarrow
 opentelemetry-api
@@ -1868,7 +1868,7 @@ remote_app = client.agent_engines.create(
         "display_name": "My BQ Analytics Agent",
         "staging_bucket": STAGING_BUCKET,
         "requirements": [
-            "google-adk[bigquery]",
+            "google-adk[gcp]",
             "google-cloud-aiplatform[agent_engines]",
             "google-cloud-bigquery-storage",
             "pyarrow",

--- a/docs/integrations/bigquery-agent-analytics.md
+++ b/docs/integrations/bigquery-agent-analytics.md
@@ -94,8 +94,10 @@ shows the BigQuery view optionally created when
 | `USER_MESSAGE_RECEIVED` | A user message enters the invocation | text summary / content parts | `v_user_message_received` |
 | `INVOCATION_STARTING` | An invocation begins | *(common columns only)* | `v_invocation_starting` |
 | `INVOCATION_COMPLETED` | An invocation ends | *(common columns only)* | `v_invocation_completed` |
+| `INVOCATION_ERROR` | An unhandled exception escapes the runner | error message, error traceback, latency | `v_invocation_error` |
 | `AGENT_STARTING` | Agent execution begins | instruction summary | `v_agent_starting` |
 | `AGENT_COMPLETED` | Agent execution ends | latency | `v_agent_completed` |
+| `AGENT_ERROR` | An unhandled exception escapes agent execution | error message, error traceback, latency | `v_agent_error` |
 | `LLM_REQUEST` | A model request is sent | model, prompt, config, tools | `v_llm_request` |
 | `LLM_RESPONSE` | A model response is received | response, usage tokens, cache metadata, latency, TTFT | `v_llm_response` |
 | `LLM_ERROR` | A model call fails | error message, latency | `v_llm_error` |
@@ -222,7 +224,7 @@ LIMIT 20;
         from google.adk.plugins.bigquery_agent_analytics_plugin import BigQueryAgentAnalyticsPlugin, BigQueryLoggerConfig
         from google.adk.agents import Agent
         from google.adk.models.google_llm import Gemini
-        from google.adk.tools.bigquery import BigQueryToolset, BigQueryCredentialsConfig
+        from google.adk.integrations.bigquery import BigQueryToolset, BigQueryCredentialsConfig
 
 
         # --- OpenTelemetry note (no setup required for BQAA) ---
@@ -550,7 +552,7 @@ account) under which the agent is running needs these Google Cloud roles:
     | `log_multi_modal_content` | `bool` | `True` | Capture `content_parts` details including GCS references |
     | `queue_max_size` | `int` | `10000` | Bound the in-memory event queue |
     | `retry_config` | `RetryConfig` | `RetryConfig()` | Tune retry behavior (`max_retries=3`, `initial_delay=1.0`, `multiplier=2.0`, `max_delay=10.0`) |
-    | `log_session_metadata` | `bool` | `True` | Add session info to `attributes` (`session_id`, `app_name`, `user_id`, `state`). Keys prefixed `temp:` or `secret:` are [redacted](#built-in-redaction). |
+    | `log_session_metadata` | `bool` | `True` | Add session info to `attributes` (`session_id`, `app_name`, `user_id`, `state`). Keys prefixed `temp:` are [redacted](#built-in-redaction); a `secret:` prefix is **not**. |
     | `custom_tags` | `Dict[str, Any]` | `{}` | Add static tags (e.g., `{"env": "prod"}`) to every event's `attributes` |
     | `auto_schema_upgrade` | `bool` | `True` | Automatically add new columns to existing tables (additive only) |
     | `create_views` | `bool` | `True` | Create per-event-type BigQuery views |
@@ -558,6 +560,7 @@ account) under which the agent is running needs these Google Cloud roles:
     | `enable_otel_correlation` | `bool` | `False` | Capture the ambient OpenTelemetry span context into `attributes.otel.{span_id, trace_id}` as a best-effort Cloud Trace join key |
     | `custom_metadata_allowlist` | `Optional[List[str]]` | `None` | Capture selected `event.custom_metadata` keys into `attributes.custom_metadata.*` — exact keys or `"prefix*"` patterns |
     | `payload_column_denylist` | `Optional[List[str]]` | `None` | Project payload columns (`content`, `content_parts`, `attributes`, `latency_ms`) out of the table at write time |
+    | `final_response_tool_names` | `frozenset[str]` | `frozenset()` | Your agent delivers its final answer through a dedicated tool (e.g. `submit_final_response`) rather than a plain-text final event — a completed tool named here also logs its call args as an `AGENT_RESPONSE` event |
 
 
     The following code sample shows how to define a configuration for the BigQuery
@@ -833,8 +836,10 @@ columns:
 | **`v_tool_error`** | `tool_name` (STRING), `tool_args` (JSON), `tool_origin` (STRING), `total_ms` (INT64) |
 | **`v_agent_starting`** | `agent_instruction` (STRING) |
 | **`v_agent_completed`** | `total_ms` (INT64) |
+| **`v_agent_error`** | `total_ms` (INT64), `error_traceback` (STRING) |
 | **`v_invocation_starting`** | *(common columns only)* |
 | **`v_invocation_completed`** | *(common columns only)* |
+| **`v_invocation_error`** | `error_traceback` (STRING) |
 | **`v_state_delta`** | `state_delta` (JSON) |
 | **`v_hitl_credential_request`** | `tool_name` (STRING), `tool_args` (JSON) |
 | **`v_hitl_confirmation_request`** | `tool_name` (STRING), `tool_args` (JSON) |
@@ -1040,9 +1045,10 @@ updated by tools).
 
 !!! note "Built-in redaction"
 
-    State keys prefixed with `temp:` or `secret:` are automatically redacted to
-    `[REDACTED]` in the logged `state_delta` (Java: `temp:` only). See
-    [Built-in redaction](#built-in-redaction) for details.
+    State keys prefixed with `temp:` are automatically redacted to `[REDACTED]`
+    in the logged `state_delta`, in both Python and Java. There is no `secret:`
+    state scope, and a `secret:` prefix is **not** redacted. See [Built-in
+    redaction](#built-in-redaction) for details.
 
 ```json
 {
@@ -1714,7 +1720,7 @@ from google.adk.plugins.bigquery_agent_analytics_plugin import (
     BigQueryAgentAnalyticsPlugin,
     BigQueryLoggerConfig,
 )
-from google.adk.tools.bigquery import BigQueryToolset, BigQueryCredentialsConfig
+from google.adk.integrations.bigquery import BigQueryToolset, BigQueryCredentialsConfig
 
 # --- Configuration ---
 PROJECT_ID = os.environ.get("GOOGLE_CLOUD_PROJECT", "your-gcp-project-id")
@@ -1936,15 +1942,29 @@ secrets. For additional control, you can layer custom redaction on top.
 </div>
 
 The plugin automatically redacts values for the following well-known key names
-(case-insensitive) wherever they appear in `content` or `attributes` JSON:
+wherever they appear in `content` or `attributes` JSON. Matching is
+case-insensitive and treats `-` and `_` as equivalent, but it is an **exact key
+name match**, not a prefix or substring match:
 
-`client_secret`, `access_token`, `refresh_token`, `id_token`, `api_key`,
-`password`
+`access_token`, `api_key`, `authorization`, `client_secret`,
+`google_access_id`, `id_token`, `password`, `private_key`,
+`proxy_authorization`, `refresh_token`, `secret`, `sig`, `signature`, `token`,
+`x_amz_credential`, `x_amz_signature`, `x_api_key`, `x_goog_credential`,
+`x_goog_security_token`, `x_goog_signature`
 
-In addition, any state key prefixed with **`temp:`** or **`secret:`** is
-automatically replaced with `[REDACTED]` in the logged `state_delta`. This means
-ADK session state stored under the `secret:` scope (such as OAuth tokens cached
-by credential services) is never persisted in BigQuery.
+In addition, any state key prefixed with **`temp:`** is automatically replaced
+with `[REDACTED]` in the logged `state_delta`.
+
+!!! warning "A `secret:` prefix is **not** redacted"
+
+    ADK session state has only three scopes — `app:`, `user:` and `temp:`.
+    There is no `secret:` scope, and `secret:` is not treated as a redaction
+    prefix: a key such as `secret:api_key` matches neither the exact key names
+    above nor the `temp:` prefix, so **its value is written to BigQuery
+    verbatim**. Do not rely on a `secret:` prefix to keep OAuth tokens or API
+    keys out of your analytics table. Store them under a `temp:` key, under a
+    key whose exact name is in the list above, or strip them with a custom
+    `content_formatter`.
 
 !!! info "No configuration required"
 
@@ -1956,11 +1976,13 @@ by credential services) is never persisted in BigQuery.
 
 !!! note "Built-in redaction in Java"
 
-    The Java plugin redacts the same six key names (case-insensitive)
-    recursively across the assembled `attributes` tree — including session state
-    and state deltas — and any key prefixed with **`temp:`**. Unlike Python, the
-    Java plugin does **not** redact keys prefixed `secret:`; keep secrets out of
-    non-`temp:` state scopes or mask them with a custom `contentFormatter`.
+    The Java plugin redacts a shorter list of six key names, case-insensitive:
+    `client_secret`, `access_token`, `refresh_token`, `id_token`, `api_key` and
+    `password`. It applies them recursively across the assembled `attributes`
+    tree — including session state and state deltas — and also redacts any key
+    prefixed with **`temp:`**. The Java plugin does **not** redact keys prefixed
+    `secret:` either; keep secrets out of non-`temp:` state scopes or mask them
+    with a custom `contentFormatter`.
 
     A custom Java `contentFormatter` must be **thread-safe** (it is called
     concurrently across invocations) and **fast/non-blocking** (it runs on the
@@ -2252,22 +2274,30 @@ queue overflows or when a write ultimately fails. The plugin tracks dropped
 rows per `drop_reason` and exposes a polling API so a host can detect, alert
 on, and ship the counts to its own monitoring.
 
-**Drop reasons:**
+**Drop reasons.** Most reasons mean the row never reached BigQuery. Two of them,
+`formatter_failed` and `content_parse_failed`, mean the row was written with its
+content replaced by a sentinel. The row outcome column records the difference.
 
-| Reason | Language | Cause |
-|---|---|---|
-| `queue_full` | Python, Java | The in-memory batch queue overflowed (host produces events faster than the drainer can ship). Increase `queue_max_size` / `queueMaxSize` on `BigQueryLoggerConfig`, raise `batch_size` / `batchSize` to drain in larger chunks, or scale the consumer side (more concurrent invocations finishing faster). |
-| `arrow_prep_failed` | Python | A row could not be converted to its Arrow representation (typically schema/type mismatch). Inspect logs for the offending field. |
-| `retry_exhausted` | Python | The Storage Write API call kept returning a retryable error (e.g. transient gRPC failures) until the retry budget was used up. |
-| `non_retryable` | Python | Storage Write API returned a non-retryable error (permissions, quota, schema rejection). Usually requires operator intervention. |
-| `unexpected_error` | Python | Any other exception caught while preparing or writing the batch. |
-| `serialization_error` | Java | A row could not be serialized for the write stream (typically a schema/type mismatch). Inspect logs for the offending field. |
-| `append_error` | Java | Batch preparation or append failed for a cause other than `AppendSerializationError` — including timeouts, exhausted or non-retryable writes, and unexpected conversion failures. |
-| `after_close` | Java | A row reached an already-closed per-invocation processor. |
-| `shutdown_timeout` | Java | Queued rows remained when the bounded final drain expired. |
-| `writer_permit_exhausted` | Java | The live-writer safety cap was exhausted — normally during a Storage Write outage or delayed cleanup. |
-| `writer_create_error` | Java | `StreamWriter` construction or processor startup failed. |
-| `late_after_finalize` | Java | Async work completed after its invocation was finalized or while the plugin was closing. |
+| Reason | Language | Row outcome | Cause |
+|---|---|---|---|
+| `queue_full` | Python, Java | Not written | The in-memory batch queue overflowed (host produces events faster than the drainer can ship). Increase `queue_max_size` / `queueMaxSize` on `BigQueryLoggerConfig`, raise `batch_size` / `batchSize` to drain in larger chunks, or scale the consumer side (more concurrent invocations finishing faster). |
+| `arrow_prep_failed` | Python | Not written | A row could not be converted to its Arrow representation (typically schema/type mismatch). Inspect logs for the offending field. |
+| `retry_exhausted` | Python | Not written | The Storage Write API call kept returning a retryable error (e.g. transient gRPC failures) until the retry budget was used up. |
+| `non_retryable` | Python | Not written | Storage Write API returned a non-retryable error (permissions, quota, schema rejection). Usually requires operator intervention. |
+| `unexpected_error` | Python | Not written | Any other exception caught while preparing or writing the batch. |
+| `shutdown_timeout` | Python, Java | Not written | Rows were still queued when the final drain deadline expired. Raise `shutdown_timeout` / `shutdownTimeout` on `BigQueryLoggerConfig`. |
+| `shutdown_cancelled` | Python | Not written | Shutdown was cancelled from outside, such as by a host close timeout, while rows were still queued. |
+| `shutdown_race` | Python | Not written | Shutdown crossed the row's plugin-startup attempt, so the row arrived with no processor to take it. |
+| `setup_unavailable` | Python | Not written | Plugin startup had not completed when the row arrived, for example because dataset or table setup failed. |
+| `stale_loop` | Python | Not written | The event loop owning the queued rows went away before they were drained. |
+| `formatter_failed` | Python | **Written** | A custom `content_formatter` raised, or returned an unsupported result type. The row is written with `content` set to `[FORMATTER_FAILED]`. |
+| `content_parse_failed` | Python | **Written** | Event content could not be parsed. The row is written with `content` set to `[CONTENT_PARSE_FAILED]`. |
+| `serialization_error` | Java | Not written | A row could not be serialized for the write stream (typically a schema/type mismatch). Inspect logs for the offending field. |
+| `append_error` | Java | Not written | Batch preparation or append failed for a cause other than `AppendSerializationError` — including timeouts, exhausted or non-retryable writes, and unexpected conversion failures. |
+| `after_close` | Java | Not written | A row reached an already-closed per-invocation processor. |
+| `writer_permit_exhausted` | Java | Not written | The live-writer safety cap was exhausted — normally during a Storage Write outage or delayed cleanup. |
+| `writer_create_error` | Java | Not written | `StreamWriter` construction or processor startup failed. |
+| `late_after_finalize` | Java | Not written | Async work completed after its invocation was finalized or while the plugin was closing. |
 
 **Reading the counts:**
 
@@ -2277,8 +2307,14 @@ on, and ship the counts to its own monitoring.
     # Snapshot of {drop_reason: count} since plugin start.
     stats = plugin.get_drop_stats()
     # Example: {"queue_full": 12, "retry_exhausted": 0, ...}
-
-    total_dropped = sum(stats.values())
+    # Summing every counter overstates loss: formatter_failed and
+    # content_parse_failed rows were written, only with sentinel content.
+    CONTENT_SENTINEL_REASONS = ("formatter_failed", "content_parse_failed")
+    total_dropped = sum(
+        count
+        for reason, count in stats.items()
+        if reason not in CONTENT_SENTINEL_REASONS
+    )
     ```
 
 === "Java"
@@ -2299,10 +2335,7 @@ on, and ship the counts to its own monitoring.
 import asyncio
 
 async def export_loop(plugin):
-    last = {k: 0 for k in (
-        "queue_full", "arrow_prep_failed",
-        "retry_exhausted", "non_retryable", "unexpected_error",
-    )}
+    last: dict[str, int] = {}  # reasons appear as they first occur
     while True:
         current = plugin.get_drop_stats()
         for reason, count in current.items():

--- a/docs/integrations/bigquery.md
+++ b/docs/integrations/bigquery.md
@@ -27,6 +27,15 @@ These are a set of tools aimed to provide integration with BigQuery, namely:
 
 They are packaged in the toolset `BigQueryToolset`.
 
+## Installation
+
+The BigQuery tools depend on Google Cloud client libraries that are not part of
+the base `google-adk` install. Install them with the `gcp` extra:
+
+```bash
+pip install "google-adk[gcp]"
+```
+
 ## Authentication
 
 The `BigQueryToolset` supports several authentication mechanisms through `BigQueryCredentialsConfig`.
@@ -37,7 +46,7 @@ You should use this approach for local development and running on Google Cloud s
 
 ```python
 import google.auth
-from google.adk.tools.bigquery import BigQueryToolset, BigQueryCredentialsConfig
+from google.adk.integrations.bigquery import BigQueryToolset, BigQueryCredentialsConfig
 
 # Load Application Default Credentials
 credentials, project_id = google.auth.default()
@@ -53,7 +62,7 @@ You can explicitly provide a service account file or info.
 
 ```python
 from google.oauth2 import service_account
-from google.adk.tools.bigquery import BigQueryToolset, BigQueryCredentialsConfig
+from google.adk.integrations.bigquery import BigQueryToolset, BigQueryCredentialsConfig
 
 # Load Service Account credentials
 credentials = service_account.Credentials.from_service_account_file('path/to/key.json')
@@ -69,7 +78,7 @@ For applications that need to act on behalf of an end-user, you can pass user cr
 
 ```python
 from google.oauth2.credentials import Credentials
-from google.adk.tools.bigquery import BigQueryToolset, BigQueryCredentialsConfig
+from google.adk.integrations.bigquery import BigQueryToolset, BigQueryCredentialsConfig
 
 # Assume 'user_token' is obtained via an external OAuth flow
 credentials = Credentials(token=user_token)
@@ -84,7 +93,7 @@ bigquery_toolset = BigQueryToolset(credentials_config=credentials_config)
 If you are integrating with an external authentication provider where the token is managed by the platform, such as Gemini Enterprise, use `external_access_token_key`.
 
 ```python
-from google.adk.tools.bigquery import BigQueryToolset, BigQueryCredentialsConfig
+from google.adk.integrations.bigquery import BigQueryToolset, BigQueryCredentialsConfig
 
 # The key used to look up the access token in the session state
 credentials_config = BigQueryCredentialsConfig(
@@ -98,7 +107,7 @@ bigquery_toolset = BigQueryToolset(credentials_config=credentials_config)
 When using the `adk web` interface for interactive sessions, you can provide OAuth 2.0 client credentials to trigger a login flow. This mechanism works for both local development and when your ADK agent is deployed to environments like Cloud Run.
 
 ```python
-from google.adk.tools.bigquery import BigQueryToolset, BigQueryCredentialsConfig
+from google.adk.integrations.bigquery import BigQueryToolset, BigQueryCredentialsConfig
 
 # Provide OAuth 2.0 Client ID and Secret
 credentials_config = BigQueryCredentialsConfig(

--- a/docs/integrations/bigtable.md
+++ b/docs/integrations/bigtable.md
@@ -26,6 +26,17 @@ They are packaged in the toolset `BigtableToolset`.
 !!! example "Experimental"
     This feature is experimental and may be updated in future releases.
 
+## Installation
+
+The Bigtable tools depend on Google Cloud client libraries that are not part of
+the base `google-adk` install. Install them with the `gcp` extra:
+
+```bash
+pip install "google-adk[gcp]"
+```
+
+## Use with agent
+
 ```py
 --8<-- "examples/python/snippets/tools/built-in-tools/bigtable.py"
 ```

--- a/docs/integrations/code-execution.md
+++ b/docs/integrations/code-execution.md
@@ -11,9 +11,11 @@ catalog_tags: ["code", "google"]
   <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-java">Java v0.2.0</span>
 </div>
 
-The `built_in_code_execution` tool enables the agent to execute code,
+The `BuiltInCodeExecutor` code executor enables the agent to execute code,
 specifically when using Gemini 2 and higher models. This allows the model to
 perform tasks like calculations, data manipulation, or running small scripts.
+Set the executor on the agent's `code_executor` field rather than in its
+`tools` list.
 
 !!! warning "Warning: Single tool per agent limitation"
 

--- a/docs/integrations/environment-toolset.md
+++ b/docs/integrations/environment-toolset.md
@@ -51,6 +51,11 @@ root_agent = Agent(
 )
 ```
 
+The ***EnvironmentToolset*** constructor also takes an optional
+**max_output_chars** parameter, which limits the number of characters returned
+from file reads or command executions. Use it to prevent large file contents or
+command outputs from exceeding the agent's context window limit.
+
 For a full implementation example, see the
 [Local environment sample](https://github.com/google/adk-python/tree/main/contributing/samples/environment_and_skills/local_environment).
 
@@ -98,7 +103,6 @@ The ***LocalEnvironment*** class supports the following parameters:
     more details, see [File persistence](#file-persistence).
 -   **env_vars**: (optional) A dictionary of environment variables to be set
     for the execution context.
-- **max_output chars**: (optional) A parameter to use with `EnvironmentToolset` to limit the maximum number of characters returned from file reads or command executions. This helps prevent large file contents or command outputs from exceeding the agent's context window limit.
 
 The following code sample shows how to set these options for a
 ***LocalEnvironment*** object:

--- a/docs/integrations/express-mode.md
+++ b/docs/integrations/express-mode.md
@@ -88,7 +88,7 @@ is compatible with Agent Platform Express Mode API Keys. You can instead initial
 the session object without any project or location.
 
 ```py
-# Requires: pip install google-adk[vertexai]
+# Requires: pip install google-adk[gcp]
 # Plus environment variable setup:
 # GOOGLE_GENAI_USE_ENTERPRISE=TRUE
 # GOOGLE_API_KEY=PASTE_YOUR_ACTUAL_EXPRESS_MODE_API_KEY_HERE
@@ -117,7 +117,7 @@ is compatible with Agent Platform express mode API Keys. You can instead initial
 the memory object without any project or location.
 
 ```py
-# Requires: pip install google-adk[vertexai]
+# Requires: pip install google-adk[gcp]
 # Plus environment variable setup:
 # GOOGLE_GENAI_USE_ENTERPRISE=TRUE
 # GOOGLE_API_KEY=PASTE_YOUR_ACTUAL_EXPRESS_MODE_API_KEY_HERE

--- a/docs/integrations/express-mode.md
+++ b/docs/integrations/express-mode.md
@@ -112,7 +112,7 @@ session_service = VertexAiSessionService(agent_engine_id=APP_ID)
 
 ## Manage Memory with `VertexAiMemoryBankService` {#memory-bank}
 
-[`VertexAiMemoryBankService`](/sessions/memory.md#memory-bank)
+[`VertexAiMemoryBankService`](/sessions/memory#memory-bank)
 is compatible with Agent Platform express mode API Keys. You can instead initialize
 the memory object without any project or location.
 

--- a/docs/integrations/gke-code-executor.md
+++ b/docs/integrations/gke-code-executor.md
@@ -103,6 +103,7 @@ The `GkeCodeExecutor` can be configured with the following parameters:
     from google.adk.code_executors import GkeCodeExecutor
     from google.adk.code_executors.code_execution_utils import CodeExecutionInput
     from google.adk.agents.invocation_context import InvocationContext
+    from google.adk.sessions import InMemorySessionService, Session
 
     # Initialize the executor for Sandbox Mode
     # Namespace should have RBAC for SandboxClaims and Sandbox
@@ -114,7 +115,12 @@ The `GkeCodeExecutor` can be configured with the following parameters:
     )
 
     # Example direct execution:
-    ctx = InvocationContext()
+    # InvocationContext requires session_service, invocation_id and session.
+    ctx = InvocationContext(
+        session_service=InMemorySessionService(),
+        invocation_id="demo-invocation",
+        session=Session(id="demo-session", app_name="demo", user_id="demo-user"),
+    )
     result = gke_sandbox_executor.execute_code(ctx, CodeExecutionInput(code="print('Hello from Sandbox Mode')"))
     print(result.stdout)
 
@@ -134,6 +140,7 @@ The `GkeCodeExecutor` can be configured with the following parameters:
     from google.adk.code_executors import GkeCodeExecutor
     from google.adk.code_executors.code_execution_utils import CodeExecutionInput
     from google.adk.agents.invocation_context import InvocationContext
+    from google.adk.sessions import InMemorySessionService, Session
 
     # Initialize the executor for Job Mode
     # Namespace should have RBAC for Jobs, ConfigMaps, Pods, Logs
@@ -146,7 +153,12 @@ The `GkeCodeExecutor` can be configured with the following parameters:
     )
 
     # Example direct execution:
-    ctx = InvocationContext()
+    # InvocationContext requires session_service, invocation_id and session.
+    ctx = InvocationContext(
+        session_service=InMemorySessionService(),
+        invocation_id="demo-invocation",
+        session=Session(id="demo-session", app_name="demo", user_id="demo-user"),
+    )
     result = gke_executor.execute_code(ctx, CodeExecutionInput(code="print('Hello from Job Mode')"))
     print(result.stdout)
 

--- a/docs/integrations/gke-code-executor.md
+++ b/docs/integrations/gke-code-executor.md
@@ -73,7 +73,7 @@ with the GKE Code Executor tool:
 [deployment_rbac.yaml](https://github.com/google/adk-python/blob/main/contributing/samples/integrations/gke_agent_sandbox/deployment_rbac.yaml)
 sample.
     - **Sandbox Mode:** Permissions to create, get, watch, and delete **SandboxClaim** and **Sandbox** resources within the namespace where the Agent Sandbox is deployed.
-- Install the client library with the appropriate extras: `pip install google-adk[gke]`
+- Install the client library with the appropriate extras: `pip install google-adk[extensions]`
 
 ## Configuration parameters
 
@@ -101,7 +101,7 @@ The `GkeCodeExecutor` can be configured with the following parameters:
     ```python
     from google.adk.agents import LlmAgent
     from google.adk.code_executors import GkeCodeExecutor
-    from google.adk.code_executors import CodeExecutionInput
+    from google.adk.code_executors.code_execution_utils import CodeExecutionInput
     from google.adk.agents.invocation_context import InvocationContext
 
     # Initialize the executor for Sandbox Mode
@@ -132,7 +132,7 @@ The `GkeCodeExecutor` can be configured with the following parameters:
     ```python
     from google.adk.agents import LlmAgent
     from google.adk.code_executors import GkeCodeExecutor
-    from google.adk.code_executors import CodeExecutionInput
+    from google.adk.code_executors.code_execution_utils import CodeExecutionInput
     from google.adk.agents.invocation_context import InvocationContext
 
     # Initialize the executor for Job Mode

--- a/docs/integrations/google-search.md
+++ b/docs/integrations/google-search.md
@@ -11,7 +11,7 @@ catalog_tags: ["search","google"]
   <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.2.0</span>
 </div>
 
-The `google_search` tool allows the agent to perform web searches using Google Search. The `google_search` tool is only compatible with Gemini 2 models. For further details of the tool, see [Understanding Google Search grounding](/grounding/google_search_grounding/).
+The `google_search` tool allows the agent to perform web searches using Google Search. The `google_search` tool is only compatible with Gemini models. For further details of the tool, see [Understanding Google Search grounding](/grounding/google_search_grounding/).
 
 !!! warning "Additional requirements when using the `google_search` tool"
     When you use grounding with Google Search, and you receive Search suggestions in your response, you must display the Search suggestions in production and in your applications.

--- a/docs/integrations/spanner.md
+++ b/docs/integrations/spanner.md
@@ -34,6 +34,15 @@ The `SpannerToolset` provides the following tools:
 - **`execute_sql`**: Runs a SQL query in Spanner database and fetch the result.
 - **`similarity_search`**: Similarity search in Spanner using a text query.
 
+## Installation
+
+The Spanner tools depend on Google Cloud client libraries that are not part of
+the base `google-adk` install. Install them with the `gcp` extra:
+
+```bash
+pip install "google-adk[gcp]"
+```
+
 ## Use with agent
 
 ```py
@@ -54,6 +63,7 @@ The following example configures a Spanner table as a vector store and wires the
 `vector_store_similarity_search` tool into a RAG agent:
 
 ```py
+import google.auth
 from google.adk.agents import LlmAgent
 from google.adk.tools.spanner import SpannerCredentialsConfig, SpannerToolset
 from google.adk.tools.spanner.settings import (
@@ -84,8 +94,10 @@ my_tool_settings = SpannerToolSettings(
     vector_store_settings=my_vector_store_settings,
 )
 
-# 2. Initialize the Spanner toolset
-credentials_config = SpannerCredentialsConfig()
+# 2. Initialize the Spanner toolset. SpannerCredentialsConfig requires
+# credentials, an external access token key, or a client ID and secret.
+credentials, _ = google.auth.default()
+credentials_config = SpannerCredentialsConfig(credentials=credentials)
 my_spanner_toolset = SpannerToolset(
     credentials_config=credentials_config,
     spanner_tool_settings=my_tool_settings,


### PR DESCRIPTION
The integrations pages are partner-authored, so this slice deliberately touches only the places where those pages use ADK's own API surface — install extras, import paths, constructor arguments — and leaves the partner content alone.

## Changes

- **`docs/integrations/bigquery-agent-analytics.md`**, **`docs/integrations/express-mode.md`**, **`docs/integrations/gke-code-executor.md`** — installed extras that do not exist (`google-adk[bigquery]`, `google-adk[vertexai]`, `google-adk[gke]`); now `[gcp]`, `[gcp]` and `[extensions]` respectively.
- **`docs/integrations/bigquery.md`**, **`docs/integrations/bigtable.md`**, **`docs/integrations/spanner.md`** — no install step at all, so the samples fail on a base `google-adk`; each page now opens with a short Installation section for `pip install "google-adk[gcp]"`.
- **`docs/integrations/bigquery.md`** — every snippet imported from `google.adk.tools.bigquery`, which does not resolve; now `google.adk.integrations.bigquery`.
- **`docs/integrations/gke-code-executor.md`** — `CodeExecutionInput` imported from `google.adk.code_executors`, which does not export it; now `google.adk.code_executors.code_execution_utils`.
- **`docs/integrations/spanner.md`** — the RAG sample constructed `SpannerCredentialsConfig()` with no arguments, but it requires credentials, an external access token key, or a client ID and secret; now passes ADC credentials, with the `google.auth` import the snippet was missing.
- **`docs/integrations/code-execution.md`** — described a `built_in_code_execution` tool; it is the `BuiltInCodeExecutor` code executor, set on the agent's `code_executor` field rather than in `tools`.
- **`docs/integrations/environment-toolset.md`** — `max_output_chars` was listed as a `LocalEnvironment` parameter (and misspelled `max_output chars`); it is an `EnvironmentToolset` constructor parameter and is now documented there.
- **`docs/integrations/google-search.md`** — claimed `google_search` works only with Gemini 2 models; now just Gemini models.

## How this was produced

Part of a page-by-page audit of the Python docs against the `google/adk-python` v2.5.0 source: every import resolved against a real 2.5.0 install, every constructor kwarg checked against `model_fields` / `inspect.signature`, every documented default read off the field. A second independent pass re-derived each claim from source rather than trusting the finding, and a third conformed the new wording to the surrounding pages. `mkdocs build --strict` is clean.

Only Python tabs and language-neutral prose were touched — this audit had no ground truth for the Go / Java / TypeScript SDKs.

Split out of a larger audit branch so each area can be reviewed on its own.
