### PR TITLE
docs(session): refactor the session docs for better usability

### DIFF
--- a/docs/context/index.md
+++ b/docs/context/index.md
@@ -1,4 +1,4 @@
-# Context
+# Agent context
 
 <div class="language-support-tag">
   <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span>
@@ -115,11 +115,11 @@ If you use these specific context types, ADK ensures that your agent has access 
 Here are the primary context flavors you will encounter:
 
 - **`InvocationContext`**: Used during core agent runs (`_run_async_impl`, `_run_live_impl`) to provide a comprehensive view of the entire invocation, including service references and lifecycle management.
-  
+
 - **`ReadonlyContext`**: A lightweight, restricted view of fundamental contextual details used in scenarios where mutation is disallowed, such as within instruction providers.
-  
+
 - **`Context`**: Used in agent lifecycle and model callbacks. It provides a robust set of features for reading/writing session state, managing artifacts, and injecting data into the memory service.
-  
+
 - **`ToolContext`**: Tailored for tool execution and tool-related callbacks. In addition to the capabilities of Context, it includes specialized methods for authentication flows, memory searching, and artifact discovery.
 
 !!! note
@@ -149,7 +149,7 @@ Here are the primary context flavors you will encounter:
                 # ... agent logic using ctx ...
                 yield # ... event ...
         ```
-        
+
     === "TypeScript"
 
         ```typescript
