### PR TITLE
docs(graphs): fix graph workflow samples and behavior claims

### DIFF
--- a/docs/graphs/data-handling.md
+++ b/docs/graphs/data-handling.md
@@ -369,6 +369,8 @@ accepted and produced by any agent node.
     ***BaseModel*** to constrain any agent's input and output:
 
     ```python
+    from datetime import date
+
     from google.adk import Agent
     from pydantic import BaseModel
 
@@ -389,14 +391,14 @@ accepted and produced by any agent node.
         output_schema=FlightSearchOutput,
         tools=[search_flights_api],
         mode="single_turn",
-        ...
+        # ...
     )
 
     assistant = Agent(
         name="assistant",
         instruction="You help users plan trips.",
         sub_agents=[flight_searcher],
-        ...
+        # ...
     )
     ```
 
@@ -466,7 +468,7 @@ accepted and produced by any agent node.
     root_agent = Workflow(
         name="root_agent",
         edges=[
-            (START, city_generator_agent, lookup_time_function, city_report_agent)
+            ("START", city_generator_agent, lookup_time_function, city_report_agent)
         ],
     )
     ```
@@ -500,9 +502,9 @@ accepted and produced by any agent node.
     framework serializes it into `Event.Output`. The successor `AgentNode`
     receives the struct as its user content — the fields are available to the
     agent's `Instruction` without any `{key}` template syntax. This is the
-    direct equivalent of Python's `input_schema=CityTime` with
-    `{CityTime.time_info}` template placeholders: the struct fields are
-    delivered as typed input rather than looked up by name from state.
+    direct equivalent of Python's `input_schema=CityTime`: in both languages
+    the struct fields are delivered as typed input rather than looked up by
+    name from state.
 
     ```go
     --8<-- "examples/go/snippets/graphs/data-handling/main.go:structured-output"

--- a/docs/graphs/data-handling.md
+++ b/docs/graphs/data-handling.md
@@ -365,8 +365,8 @@ accepted and produced by any agent node.
     The curly-brace `{key}` placeholders that an `instruction` supports are
     substituted from *session state*, not from the node input, so a
     placeholder such as `{CityTime.time_info}` is left in the prompt verbatim.
-    To template a value into an instruction, write it to state first — with
-    `output_key` or `Event(state=...)` — and reference it as `{time_info}`.
+    To template a value into an instruction, write it to state first, with
+    `output_key` or `Event(state=...)`, and reference it as `{time_info}`.
 
 === "Go"
 

--- a/docs/graphs/data-handling.md
+++ b/docs/graphs/data-handling.md
@@ -84,8 +84,9 @@ Each step in a workflow produces output for its successor.
     Use the ***return*** syntax when outputting ***Event*** data that does not
     require additional processing. When emitting data that requires additional
     processing, or if you are generating more than one data item, you can use
-    more than one ***yield*** command. Each ***yield*** call adds to a list of
-    data objects on the Event which is passed to the next node of a graph. A
+    more than one ***yield*** command. Each ***yield*** call emits a separate
+    ***Event***, but only one of those events may carry an `output`, and that
+    single value is what the next node of the graph receives. A
     ***return*** or ***yield*** command without a parameter passes a `None` value
     to the next node.
 
@@ -216,7 +217,7 @@ inside tools and callbacks regardless of which agent style you use.
           },
       )
 
-    async def task_attempt_node(node_input: Content, attempts: int):
+    async def task_attempt_node(node_input, attempts: int):
       yield Event(
           state={
               "attempts": attempts + 1,
@@ -224,7 +225,7 @@ inside tools and callbacks regardless of which agent style you use.
       )
 
     async def read_state_node(ctx: Context):
-      print(f"attempts state: {ctx.state}") # attempts state: attempts: 1
+      print(f"attempts state: {ctx.state['attempts']}") # attempts state: 1
 
     root_agent = Workflow(
         name="root_agent",
@@ -328,35 +329,26 @@ accepted and produced by any agent node.
 
 === "Python"
 
-    Use the curly-brace `{ }` syntax to select properties from the input
-    schema, or `< >` to select a property and also qualify it by the name
-    of the source node:
+    Use `input_schema` on an agent to validate the structured output of the
+    preceding node and deliver it as the agent's input. Refer to the fields of
+    that input by name in the instruction:
 
     ```python
     class CityTime(BaseModel):
         time_info: str  # time information
         city: str       # city name
 
-    def lookup_time_function(city: str):
+    def lookup_time_function(node_input: str):
         """Simulate returning the current time in the specified city."""
-        return Event(output=CityTime(time_info='10:10 AM', city=city))
+        return Event(output=CityTime(time_info='10:10 AM', city=node_input))
 
     city_report_agent = Agent(
         name="city_report_agent",
         model="gemini-flash-latest",
         input_schema=CityTime,
-
-        # data selection based on class and parameter
-        # instruction="""
-        #     Return a sentence in the following format:
-        #     It is {CityTime.time_info} in {CityTime.city} right now.
-        # """,
-
-        # more restrictive data selection based on source node name
         instruction="""
-            Return a sentence in the following format:
-            It is <CityTime.time_info from lookup_time_function> in
-            <CityTime.city from lookup_time_function> right now.
+            You receive a CityTime with time_info and city fields. Reply with a
+            single sentence stating that it is that time in that city right now.
         """,
     )
 
@@ -367,6 +359,12 @@ accepted and produced by any agent node.
         ],
     )
     ```
+
+    The curly-brace `{key}` placeholders that an `instruction` supports are
+    substituted from *session state*, not from the node input, so a
+    placeholder such as `{CityTime.time_info}` is left in the prompt verbatim.
+    To template a value into an instruction, write it to state first — with
+    `output_key` or `Event(state=...)` — and reference it as `{time_info}`.
 
 === "Go"
 

--- a/docs/graphs/data-handling.md
+++ b/docs/graphs/data-handling.md
@@ -109,8 +109,9 @@ Each step in a workflow produces output for its successor.
     Use the ***return*** syntax when outputting ***Event*** data that does not
     require additional processing. When emitting data that requires additional
     processing, or if you are generating more than one data item, you can use
-    more than one ***yield*** command. Each ***yield*** call adds to a list of
-    data objects on the Event which is passed to the next node of a graph. A
+    more than one ***yield*** command. Each ***yield*** call emits a separate
+    ***Event***, but only one of those events may carry an `output`, and that
+    single value is what the next node of the graph receives. A
     ***return*** or ***yield*** command without a parameter passes a `None` value
     to the next node.
 
@@ -291,7 +292,7 @@ inside tools and callbacks regardless of which agent style you use.
           },
       )
 
-    async def task_attempt_node(node_input: Content, attempts: int):
+    async def task_attempt_node(node_input, attempts: int):
       yield Event(
           state={
               "attempts": attempts + 1,
@@ -299,7 +300,7 @@ inside tools and callbacks regardless of which agent style you use.
       )
 
     async def read_state_node(ctx: Context):
-      print(f"attempts state: {ctx.state}") # attempts state: attempts: 1
+      print(f"attempts state: {ctx.state['attempts']}") # attempts state: 1
 
     root_agent = Workflow(
         name="root_agent",
@@ -439,35 +440,26 @@ accepted and produced by any agent node.
 
 === "Python"
 
-    Use the curly-brace `{ }` syntax to select properties from the input
-    schema, or `< >` to select a property and also qualify it by the name
-    of the source node:
+    Use `input_schema` on an agent to validate the structured output of the
+    preceding node and deliver it as the agent's input. Refer to the fields of
+    that input by name in the instruction:
 
     ```python
     class CityTime(BaseModel):
         time_info: str  # time information
         city: str       # city name
 
-    def lookup_time_function(city: str):
+    def lookup_time_function(node_input: str):
         """Simulate returning the current time in the specified city."""
-        return Event(output=CityTime(time_info='10:10 AM', city=city))
+        return Event(output=CityTime(time_info='10:10 AM', city=node_input))
 
     city_report_agent = Agent(
         name="city_report_agent",
         model="gemini-flash-latest",
         input_schema=CityTime,
-
-        # data selection based on class and parameter
-        # instruction="""
-        #     Return a sentence in the following format:
-        #     It is {CityTime.time_info} in {CityTime.city} right now.
-        # """,
-
-        # more restrictive data selection based on source node name
         instruction="""
-            Return a sentence in the following format:
-            It is <CityTime.time_info from lookup_time_function> in
-            <CityTime.city from lookup_time_function> right now.
+            You receive a CityTime with time_info and city fields. Reply with a
+            single sentence stating that it is that time in that city right now.
         """,
     )
 
@@ -478,6 +470,12 @@ accepted and produced by any agent node.
         ],
     )
     ```
+
+    The curly-brace `{key}` placeholders that an `instruction` supports are
+    substituted from *session state*, not from the node input, so a
+    placeholder such as `{CityTime.time_info}` is left in the prompt verbatim.
+    To template a value into an instruction, write it to state first — with
+    `output_key` or `Event(state=...)` — and reference it as `{time_info}`.
 
 === "TypeScript"
 

--- a/docs/graphs/data-handling.md
+++ b/docs/graphs/data-handling.md
@@ -276,6 +276,8 @@ accepted and produced by any agent node.
     ***BaseModel*** to constrain any agent's input and output:
 
     ```python
+    from datetime import date
+
     from google.adk import Agent
     from pydantic import BaseModel
 
@@ -296,14 +298,14 @@ accepted and produced by any agent node.
         output_schema=FlightSearchOutput,
         tools=[search_flights_api],
         mode="single_turn",
-        ...
+        # ...
     )
 
     assistant = Agent(
         name="assistant",
         instruction="You help users plan trips.",
         sub_agents=[flight_searcher],
-        ...
+        # ...
     )
     ```
 
@@ -355,7 +357,7 @@ accepted and produced by any agent node.
     root_agent = Workflow(
         name="root_agent",
         edges=[
-            (START, city_generator_agent, lookup_time_function, city_report_agent)
+            ("START", city_generator_agent, lookup_time_function, city_report_agent)
         ],
     )
     ```
@@ -372,9 +374,9 @@ accepted and produced by any agent node.
     framework serializes it into `Event.Output`. The successor `AgentNode`
     receives the struct as its user content — the fields are available to the
     agent's `Instruction` without any `{key}` template syntax. This is the
-    direct equivalent of Python's `input_schema=CityTime` with
-    `{CityTime.time_info}` template placeholders: the struct fields are
-    delivered as typed input rather than looked up by name from state.
+    direct equivalent of Python's `input_schema=CityTime`: in both languages
+    the struct fields are delivered as typed input rather than looked up by
+    name from state.
 
     ```go
     --8<-- "examples/go/snippets/graphs/data-handling/main.go:structured-output"

--- a/docs/graphs/data-handling.md
+++ b/docs/graphs/data-handling.md
@@ -476,8 +476,8 @@ accepted and produced by any agent node.
     The curly-brace `{key}` placeholders that an `instruction` supports are
     substituted from *session state*, not from the node input, so a
     placeholder such as `{CityTime.time_info}` is left in the prompt verbatim.
-    To template a value into an instruction, write it to state first — with
-    `output_key` or `Event(state=...)` — and reference it as `{time_info}`.
+    To template a value into an instruction, write it to state first, with
+    `output_key` or `Event(state=...)`, and reference it as `{time_info}`.
 
 === "TypeScript"
 

--- a/docs/graphs/dynamic.md
+++ b/docs/graphs/dynamic.md
@@ -114,7 +114,7 @@ run within a workflow.
 
     # FunctionNode wrapper with options
     success_node = FunctionNode(
-        my_function_node,
+        func=my_function_node,
         name="hello",
         rerun_on_resume=True,
     )
@@ -245,9 +245,9 @@ manually read and write session state keys for data transfer.
         city: str       # city name
 
     @node
-    def city_time_function(city: str):
+    def city_time_function(node_input: str):
         """Simulate returning the current time in a specified city."""
-        return CityTime(time_info="10:10 AM", city=city)
+        return CityTime(time_info="10:10 AM", city=node_input)
 
     city_report_agent = Agent(
         name="city_report_agent",
@@ -256,7 +256,7 @@ manually read and write session state keys for data transfer.
         instruction="""output the data provided by the previous node.""",
     )
 
-    @node # workflow node
+    @node(rerun_on_resume=True) # workflow node
     async def city_workflow(ctx: Context):
         city_time = await ctx.run_node(city_time_function, "Paris")
         report_text = await ctx.run_node(city_report_agent, city_time)
@@ -296,7 +296,7 @@ as you can with graph-based workflows.
     function node, and a second agent:
 
     ```python
-    @node # workflow node
+    @node(rerun_on_resume=True) # workflow node
     async def city_workflow(ctx: Context):
         city = await ctx.run_node(city_generator_agent)
         city_time = await ctx.run_node(city_time_function, city)
@@ -352,7 +352,7 @@ workflows offer much more flexibility to define the routing logic you need.
         output_schema=str,
     )
 
-    @node # workflow node
+    @node(rerun_on_resume=True) # workflow node
     async def code_workflow(ctx: Context, user_request: str):
       code = await ctx.run_node(coder_agent, user_request)
       check_resp = await ctx.run_node(compile_lint_check, code)
@@ -363,7 +363,9 @@ workflows offer much more flexibility to define the routing logic you need.
 
         check_resp = await ctx.run_node(compile_lint_check, code)
 
-      return code
+      # A node that yields is an async generator, so emit the final output
+      # as an event instead of returning it.
+      yield Event(output=code)
     ```
 
 === "Go"
@@ -388,18 +390,23 @@ Dynamic workflows in ADK can support parallel execution.
     import asyncio
     from typing import Any
     from google.adk import Context
-    from google.adk.workflow import BaseNode, node
+    from google.adk.workflow import node
+
+
+    @node
+    def worker_node(node_input: Any):
+        """Processes a single item."""
+        return f"done {node_input}"
 
 
     @node(rerun_on_resume=True)
-    async def parallel_supervisor(
-        ctx: Context, node_input: list[Any], real_node: BaseNode
-    ):
-        """Runs a worker node in parallel for each item in the input list."""
+    async def parallel_supervisor(ctx: Context, node_input: list[Any]):
+        """Runs worker_node in parallel for each item in the input list."""
         tasks = []
         for item in node_input:
-            # ctx.run_node returns a future. Append instead of awaiting immediately.
-            tasks.append(ctx.run_node(real_node, item))
+            # ctx.run_node returns a coroutine. Append instead of awaiting
+            # immediately, and use a sub-branch to isolate each run's events.
+            tasks.append(ctx.run_node(worker_node, item, use_sub_branch=True))
 
         # Collect all results in parallel
         results = await asyncio.gather(*tasks)

--- a/docs/graphs/dynamic.md
+++ b/docs/graphs/dynamic.md
@@ -108,15 +108,16 @@ run within a workflow.
     ***@node*** annotation:
 
     ```python
+    from google.adk.workflow import FunctionNode
+
     # base function
-    def my_function_node(node_input: Any):
+    def hello_world(node_input: Any):
         return "Hello World"
 
     # FunctionNode wrapper with options
-    success_node = FunctionNode(
-        func=my_function_node,
-        name="hello",
-        rerun_on_resume=True,
+    my_function_node = FunctionNode(
+        func=hello_world,
+        name="hello_node",
     )
     ```
 
@@ -210,9 +211,9 @@ execution logic (order and paths) for those nodes.
 ## Data handling
 
 When using dynamic workflows with ADK, passing data is simpler than
-[graph-based workflows](/graphs/) because `workflow.RunNode` returns the
-child node's output directly as a typed Go value — eliminating the need to
-manually read and write session state keys for data transfer.
+[graph-based workflows](/graphs/) because running a child node returns that
+node's output directly to the caller — eliminating the need to manually read
+and write session state keys for data transfer.
 
 === "Python"
 
@@ -528,9 +529,22 @@ and logically remain the same for the input.
     from typing import Any
     import asyncio
 
+    class Product(BaseModel):
+      sku: str
+      quantity: int
+
     class Order(BaseModel):
       order_id: str
       cart_items: list[Product]
+
+    async def get_orders() -> list[Order]:
+      """Fetch the orders to process from your own data source."""
+      ...
+
+    @node
+    async def process_order(node_input: Order):
+      """Processes a single order."""
+      return f"processed {node_input.order_id}"
 
     @node(rerun_on_resume=True)
     async def process_all_orders(ctx: Context, node_input: Any):

--- a/docs/graphs/dynamic.md
+++ b/docs/graphs/dynamic.md
@@ -128,15 +128,16 @@ run within a workflow.
     ***@node*** annotation:
 
     ```python
+    from google.adk.workflow import FunctionNode
+
     # base function
-    def my_function_node(node_input: Any):
+    def hello_world(node_input: Any):
         return "Hello World"
 
     # FunctionNode wrapper with options
-    success_node = FunctionNode(
-        func=my_function_node,
-        name="hello",
-        rerun_on_resume=True,
+    my_function_node = FunctionNode(
+        func=hello_world,
+        name="hello_node",
     )
     ```
 
@@ -265,9 +266,9 @@ execution logic (order and paths) for those nodes.
 ## Data handling
 
 When using dynamic workflows with ADK, passing data is simpler than
-[graph-based workflows](/graphs/) because `workflow.RunNode` returns the
-child node's output directly as a typed Go value — eliminating the need to
-manually read and write session state keys for data transfer.
+[graph-based workflows](/graphs/) because running a child node returns that
+node's output directly to the caller — eliminating the need to manually read
+and write session state keys for data transfer.
 
 === "Python"
 
@@ -658,9 +659,22 @@ and logically remain the same for the input.
     from typing import Any
     import asyncio
 
+    class Product(BaseModel):
+      sku: str
+      quantity: int
+
     class Order(BaseModel):
       order_id: str
       cart_items: list[Product]
+
+    async def get_orders() -> list[Order]:
+      """Fetch the orders to process from your own data source."""
+      ...
+
+    @node
+    async def process_order(node_input: Order):
+      """Processes a single order."""
+      return f"processed {node_input.order_id}"
 
     @node(rerun_on_resume=True)
     async def process_all_orders(ctx: Context, node_input: Any):

--- a/docs/graphs/dynamic.md
+++ b/docs/graphs/dynamic.md
@@ -134,7 +134,7 @@ run within a workflow.
 
     # FunctionNode wrapper with options
     success_node = FunctionNode(
-        my_function_node,
+        func=my_function_node,
         name="hello",
         rerun_on_resume=True,
     )
@@ -300,9 +300,9 @@ manually read and write session state keys for data transfer.
         city: str       # city name
 
     @node
-    def city_time_function(city: str):
+    def city_time_function(node_input: str):
         """Simulate returning the current time in a specified city."""
-        return CityTime(time_info="10:10 AM", city=city)
+        return CityTime(time_info="10:10 AM", city=node_input)
 
     city_report_agent = Agent(
         name="city_report_agent",
@@ -311,7 +311,7 @@ manually read and write session state keys for data transfer.
         instruction="""output the data provided by the previous node.""",
     )
 
-    @node # workflow node
+    @node(rerun_on_resume=True) # workflow node
     async def city_workflow(ctx: Context):
         city_time = await ctx.run_node(city_time_function, "Paris")
         report_text = await ctx.run_node(city_report_agent, city_time)
@@ -365,7 +365,7 @@ as you can with graph-based workflows.
     function node, and a second agent:
 
     ```python
-    @node # workflow node
+    @node(rerun_on_resume=True) # workflow node
     async def city_workflow(ctx: Context):
         city = await ctx.run_node(city_generator_agent)
         city_time = await ctx.run_node(city_time_function, city)
@@ -430,7 +430,7 @@ workflows offer much more flexibility to define the routing logic you need.
         output_schema=str,
     )
 
-    @node # workflow node
+    @node(rerun_on_resume=True) # workflow node
     async def code_workflow(ctx: Context, user_request: str):
       code = await ctx.run_node(coder_agent, user_request)
       check_resp = await ctx.run_node(compile_lint_check, code)
@@ -441,7 +441,9 @@ workflows offer much more flexibility to define the routing logic you need.
 
         check_resp = await ctx.run_node(compile_lint_check, code)
 
-      return code
+      # A node that yields is an async generator, so emit the final output
+      # as an event instead of returning it.
+      yield Event(output=code)
     ```
 
 === "TypeScript"
@@ -478,18 +480,23 @@ Dynamic workflows in ADK can support parallel execution.
     import asyncio
     from typing import Any
     from google.adk import Context
-    from google.adk.workflow import BaseNode, node
+    from google.adk.workflow import node
+
+
+    @node
+    def worker_node(node_input: Any):
+        """Processes a single item."""
+        return f"done {node_input}"
 
 
     @node(rerun_on_resume=True)
-    async def parallel_supervisor(
-        ctx: Context, node_input: list[Any], real_node: BaseNode
-    ):
-        """Runs a worker node in parallel for each item in the input list."""
+    async def parallel_supervisor(ctx: Context, node_input: list[Any]):
+        """Runs worker_node in parallel for each item in the input list."""
         tasks = []
         for item in node_input:
-            # ctx.run_node returns a future. Append instead of awaiting immediately.
-            tasks.append(ctx.run_node(real_node, item))
+            # ctx.run_node returns a coroutine. Append instead of awaiting
+            # immediately, and use a sub-branch to isolate each run's events.
+            tasks.append(ctx.run_node(worker_node, item, use_sub_branch=True))
 
         # Collect all results in parallel
         results = await asyncio.gather(*tasks)

--- a/docs/graphs/human-input.md
+++ b/docs/graphs/human-input.md
@@ -221,8 +221,10 @@ specific tool call.
     Wrap the tool with ***FunctionTool*** and set `require_confirmation=True`
     for a static yes/no approval before the tool runs, or call
     `tool_context.request_confirmation()` from inside the tool for a custom
-    hint message. Guard that call with `tool_context.tool_confirmation` so the
-    tool asks once and proceeds after the user approves:
+    hint message. ADK only rejects the call for you on the
+    `require_confirmation=True` path, so a tool that asks for its own
+    confirmation must check both: `tool_context.tool_confirmation` to ask
+    once, then `tool_confirmation.confirmed` to handle a rejection:
 
     ```python
     from google.adk.agents import Agent
@@ -239,6 +241,8 @@ specific tool call.
                hint=f"Approve a refund of {amount}?"
            )
            return "Waiting for approval."
+       elif not tool_context.tool_confirmation.confirmed:
+           return "Refund rejected by user."
        ...
 
     root_agent = Agent(

--- a/docs/graphs/human-input.md
+++ b/docs/graphs/human-input.md
@@ -173,8 +173,10 @@ specific tool call.
     Wrap the tool with ***FunctionTool*** and set `require_confirmation=True`
     for a static yes/no approval before the tool runs, or call
     `tool_context.request_confirmation()` from inside the tool for a custom
-    hint message. Guard that call with `tool_context.tool_confirmation` so the
-    tool asks once and proceeds after the user approves:
+    hint message. ADK only rejects the call for you on the
+    `require_confirmation=True` path, so a tool that asks for its own
+    confirmation must check both: `tool_context.tool_confirmation` to ask
+    once, then `tool_confirmation.confirmed` to handle a rejection:
 
     ```python
     from google.adk.agents import Agent
@@ -191,6 +193,8 @@ specific tool call.
                hint=f"Approve a refund of {amount}?"
            )
            return "Waiting for approval."
+       elif not tool_context.tool_confirmation.confirmed:
+           return "Refund rejected by user."
        ...
 
     root_agent = Agent(

--- a/docs/graphs/human-input.md
+++ b/docs/graphs/human-input.md
@@ -218,24 +218,34 @@ specific tool call.
 
 === "Python"
 
-    The following code sample shows how to construct a ***RequestInput*** object
-    in a workflow node, including a ***response schema***:
+    Wrap the tool with ***FunctionTool*** and set `require_confirmation=True`
+    for a static yes/no approval before the tool runs, or call
+    `tool_context.request_confirmation()` from inside the tool for a custom
+    hint message. Guard that call with `tool_context.tool_confirmation` so the
+    tool asks once and proceeds after the user approves:
 
     ```python
-    async def initial_prompt(ctx: Context):
-       """Ask the user for itinerary information"""
-       input_message = """
-           This is an interactive concierge workflow tasked with making you a great
-           itinerary for you in your city of choice. If you give some details about
-           yourself or what you are generally looking for I can better personalize
-           your itinerary.
-           For example, input your:
-               City (Required),
-               Age,
-               Hobby,
-               Example of attraction you liked
-       """
-       yield RequestInput(message=input_message, response_schema=str)
+    from google.adk.agents import Agent
+    from google.adk.tools import FunctionTool, ToolContext
+
+    def book_flight(flight_id: str) -> str:
+       """Books the selected flight."""
+       ...
+
+    def refund(amount: float, tool_context: ToolContext) -> str:
+       """Refunds an order."""
+       if not tool_context.tool_confirmation:
+           tool_context.request_confirmation(
+               hint=f"Approve a refund of {amount}?"
+           )
+           return "Waiting for approval."
+       ...
+
+    root_agent = Agent(
+       name="concierge",
+       model="gemini-flash-latest",
+       tools=[FunctionTool(book_flight, require_confirmation=True), refund],
+    )
     ```
 
 === "TypeScript"
@@ -265,3 +275,7 @@ specific tool call.
     ```go
     --8<-- "examples/go/snippets/graphs/human-input/main.go:hitl-with-hint"
     ```
+
+For the full tool-confirmation workflow, including dynamic confirmation and how
+the client replies, see
+[Get action confirmation for ADK Tools](/tools-custom/confirmation/).

--- a/docs/graphs/human-input.md
+++ b/docs/graphs/human-input.md
@@ -170,24 +170,34 @@ specific tool call.
 
 === "Python"
 
-    The following code sample shows how to construct a ***RequestInput*** object
-    in a workflow node, including a ***response schema***:
+    Wrap the tool with ***FunctionTool*** and set `require_confirmation=True`
+    for a static yes/no approval before the tool runs, or call
+    `tool_context.request_confirmation()` from inside the tool for a custom
+    hint message. Guard that call with `tool_context.tool_confirmation` so the
+    tool asks once and proceeds after the user approves:
 
     ```python
-    async def initial_prompt(ctx: Context):
-       """Ask the user for itinerary information"""
-       input_message = """
-           This is an interactive concierge workflow tasked with making you a great
-           itinerary for you in your city of choice. If you give some details about
-           yourself or what you are generally looking for I can better personalize
-           your itinerary.
-           For example, input your:
-               City (Required),
-               Age,
-               Hobby,
-               Example of attraction you liked
-       """
-       yield RequestInput(message=input_message, response_schema=str)
+    from google.adk.agents import Agent
+    from google.adk.tools import FunctionTool, ToolContext
+
+    def book_flight(flight_id: str) -> str:
+       """Books the selected flight."""
+       ...
+
+    def refund(amount: float, tool_context: ToolContext) -> str:
+       """Refunds an order."""
+       if not tool_context.tool_confirmation:
+           tool_context.request_confirmation(
+               hint=f"Approve a refund of {amount}?"
+           )
+           return "Waiting for approval."
+       ...
+
+    root_agent = Agent(
+       name="concierge",
+       model="gemini-flash-latest",
+       tools=[FunctionTool(book_flight, require_confirmation=True), refund],
+    )
     ```
 
 === "Go"
@@ -205,3 +215,7 @@ specific tool call.
     ```go
     --8<-- "examples/go/snippets/graphs/human-input/main.go:hitl-with-hint"
     ```
+
+For the full tool-confirmation workflow, including dynamic confirmation and how
+the client replies, see
+[Get action confirmation for ADK Tools](/tools-custom/confirmation/).

--- a/docs/graphs/index.md
+++ b/docs/graphs/index.md
@@ -82,8 +82,9 @@ function, and the final agent reports the information.
         name="city_report_agent",
         model="gemini-flash-latest",
         input_schema=CityTime,
-        instruction="""Output following line:
-        It is {CityTime.time_info} in {CityTime.city} right now.""",
+        instruction="""You receive a CityTime with time_info and city fields.
+        Output a single line stating that it is that time in that city right
+        now.""",
         output_schema=str,
     )
 
@@ -219,8 +220,9 @@ are *not compatible* with the following ADK features:
 
 -   **Live streaming:** An ***LlmAgent*** node in `single_turn` mode — the
     default for a graph node — always runs in non-live mode and ignores the
-    live request queue, even inside a live session. Use `task` or `chat` mode
-    for nodes that must stream.
+    live request queue, even inside a live session. Use `task` mode for nodes
+    that must stream, or `chat` mode, which is only allowed directly after
+    `START`.
 -   **Integrations:** Some third-party
     [integrations](/integrations/) may not be compatible with graph-based
     workflows.

--- a/docs/graphs/index.md
+++ b/docs/graphs/index.md
@@ -218,8 +218,8 @@ For information about building advanced pipelines, see
 There are some known limitations with graph-based workflows. They
 are *not compatible* with the following ADK features:
 
--   **Live streaming:** An ***LlmAgent*** node in `single_turn` mode — the
-    default for a graph node — always runs in non-live mode and ignores the
+-   **Live streaming:** An ***LlmAgent*** node in `single_turn` mode, the
+    default for a graph node, always runs in non-live mode and ignores the
     live request queue, even inside a live session. Use `task` mode for nodes
     that must stream, or `chat` mode, which is only allowed directly after
     `START`.

--- a/docs/graphs/index.md
+++ b/docs/graphs/index.md
@@ -82,8 +82,9 @@ function, and the final agent reports the information.
         name="city_report_agent",
         model="gemini-flash-latest",
         input_schema=CityTime,
-        instruction="""Output following line:
-        It is {CityTime.time_info} in {CityTime.city} right now.""",
+        instruction="""You receive a CityTime with time_info and city fields.
+        Output a single line stating that it is that time in that city right
+        now.""",
         output_schema=str,
     )
 