@@ -538,7 +538,7 @@ You'll frequently need to read information stored within the context.
         public void myTool(ToolContext toolContext) {
             String userPref = (String) toolContext.state().getOrDefault("user_display_preference", "default_mode");
             String apiEndpoint = (String) toolContext.state().get("app:api_endpoint"); // Read app-level state
-            
+
             if ("dark_mode".equals(userPref)) {
                 // ... apply dark mode logic ...
             }
@@ -551,7 +551,7 @@ You'll frequently need to read information stored within the context.
 
         public void myCallback(CallbackContext callbackContext) {
             String lastToolResult = (String) callbackContext.state().get("temp:last_api_result"); // Read temporary state
-            
+
             if (lastToolResult != null && !lastToolResult.isEmpty()) {
                 System.out.println("Found temporary result from last tool: " + lastToolResult);
             }
@@ -1288,8 +1288,8 @@ Securely manage API keys or other credentials needed by tools.
     import com.google.adk.tools.ToolContext;
     import java.util.Map;
 
-    // Note: AuthConfig, requestCredential, and getAuthResponse are not yet 
-    // fully implemented in the Java ADK public API. 
+    // Note: AuthConfig, requestCredential, and getAuthResponse are not yet
+    // fully implemented in the Java ADK public API.
     // This example relies on external auth population into the session state.
 
     public class SecureApiTool {
@@ -1513,13 +1513,13 @@ While most interactions happen via `CallbackContext` or `ToolContext`, sometimes
         if (criticalError != null && criticalError) {
           System.out.println("Critical error detected, ending invocation.");
           ctx.setEndInvocation(true); // Signal framework to stop processing
-          
+
           Event errorEvent = Event.builder()
               .author(name())
               .invocationId(ctx.invocationId())
               .content(Content.builder().parts(List.of(Part.builder().text("Stopping due to critical error.").build())).build())
               .build();
-              
+
           return Flowable.just(errorEvent); // Stop this agent's execution
         }
 

--- a/docs/sessions/session/index.md
+++ b/docs/sessions/session/index.md
@@ -9,7 +9,7 @@ agent. Just like you wouldn't start every text message from scratch, agents need
 context regarding the ongoing interaction. The `Session` object in ADK is
 designed specifically to track and manage these individual conversation threads.
 
-## The `Session` object
+## `Session` objects
 
 When a user starts interacting with your agent, the `SessionService` creates a
 `Session` object (`google.adk.sessions.Session`). This object acts as the
@@ -36,6 +36,9 @@ are its key properties:
   an event occurred in this conversation thread.
 
 ### Example: Examining session properties
+
+The following code example demonstrates how to list various values stored in a
+session object:
 
 === "Python"
 
@@ -165,6 +168,41 @@ are its key properties:
 
 *(**Note:** The state shown above is only the initial state. State updates
 happen via events, as discussed in the State section.)*
+
+## Session lifecycle
+
+<img src="../../assets/event-loop.png" alt="Session lifecycle">
+
+Here’s a simplified flow of how `Session` and `SessionService` work together
+during a conversation turn:
+
+1. **Start or Resume:** Your application needs to use the `SessionService` to
+   either `create_session` (for a new chat) or use an existing session id.
+2. **Context Provided:** The `Runner` gets the appropriate `Session` object from
+   the appropriate service method, providing the agent with access to the
+   corresponding Session's `state` and `events`.
+3. **Agent Processing:** The user prompts the agent with a query. The agent
+   analyzes the query and potentially the session `state` and `events` history
+   to determine the response.
+4. **Response & State Update:** The agent generates a response (and potentially
+   flags data to be updated in the `state`). The `Runner` packages this as an
+   `Event`.
+5. **Save Interaction:** The `Runner` calls
+   `sessionService.append_event(session, event)` with the `session` and the new
+   `event` as the arguments. The service adds the `Event` to the history and
+   updates the session's `state` in storage based on information within the
+   event. The session's `last_update_time` also get updated.
+6. **Ready for Next:** The agent's response goes to the user. The updated
+   `Session` is now stored by the `SessionService`, ready for the next turn
+   (which restarts the cycle at step 1, usually with the continuation of the
+   conversation in the current session).
+7. **End Conversation:** When the conversation is over, your application calls
+   `sessionService.delete_session(...)` to clean up the stored session data if
+   it is no longer required.
+
+This cycle highlights how the `SessionService` ensures conversational continuity
+by managing the history and state associated with each `Session` object.
+
 
 ## Managing sessions with a `SessionService`
 
@@ -371,40 +409,6 @@ through a two-tiered locking architecture:
     The schema for the session database changed in ADK Python v1.22.0, which
     requires migration of the Session Database. For more information, see
     [Session database schema migration](/sessions/session/migrate/).
-
-## The session lifecycle
-
-<img src="../../assets/event-loop.png" alt="Session lifecycle">
-
-Here’s a simplified flow of how `Session` and `SessionService` work together
-during a conversation turn:
-
-1. **Start or Resume:** Your application needs to use the `SessionService` to
-   either `create_session` (for a new chat) or use an existing session id.
-2. **Context Provided:** The `Runner` gets the appropriate `Session` object from
-   the appropriate service method, providing the agent with access to the
-   corresponding Session's `state` and `events`.
-3. **Agent Processing:** The user prompts the agent with a query. The agent
-   analyzes the query and potentially the session `state` and `events` history
-   to determine the response.
-4. **Response & State Update:** The agent generates a response (and potentially
-   flags data to be updated in the `state`). The `Runner` packages this as an
-   `Event`.
-5. **Save Interaction:** The `Runner` calls
-   `sessionService.append_event(session, event)` with the `session` and the new
-   `event` as the arguments. The service adds the `Event` to the history and
-   updates the session's `state` in storage based on information within the
-   event. The session's `last_update_time` also get updated.
-6. **Ready for Next:** The agent's response goes to the user. The updated
-   `Session` is now stored by the `SessionService`, ready for the next turn
-   (which restarts the cycle at step 1, usually with the continuation of the
-   conversation in the current session).
-7. **End Conversation:** When the conversation is over, your application calls
-   `sessionService.delete_session(...)` to clean up the stored session data if
-   it is no longer required.
-
-This cycle highlights how the `SessionService` ensures conversational continuity
-by managing the history and state associated with each `Session` object.
 
 ## Troubleshoot session errors
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -380,12 +380,9 @@ nav:
         - Types of callbacks: callbacks/types-of-callbacks.md
         - Callback patterns: callbacks/design-patterns-and-best-practices.md
       - Plugins: plugins/index.md
-    - Context:
+    - Agent context:
       - context/index.md
-      - Context caching: context/caching.md
-      - Context compression: context/compaction.md
-    - Sessions and Memory:
-      - sessions/index.md
+      - Conversational context: sessions/index.md
       - Sessions:
         - sessions/session/index.md
         - Rewind sessions: sessions/session/rewind.md
@@ -393,6 +390,8 @@ nav:
       - State: sessions/state.md
       - Events: events/index.md
       - Memory: sessions/memory.md
+      - Context compression: context/compaction.md
+      - Model context caching: context/caching.md
     - MCP:
       - mcp/index.md
     - A2A Protocol:


### PR DESCRIPTION
stage: https://deploy-preview-2027--adk-docs-preview.netlify.app/context/

correcting a conceptual / presentation problem with ADK agent context:

The current navigation separates "Context" from "Sessions and memory" but that's not correct, and it's confusing. Sessions, state, events, and memory are all part of an agent's ***overall*** context, so we should presented it that way, and let sessions, state, etc. be components of the overall context of an agent.

Also moved the **Session lifecycle** section up for better visibility