--- a/docs/graphs/index.md
+++ b/docs/graphs/index.md
@@ -217,7 +217,10 @@ For information about building advanced pipelines, see
 There are some known limitations with graph-based workflows. They
 are *not compatible* with the following ADK features:
 
--   **Live streaming:** Not supported in graph-based workflows.
+-   **Live streaming:** An ***LlmAgent*** node in `single_turn` mode — the
+    default for a graph node — always runs in non-live mode and ignores the
+    live request queue, even inside a live session. Use `task` or `chat` mode
+    for nodes that must stream.
 -   **Integrations:** Some third-party
     [integrations](/integrations/) may not be compatible with graph-based
     workflows.

--- a/docs/graphs/routes.md
+++ b/docs/graphs/routes.md
@@ -438,8 +438,8 @@ accomplish this goal.
     emits it as the output of the nested workflow.
 
     A workflow must have at most *one* terminal node that produces output. If
-    two or more terminal nodes produce output — for example the ends of two
-    parallel branches — the workflow fails with a `ValueError`. Merge those
+    two or more terminal nodes produce output, for example the ends of two
+    parallel branches, the workflow fails with a `ValueError`. Merge those
     branches with a ***JoinNode*** so the graph ends in a single terminal
     output.
 
@@ -522,8 +522,8 @@ lifecycle on each iteration.
     )
     ```
 
-    A cycle must contain at least one routed (conditional) edge; a cycle made
-    only of unconditional edges is rejected when the `Workflow` is built.
+    A cycle must contain at least one routed, or conditional, edge. A cycle
+    made only of unconditional edges is rejected when the `Workflow` is built.
 
 === "TypeScript"
 

--- a/docs/graphs/routes.md
+++ b/docs/graphs/routes.md
@@ -146,9 +146,10 @@ overview of the common routing patterns.
 
 !!! caution "Caution: Workflow agent limitations"
 
-    You can add ***LlmAgents*** to graph-based workflows. However, they must
-    be configured for single-turn or task mode. For more information about
-    agent modes, see
+    You can add ***LlmAgents*** to graph-based workflows. An agent used as a
+    graph node defaults to `single_turn` mode; a `chat` mode agent is only
+    allowed directly after `START`, because it consumes conversational history
+    rather than a node input. For more information about agent modes, see
     [Build collaborative agent teams](/workflows/collaboration/#mode-configuration-and-behaviors).
 
 ### Route sequences
@@ -433,8 +434,14 @@ accomplish this goal.
     transmits data to the next node in the nested workflow's graph *and* the
     system bubbles up the Event for that node to the parent workflow for
     process traceability. When the nested workflow completes the last node in
-    its process, the parent node extracts data from the final leaf nodes and
+    its process, the parent node extracts data from the final leaf node and
     emits it as the output of the nested workflow.
+
+    A workflow must have at most *one* terminal node that produces output. If
+    two or more terminal nodes produce output — for example the ends of two
+    parallel branches — the workflow fails with a `ValueError`. Merge those
+    branches with a ***JoinNode*** so the graph ends in a single terminal
+    output.
 
 === "TypeScript"
 
@@ -495,24 +502,28 @@ lifecycle on each iteration.
 
 
     def router(node_input: str):
-        """Route to task B or C based on node_input."""
+        """Exit the loop when the task is done, otherwise iterate again."""
         if condition(node_input):
-            return Event(route="RUN_TASK_C")
-        return Event(route="RUN_TASK_B")
+            return Event(route="DONE")
+        return Event(route="RETRY")
 
     root_agent = Workflow(
-        name="routing_workflow",
+        name="looping_workflow",
         edges=[
             ("START", task_A_node, router),
             (router,
               {
-                "RUN_TASK_B": task_B_node,
-                "RUN_TASK_C": task_C_node,
+                # Back-edge: re-runs task_A_node for another iteration.
+                "RETRY": task_A_node,
+                "DONE": final_task_node,
               },
             ),
         ],
     )
     ```
+
+    A cycle must contain at least one routed (conditional) edge; a cycle made
+    only of unconditional edges is rejected when the `Workflow` is built.
 
 === "TypeScript"
 

--- a/docs/graphs/routes.md
+++ b/docs/graphs/routes.md
@@ -114,9 +114,10 @@ overview of the common routing patterns.
 
 !!! caution "Caution: Workflow agent limitations"
 
-    You can add ***LlmAgents*** to graph-based workflows. However, they must
-    be configured for single-turn or task mode. For more information about
-    agent modes, see
+    You can add ***LlmAgents*** to graph-based workflows. An agent used as a
+    graph node defaults to `single_turn` mode; a `chat` mode agent is only
+    allowed directly after `START`, because it consumes conversational history
+    rather than a node input. For more information about agent modes, see
     [Build collaborative agent teams](/workflows/collaboration/#mode-configuration-and-behaviors).
 
 ### Route sequences
@@ -283,11 +284,12 @@ before passing results to the next step.
 
     !!! warning "Caution: Stuck JoinNode from incomplete nodes"
 
-        The ***JoinNode*** object proceeds only after all its upstream nodes
-        have provided an Event output. If one of the upstream nodes fails to
-        provide output, the JoinNode is stuck and workflow execution stops.
-        Make sure to include failsafe output from any node that outputs to a
-        ***JoinNode***.
+        The ***JoinNode*** object proceeds only after every one of its upstream
+        nodes has *completed*. Completing without output is fine: that node's
+        key in the aggregated dictionary is `None`. A node that never runs, such
+        as one on a conditional branch that was not taken, never triggers the
+        join and stalls that path of the workflow. Make sure every static
+        predecessor of a ***JoinNode*** is always reached.
 
 === "Go"
 
@@ -367,8 +369,14 @@ accomplish this goal.
     transmits data to the next node in the nested workflow's graph *and* the
     system bubbles up the Event for that node to the parent workflow for
     process traceability. When the nested workflow completes the last node in
-    its process, the parent node extracts data from the final leaf nodes and
+    its process, the parent node extracts data from the final leaf node and
     emits it as the output of the nested workflow.
+
+    A workflow must have at most *one* terminal node that produces output. If
+    two or more terminal nodes produce output — for example the ends of two
+    parallel branches — the workflow fails with a `ValueError`. Merge those
+    branches with a ***JoinNode*** so the graph ends in a single terminal
+    output.
 
 === "Go"
 
@@ -415,24 +423,28 @@ lifecycle on each iteration.
 
 
     def router(node_input: str):
-        """Route to task B or C based on node_input."""
+        """Exit the loop when the task is done, otherwise iterate again."""
         if condition(node_input):
-            return Event(route="RUN_TASK_C")
-        return Event(route="RUN_TASK_B")
+            return Event(route="DONE")
+        return Event(route="RETRY")
 
     root_agent = Workflow(
-        name="routing_workflow",
+        name="looping_workflow",
         edges=[
             ("START", task_A_node, router),
             (router,
               {
-                "RUN_TASK_B": task_B_node,
-                "RUN_TASK_C": task_C_node,
+                # Back-edge: re-runs task_A_node for another iteration.
+                "RETRY": task_A_node,
+                "DONE": final_task_node,
               },
             ),
         ],
     )
     ```
+
+    A cycle must contain at least one routed (conditional) edge; a cycle made
+    only of unconditional edges is rejected when the `Workflow` is built.
 
 === "Go"
 

--- a/docs/graphs/routes.md
+++ b/docs/graphs/routes.md
@@ -373,8 +373,8 @@ accomplish this goal.
     emits it as the output of the nested workflow.
 
     A workflow must have at most *one* terminal node that produces output. If
-    two or more terminal nodes produce output — for example the ends of two
-    parallel branches — the workflow fails with a `ValueError`. Merge those
+    two or more terminal nodes produce output, for example the ends of two
+    parallel branches, the workflow fails with a `ValueError`. Merge those
     branches with a ***JoinNode*** so the graph ends in a single terminal
     output.
 
@@ -443,8 +443,8 @@ lifecycle on each iteration.
     )
     ```
 
-    A cycle must contain at least one routed (conditional) edge; a cycle made
-    only of unconditional edges is rejected when the `Workflow` is built.
+    A cycle must contain at least one routed, or conditional, edge. A cycle
+    made only of unconditional edges is rejected when the `Workflow` is built.
 
 === "Go"
 

--- a/docs/workflows/patterns.md
+++ b/docs/workflows/patterns.md
@@ -13,9 +13,9 @@ your project requirements before committing to a full implementation.
 
     In Python, `SequentialAgent`, `ParallelAgent`, and `LoopAgent` are
     deprecated: constructing one emits a `DeprecationWarning`, and the classes
-    will be removed in a future release. The Python examples below still run.
-    For new code, express these patterns with a
-    [graph-based workflow](/graphs/), which cannot yet be used as an `LlmAgent`
+    are scheduled for removal in a future release. The Python examples below
+    still run. For new code, express these patterns with a
+    [graph-based workflow](/graphs/), which cannot be used as an `LlmAgent`
     sub-agent.
 
 ## Coordinator and dispatcher
@@ -42,7 +42,7 @@ your project requirements before committing to a full implementation.
         model="gemini-flash-latest",
         instruction="Route user requests: Use Billing agent for payment issues, Support agent for technical problems.",
         description="Main help desk router.",
-        # Setting sub_agents selects AutoFlow, which adds transfer_to_agent
+        # allow_transfer=True is often implicit with sub_agents in AutoFlow
         sub_agents=[billing_agent, support_agent]
     )
     # User asks "My payment failed" -> Coordinator's LLM should call transfer_to_agent(agent_name='Billing')
@@ -802,7 +802,7 @@ your project requirements before committing to a full implementation.
     * **Interaction:** Can be implemented using a custom **Tool** that pauses execution and sends a request to an external system (e.g., a UI, ticketing system) waiting for human input. The tool then returns the human's response to the agent.
     * **Workflow:** Could use **LLM-Driven Delegation** (`transfer_to_agent`) targeting a conceptual "Human Agent" that triggers the external workflow, or use the custom tool within an `LlmAgent`.
     * **State/Callbacks:** State can hold task details for the human; callbacks can manage the interaction flow.
-    * **Note:** ADK has no "Human Agent" agent type, but in Python you do not have to build the pause yourself: yield a `RequestInput` event from a [graph workflow node](/graphs/human-input/), or set `require_confirmation=True` on a `FunctionTool` (or call `tool_context.request_confirmation()` inside the tool) for a yes/no approval.
+    * **Note:** ADK has no "Human Agent" agent type, but in Python you do not have to build the pause yourself: yield a `RequestInput` event from a [graph workflow node](/graphs/human-input/), or set `require_confirmation=True` on a `FunctionTool` for a yes/no approval. To supply a custom hint, call `tool_context.request_confirmation()` inside the tool.
 
 === "Python"
 

--- a/docs/workflows/patterns.md
+++ b/docs/workflows/patterns.md
@@ -9,6 +9,15 @@ Agent Development Kit (ADK), including code examples. These patterns are useful
 across a broad set of applications and you should evaluate and test them against
 your project requirements before committing to a full implementation.
 
+!!! note "Python: template workflow agents are deprecated"
+
+    In Python, `SequentialAgent`, `ParallelAgent`, and `LoopAgent` are
+    deprecated: constructing one emits a `DeprecationWarning`, and the classes
+    will be removed in a future release. The Python examples below still run.
+    For new code, express these patterns with a
+    [graph-based workflow](/graphs/), which cannot yet be used as an `LlmAgent`
+    sub-agent.
+
 ## Coordinator and dispatcher
 
 * **Structure:** A central [`LlmAgent`](/agents/llm-agents/) (Coordinator) manages several specialized `sub_agents`.

--- a/docs/workflows/patterns.md
+++ b/docs/workflows/patterns.md
@@ -42,7 +42,7 @@ your project requirements before committing to a full implementation.
         model="gemini-flash-latest",
         instruction="Route user requests: Use Billing agent for payment issues, Support agent for technical problems.",
         description="Main help desk router.",
-        # allow_transfer=True is often implicit with sub_agents in AutoFlow
+        # Setting sub_agents selects AutoFlow, which adds transfer_to_agent
         sub_agents=[billing_agent, support_agent]
     )
     # User asks "My payment failed" -> Coordinator's LLM should call transfer_to_agent(agent_name='Billing')
@@ -802,7 +802,7 @@ your project requirements before committing to a full implementation.
     * **Interaction:** Can be implemented using a custom **Tool** that pauses execution and sends a request to an external system (e.g., a UI, ticketing system) waiting for human input. The tool then returns the human's response to the agent.
     * **Workflow:** Could use **LLM-Driven Delegation** (`transfer_to_agent`) targeting a conceptual "Human Agent" that triggers the external workflow, or use the custom tool within an `LlmAgent`.
     * **State/Callbacks:** State can hold task details for the human; callbacks can manage the interaction flow.
-    * **Note:** ADK doesn't have a built-in "Human Agent" type, so this requires custom integration.
+    * **Note:** ADK has no "Human Agent" agent type, but in Python you do not have to build the pause yourself: yield a `RequestInput` event from a [graph workflow node](/graphs/human-input/), or set `require_confirmation=True` on a `FunctionTool` (or call `tool_context.request_confirmation()` inside the tool) for a yes/no approval.
 
 === "Python"
 


### PR DESCRIPTION
Corrections to the `docs/graphs/` pages (plus one note on `docs/workflows/patterns.md`) where Python samples could not run as written and documented behavior did not match v2.5.0.

## Changes
- **`docs/graphs/dynamic.md`** — a node that `yield`s is an async generator, so the sample's bare `return code` emitted nothing; it now yields `Event(output=code)`. Also `FunctionNode(func=...)` as a keyword, `@node(rerun_on_resume=True)` on workflow nodes, and the parallel sample no longer takes a `real_node` argument no caller could supply — it defines the worker node and passes `use_sub_branch=True`.
- **`docs/graphs/index.md`** — live streaming was listed as flatly unsupported. It is the default `single_turn` node mode that ignores the live request queue; nodes in `task` or `chat` mode can stream.
- **`docs/graphs/data-handling.md`** — dropped the `{CityTime.time_info}` / `<field from node>` data-selection syntax, which does not exist; `instruction` placeholders are substituted from session state, so an unmatched one is left in the prompt verbatim. Also corrected the multi-`yield` description (each `yield` emits a separate Event and only one may carry `output`) and the state-print / node-input parameter names.
- **`docs/graphs/routes.md`** — `JoinNode` waits on upstream *completion*, not output (completing with no output gives `None`; a node that never runs stalls the join). A workflow may have at most one output-producing terminal node, else `ValueError`. `chat` mode agents are only allowed directly after `START`, and a cycle needs at least one routed edge; the loop sample now actually loops.
- **`docs/graphs/human-input.md`** — replaced the `RequestInput` sample with the tool-confirmation API (`FunctionTool(..., require_confirmation=True)` and `tool_context.request_confirmation()`), and linked the full confirmation page.
- **`docs/workflows/patterns.md`** — added a note that `SequentialAgent`, `ParallelAgent` and `LoopAgent` are deprecated in Python and emit a `DeprecationWarning`.

## How this was produced

Part of a page-by-page audit of the Python docs against the `google/adk-python` v2.5.0 source: every import resolved against a real 2.5.0 install, every constructor kwarg checked against `model_fields` / `inspect.signature`, every documented default read off the field. A second independent pass re-derived each claim from source rather than trusting the finding, and a third conformed the new wording to the surrounding pages. `mkdocs build --strict` is clean.

Only Python tabs and language-neutral prose were touched — this audit had no ground truth for the Go / Java / TypeScript SDKs.

Split out of a larger audit branch so each area can be reviewed on its own.
