### PR TITLE
docs(examples): fix unrunnable Python snippets included by the docs

### DIFF
--- a/examples/python/agent-samples/youtube_shorts_assistant/loop_agent_runner.py
+++ b/examples/python/agent-samples/youtube_shorts_assistant/loop_agent_runner.py
@@ -60,6 +60,8 @@ root_agent = youtube_shorts_agent
 
 
 # Code required to make the agent programmatically runnable.
+import asyncio
+
 from google.genai import types
 from google.adk.sessions import InMemorySessionService
 from google.adk.runners import Runner
@@ -91,8 +93,12 @@ async def call_agent_async(query):
     events = runner.run_async(user_id=USER_ID, session_id=SESSION_ID, new_message=content)
 
     async for event in events:
-        if event.is_final_response():
+        if event.is_final_response() and event.content and event.content.parts:
             final_response = event.content.parts[0].text
             print("Agent Response: ", final_response)
 
-call_agent_async("I want to write a short on how to build AI Agents")
+async def main():
+    await call_agent_async("I want to write a short on how to build AI Agents")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/snippets/agents/custom-agent/storyflow_agent.py
+++ b/examples/python/snippets/agents/custom-agent/storyflow_agent.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import logging
 from typing import AsyncGenerator
 from typing_extensions import override
@@ -273,7 +274,10 @@ async def call_agent_async(user_input_topic: str):
     print("-------------------------------\n")
 
 # --- Run the Agent ---
-# Note: In Colab, you can directly use 'await' at the top level.
-# If running this code as a standalone Python script, you'll need to use asyncio.run() or manage the event loop.
-await call_agent_async("a lonely robot finding a friend in a junkyard")
+async def main():
+    await call_agent_async("a lonely robot finding a friend in a junkyard")
+
+# Note: In Colab, you can directly 'await call_agent_async(...)' at the top level.
+if __name__ == "__main__":
+    asyncio.run(main())
 # --8<-- [end:story_flow_agent]

--- a/examples/python/snippets/callbacks/after_agent_callback.py
+++ b/examples/python/snippets/callbacks/after_agent_callback.py
@@ -133,7 +133,7 @@ async def main():
             role="user", parts=[types.Part(text="Process this please.")]
         ),
     ):
-        # Print final output (from the LLM, or from the callback's extra event)
+        # Print final output, from the LLM or from the callback's extra event
         if event.is_final_response() and event.content and event.content.parts:
             print(
                 f"Final Output: [{event.author}] {event.content.parts[0].text.strip()}"
@@ -155,7 +155,7 @@ async def main():
             role="user", parts=[types.Part(text="Process this and add note.")]
         ),
     ):
-        # Print final output (from the LLM, or from the callback's extra event)
+        # Print final output, from the LLM or from the callback's extra event
         if event.is_final_response() and event.content and event.content.parts:
             print(
                 f"Final Output: [{event.author}] {event.content.parts[0].text.strip()}"

--- a/examples/python/snippets/callbacks/after_agent_callback.py
+++ b/examples/python/snippets/callbacks/after_agent_callback.py
@@ -27,6 +27,8 @@
 
 
 # ADK Imports
+import asyncio
+
 from google.adk.agents import LlmAgent
 from google.adk.agents.callback_context import CallbackContext
 from google.adk.runners import InMemoryRunner  # Use InMemoryRunner
@@ -43,8 +45,9 @@ def modify_output_after_agent(
 ) -> Optional[types.Content]:
     """
     Logs exit from an agent and checks 'add_concluding_note' in session state.
-    If True, returns new Content to *replace* the agent's original output.
-    If False or not present, returns None, allowing the agent's original output to be used.
+    If True, returns new Content, which ADK emits as an *additional* event after
+    the agent's own output. The agent's original output is still produced.
+    If False or not present, returns None, so no extra event is emitted.
     """
     agent_name = callback_context.agent_name
     invocation_id = callback_context.invocation_id
@@ -56,22 +59,23 @@ def modify_output_after_agent(
     # Example: Check state to decide whether to modify the final output
     if current_state.get("add_concluding_note", False):
         print(
-            f"[Callback] State condition 'add_concluding_note=True' met: Replacing agent {agent_name}'s output."
+            f"[Callback] State condition 'add_concluding_note=True' met: Appending a note after agent {agent_name}'s output."
         )
-        # Return Content to *replace* the agent's own output
+        # Returned Content is emitted as an extra event after the agent's own
+        # output; it does not overwrite what the agent already produced.
         return types.Content(
             parts=[
                 types.Part(
-                    text=f"Concluding note added by after_agent_callback, replacing original output."
+                    text=f"Concluding note added by after_agent_callback, after the original output."
                 )
             ],
-            role="model",  # Assign model role to the overriding response
+            role="model",  # Assign model role to the appended response
         )
     else:
         print(
-            f"[Callback] State condition not met: Using agent {agent_name}'s original output."
+            f"[Callback] State condition not met: Only agent {agent_name}'s original output is emitted."
         )
-        # Return None - the agent's output produced just before this callback will be used.
+        # Return None - no extra event is emitted after the agent's output.
         return None
 
 
@@ -80,7 +84,7 @@ llm_agent_with_after_cb = LlmAgent(
     name="MySimpleAgentWithAfter",
     model=GEMINI_2_FLASH,
     instruction="You are a simple agent. Just say 'Processing complete!'",
-    description="An LLM agent demonstrating after_agent_callback for output modification",
+    description="An LLM agent demonstrating after_agent_callback appending an extra event",
     after_agent_callback=modify_output_after_agent,  # Assign the callback here
 )
 
@@ -106,7 +110,7 @@ async def main():
     )
     # print(f"Session '{session_id_normal}' created with default state.")
 
-    # Create session 2: Agent output will be replaced by the callback
+    # Create session 2: The callback appends an extra event after the agent output
     await session_service.create_session(
         app_name=app_name,
         user_id=user_id,
@@ -115,11 +119,11 @@ async def main():
     )
     # print(f"Session '{session_id_modify}' created with state={{'add_concluding_note': True}}.")
 
-    # --- Scenario 1: Run where callback allows agent's original output ---
+    # --- Scenario 1: Run where the callback adds nothing ---
     print(
         "\n"
         + "=" * 20
-        + f" SCENARIO 1: Running Agent on Session '{session_id_normal}' (Should Use Original Output) "
+        + f" SCENARIO 1: Running Agent on Session '{session_id_normal}' (Only Original Output) "
         + "=" * 20
     )
     async for event in runner.run_async(
@@ -129,19 +133,19 @@ async def main():
             role="user", parts=[types.Part(text="Process this please.")]
         ),
     ):
-        # Print final output (either from LLM or callback override)
-        if event.is_final_response() and event.content:
+        # Print final output (from the LLM, or from the callback's extra event)
+        if event.is_final_response() and event.content and event.content.parts:
             print(
                 f"Final Output: [{event.author}] {event.content.parts[0].text.strip()}"
             )
-        elif event.is_error():
-            print(f"Error Event: {event.error_details}")
+        elif event.error_code:
+            print(f"Error Event: {event.error_code} - {event.error_message}")
 
-    # --- Scenario 2: Run where callback replaces the agent's output ---
+    # --- Scenario 2: Run where the callback appends an extra event ---
     print(
         "\n"
         + "=" * 20
-        + f" SCENARIO 2: Running Agent on Session '{session_id_modify}' (Should Replace Output) "
+        + f" SCENARIO 2: Running Agent on Session '{session_id_modify}' (Original Output + Appended Note) "
         + "=" * 20
     )
     async for event in runner.run_async(
@@ -151,22 +155,19 @@ async def main():
             role="user", parts=[types.Part(text="Process this and add note.")]
         ),
     ):
-        # Print final output (either from LLM or callback override)
-        if event.is_final_response() and event.content:
+        # Print final output (from the LLM, or from the callback's extra event)
+        if event.is_final_response() and event.content and event.content.parts:
             print(
                 f"Final Output: [{event.author}] {event.content.parts[0].text.strip()}"
             )
-        elif event.is_error():
-            print(f"Error Event: {event.error_details}")
+        elif event.error_code:
+            print(f"Error Event: {event.error_code} - {event.error_message}")
 
 
 # --- 4. Execute ---
-# In a Python script:
-# import asyncio
-# if __name__ == "__main__":
-#     # Make sure GOOGLE_API_KEY environment variable is set if not using Agent Platform auth
-#     # Or ensure Application Default Credentials (ADC) are configured for Agent Platform
-#     asyncio.run(main())
-
-# In a Jupyter Notebook or similar environment:
-await main()
+# In a Jupyter Notebook or similar environment you can `await main()` directly.
+# As a script:
+if __name__ == "__main__":
+    # Make sure GOOGLE_API_KEY environment variable is set if not using Agent Platform auth
+    # Or ensure Application Default Credentials (ADC) are configured for Agent Platform
+    asyncio.run(main())

--- a/examples/python/snippets/callbacks/after_model_callback.py
+++ b/examples/python/snippets/callbacks/after_model_callback.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+
 from google.adk.agents import LlmAgent
 from google.adk.agents.callback_context import CallbackContext
 from google.adk.runners import Runner
@@ -106,10 +108,13 @@ async def call_agent_async(query):
   events = runner.run_async(user_id=USER_ID, session_id=SESSION_ID, new_message=content)
 
   async for event in events:
-      if event.is_final_response():
+      if event.is_final_response() and event.content and event.content.parts:
           final_response = event.content.parts[0].text
           print("Agent Response: ", final_response)
 
-# Note: In Colab, you can directly use 'await' at the top level.
-# If running this code as a standalone Python script, you'll need to use asyncio.run() or manage the event loop.
-await call_agent_async("""write multiple time the word "joke" """)
+async def main():
+  await call_agent_async("""write multiple time the word "joke" """)
+
+# Note: In Colab, you can directly 'await call_agent_async(...)' at the top level.
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/snippets/callbacks/after_tool_callback.py
+++ b/examples/python/snippets/callbacks/after_tool_callback.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+
 from google.adk.agents import LlmAgent
 from google.adk.runners import Runner
 from typing import Optional
@@ -26,7 +28,7 @@ from copy import deepcopy
 GEMINI_2_FLASH="gemini-2.0-flash"
 
 # --- Define a Simple Tool Function (Same as before) ---
-def get_capital_city(country: str) -> str:
+def get_capital_city(country: str) -> dict:
     """Retrieves the capital city of a given country."""
     print(f"--- Tool 'get_capital_city' executing with country: {country} ---")
     country_capitals = {
@@ -51,9 +53,11 @@ def simple_after_tool_modifier(
     print(f"[Callback] Args used: {args}")
     print(f"[Callback] Original tool_response: {tool_response}")
 
-    # Default structure for function tool results is {"result": <return_value>}
+    # `tool_response` is whatever the tool function returned, unchanged. ADK does
+    # not wrap it here: a non-dict return is only wrapped in {"result": ...} later,
+    # when the function-response event is built. This tool returns a dict with a
+    # "result" key of its own, so read that key.
     original_result_value = tool_response.get("result", "")
-    # original_result_value = tool_response
 
     # --- Modification Example ---
     # If the tool was 'get_capital_city' and result is 'Washington, D.C.'
@@ -102,10 +106,13 @@ async def call_agent_async(query):
     events = runner.run_async(user_id=USER_ID, session_id=SESSION_ID, new_message=content)
 
     async for event in events:
-        if event.is_final_response():
+        if event.is_final_response() and event.content and event.content.parts:
             final_response = event.content.parts[0].text
             print("Agent Response: ", final_response)
 
-# Note: In Colab, you can directly use 'await' at the top level.
-# If running this code as a standalone Python script, you'll need to use asyncio.run() or manage the event loop.
-await call_agent_async("united states")
+async def main():
+    await call_agent_async("united states")
+
+# Note: In Colab, you can directly 'await call_agent_async(...)' at the top level.
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/snippets/callbacks/before_agent_callback.py
+++ b/examples/python/snippets/callbacks/before_agent_callback.py
@@ -26,6 +26,8 @@
 # # https://adk.dev/agents/models/
 
 # ADK Imports
+import asyncio
+
 from google.adk.agents import LlmAgent
 from google.adk.agents.callback_context import CallbackContext
 from google.adk.runners import InMemoryRunner  # Use InMemoryRunner
@@ -127,12 +129,12 @@ async def main():
         ),
     ):
         # Print final output (either from LLM or callback override)
-        if event.is_final_response() and event.content:
+        if event.is_final_response() and event.content and event.content.parts:
             print(
                 f"Final Output: [{event.author}] {event.content.parts[0].text.strip()}"
             )
-        elif event.is_error():
-            print(f"Error Event: {event.error_details}")
+        elif event.error_code:
+            print(f"Error Event: {event.error_code} - {event.error_message}")
 
     # --- Scenario 2: Run where callback intercepts and skips agent ---
     print(
@@ -149,21 +151,18 @@ async def main():
         ),
     ):
         # Print final output (either from LLM or callback override)
-        if event.is_final_response() and event.content:
+        if event.is_final_response() and event.content and event.content.parts:
             print(
                 f"Final Output: [{event.author}] {event.content.parts[0].text.strip()}"
             )
-        elif event.is_error():
-            print(f"Error Event: {event.error_details}")
+        elif event.error_code:
+            print(f"Error Event: {event.error_code} - {event.error_message}")
 
 
 # --- 4. Execute ---
-# In a Python script:
-# import asyncio
-# if __name__ == "__main__":
-#     # Make sure GOOGLE_API_KEY environment variable is set if not using Agent Platform auth
-#     # Or ensure Application Default Credentials (ADC) are configured for Agent Platform
-#     asyncio.run(main())
-
-# In a Jupyter Notebook or similar environment:
-await main()
+# In a Jupyter Notebook or similar environment you can `await main()` directly.
+# As a script:
+if __name__ == "__main__":
+    # Make sure GOOGLE_API_KEY environment variable is set if not using Agent Platform auth
+    # Or ensure Application Default Credentials (ADC) are configured for Agent Platform
+    asyncio.run(main())

--- a/examples/python/snippets/callbacks/before_model_callback.py
+++ b/examples/python/snippets/callbacks/before_model_callback.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+
 from google.adk.agents import LlmAgent
 from google.adk.agents.callback_context import CallbackContext
 from google.adk.models import LlmResponse, LlmRequest
@@ -99,10 +101,13 @@ async def call_agent_async(query):
     events = runner.run_async(user_id=USER_ID, session_id=SESSION_ID, new_message=content)
 
     async for event in events:
-        if event.is_final_response():
+        if event.is_final_response() and event.content and event.content.parts:
             final_response = event.content.parts[0].text
             print("Agent Response: ", final_response)
 
-# Note: In Colab, you can directly use 'await' at the top level.
-# If running this code as a standalone Python script, you'll need to use asyncio.run() or manage the event loop.
-await call_agent_async("write a joke on BLOCK")
+async def main():
+    await call_agent_async("write a joke on BLOCK")
+
+# Note: In Colab, you can directly 'await call_agent_async(...)' at the top level.
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/snippets/callbacks/before_tool_callback.py
+++ b/examples/python/snippets/callbacks/before_tool_callback.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+
 from google.adk.agents import LlmAgent
 from google.adk.runners import Runner
 from typing import Optional
@@ -88,10 +90,13 @@ async def call_agent_async(query):
     events = runner.run_async(user_id=USER_ID, session_id=SESSION_ID, new_message=content)
 
     async for event in events:
-        if event.is_final_response():
+        if event.is_final_response() and event.content and event.content.parts:
             final_response = event.content.parts[0].text
             print("Agent Response: ", final_response)
 
-# Note: In Colab, you can directly use 'await' at the top level.
-# If running this code as a standalone Python script, you'll need to use asyncio.run() or manage the event loop.
-await call_agent_async("Canada")
+async def main():
+    await call_agent_async("Canada")
+
+# Note: In Colab, you can directly 'await call_agent_async(...)' at the top level.
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/snippets/callbacks/callback_basic.py
+++ b/examples/python/snippets/callbacks/callback_basic.py
@@ -40,6 +40,8 @@ APP_NAME = "guardrail_app"
 USER_ID = "user_1"
 SESSION_ID = "session_001"
 
+import asyncio
+
 from google.adk.runners import Runner
 from google.genai import types 
 from google.adk.sessions import InMemorySessionService
@@ -58,10 +60,13 @@ async def call_agent_async(query):
     events = runner.run_async(user_id=USER_ID, session_id=SESSION_ID, new_message=content)
 
     async for event in events:
-        if event.is_final_response():
+        if event.is_final_response() and event.content and event.content.parts:
             final_response = event.content.parts[0].text
             print("Agent Response: ", final_response)
 
-# Note: In Colab, you can directly use 'await' at the top level.
-# If running this code as a standalone Python script, you'll need to use asyncio.run() or manage the event loop.
-await call_agent_async("write a short joke")
+async def main():
+    await call_agent_async("write a short joke")
+
+# Note: In Colab, you can directly 'await call_agent_async(...)' at the top level.
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/snippets/tools/auth/agent_cli.py
+++ b/examples/python/snippets/tools/auth/agent_cli.py
@@ -22,7 +22,7 @@ async def async_main():
   artifacts_service = InMemoryArtifactService()
 
   # Create a new user session to maintain conversation state.
-  session = session_service.create_session(
+  session = await session_service.create_session(
       state={},  # Optional state dictionary for session-specific data
       app_name='my_app', # Application identifier
       user_id='user' # User identifier

--- a/examples/python/snippets/tools/auth/agent_cli.py
+++ b/examples/python/snippets/tools/auth/agent_cli.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import asyncio
 from dotenv import load_dotenv
 from google.adk.artifacts.in_memory_artifact_service import InMemoryArtifactService

--- a/examples/python/snippets/tools/auth/helpers.py
+++ b/examples/python/snippets/tools/auth/helpers.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from google.adk.auth import AuthConfig
 from google.adk.events import Event
 import asyncio

--- a/examples/python/snippets/tools/auth/helpers.py
+++ b/examples/python/snippets/tools/auth/helpers.py
@@ -90,9 +90,11 @@ def get_function_call_auth_config(event: Event) -> AuthConfig:
     An AuthConfig object populated with details from the function call arguments.
 
   Raises:
-    ValueError: If the 'auth_config' argument cannot be found in the event.
+    ValueError: If the 'authConfig' argument cannot be found in the event.
                 (Corrected typo from `contents` to `content` below)
   """
+  # ADK serialises the function call arguments with `by_alias=True`, so the
+  # argument key is the camelCase alias `authConfig`, not `auth_config`.
   if (
       event
       and event.content
@@ -100,11 +102,11 @@ def get_function_call_auth_config(event: Event) -> AuthConfig:
       and event.content.parts[0] # Use content, not contents
       and event.content.parts[0].function_call
       and event.content.parts[0].function_call.args
-      and event.content.parts[0].function_call.args.get('auth_config')
+      and event.content.parts[0].function_call.args.get('authConfig')
   ):
     # Reconstruct the AuthConfig object using the dictionary provided in the arguments.
     # The ** operator unpacks the dictionary into keyword arguments for the constructor.
     return AuthConfig(
-          **event.content.parts[0].function_call.args.get('auth_config')
+          **event.content.parts[0].function_call.args.get('authConfig')
       )
   raise ValueError(f'Cannot get auth config from event {event}')

--- a/examples/python/snippets/tools/auth/helpers.py
+++ b/examples/python/snippets/tools/auth/helpers.py
@@ -93,7 +93,7 @@ def get_function_call_auth_config(event: Event) -> AuthConfig:
     ValueError: If the 'authConfig' argument cannot be found in the event.
                 (Corrected typo from `contents` to `content` below)
   """
-  # ADK serialises the function call arguments with `by_alias=True`, so the
+  # ADK serializes the function call arguments with `by_alias=True`, so the
   # argument key is the camelCase alias `authConfig`, not `auth_config`.
   if (
       event

--- a/examples/python/snippets/tools/built-in-tools/agent_search.py
+++ b/examples/python/snippets/tools/built-in-tools/agent_search.py
@@ -54,8 +54,12 @@ runner_vsearch = Runner(
     app_name=APP_NAME_VSEARCH,
     session_service=session_service_vsearch,
 )
-session_vsearch = session_service_vsearch.create_session(
-    app_name=APP_NAME_VSEARCH, user_id=USER_ID_VSEARCH, session_id=SESSION_ID_VSEARCH
+session_vsearch = asyncio.run(
+    session_service_vsearch.create_session(
+        app_name=APP_NAME_VSEARCH,
+        user_id=USER_ID_VSEARCH,
+        session_id=SESSION_ID_VSEARCH,
+    )
 )
 
 
@@ -82,8 +86,9 @@ async def call_vsearch_agent_async(query):
                 print(f"Agent Response: {final_response_text}")
                 # You can inspect event.grounding_metadata for source citations
                 if event.grounding_metadata:
+                    grounding_chunks = event.grounding_metadata.grounding_chunks or []
                     print(
-                        f"  (Grounding metadata found with {len(event.grounding_metadata.grounding_attributions)} attributions)"
+                        f"  (Grounding metadata found with {len(grounding_chunks)} chunks)"
                     )
 
     except Exception as e:

--- a/examples/python/snippets/tools/built-in-tools/bigquery.py
+++ b/examples/python/snippets/tools/built-in-tools/bigquery.py
@@ -83,7 +83,7 @@ def call_agent(query):
 
     print("USER:", query)
     for event in events:
-        if event.is_final_response():
+        if event.is_final_response() and event.content and event.content.parts:
             final_response = event.content.parts[0].text
             print("AGENT:", final_response)
 

--- a/examples/python/snippets/tools/built-in-tools/bigtable.py
+++ b/examples/python/snippets/tools/built-in-tools/bigtable.py
@@ -54,7 +54,9 @@ bigtable_toolset = BigtableToolset(
 # Create a wrapped function tool for the agent on top of the built-in
 # `execute_sql` tool in the bigtable toolset.
 # For example, this customized tool can perform a dynamically-built query.
-def count_rows_tool(
+# `query_tool.execute_sql` is a coroutine function, so the wrapper must be
+# `async def` and `await` it; GoogleTool supports async tool functions.
+async def count_rows_tool(
     table_name: str,
     credentials: Credentials,  # GoogleTool handles `credentials`
     settings: BigtableToolSettings,  # GoogleTool handles `settings`
@@ -77,7 +79,7 @@ def count_rows_tool(
   SELECT count(*) FROM {table_name}
     """
 
-  return query_tool.execute_sql(
+  return await query_tool.execute_sql(
       project_id=PROJECT_ID,
       instance_id=INSTANCE_ID,
       query=query,
@@ -132,7 +134,7 @@ def call_agent(query):
 
     print("USER:", query)
     for event in events:
-        if event.is_final_response():
+        if event.is_final_response() and event.content and event.content.parts:
             final_response = event.content.parts[0].text
             print("AGENT:", final_response)
 

--- a/examples/python/snippets/tools/built-in-tools/data_agent.py
+++ b/examples/python/snippets/tools/built-in-tools/data_agent.py
@@ -87,7 +87,7 @@ def call_agent(query):
 
     print("USER:", query)
     for event in events:
-        if event.is_final_response():
+        if event.is_final_response() and event.content and event.content.parts:
             final_response = event.content.parts[0].text
             print("AGENT:", final_response)
 

--- a/examples/python/snippets/tools/built-in-tools/google_search.py
+++ b/examples/python/snippets/tools/built-in-tools/google_search.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+
 from google.adk.agents import Agent
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
@@ -46,10 +48,13 @@ async def call_agent_async(query):
     events = runner.run_async(user_id=USER_ID, session_id=SESSION_ID, new_message=content)
 
     async for event in events:
-        if event.is_final_response():
+        if event.is_final_response() and event.content and event.content.parts:
             final_response = event.content.parts[0].text
             print("Agent Response: ", final_response)
 
-# Note: In Colab, you can directly use 'await' at the top level.
-# If running this code as a standalone Python script, you'll need to use asyncio.run() or manage the event loop.
-await call_agent_async("what's the latest ai news?")
+async def main():
+    await call_agent_async("what's the latest ai news?")
+
+# Note: In Colab, you can directly 'await call_agent_async(...)' at the top level.
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/snippets/tools/built-in-tools/pubsub.py
+++ b/examples/python/snippets/tools/built-in-tools/pubsub.py
@@ -85,7 +85,7 @@ def call_agent(query):
 
     print("USER:", query)
     for event in events:
-        if event.is_final_response():
+        if event.is_final_response() and event.content and event.content.parts:
             final_response = event.content.parts[0].text
             print("AGENT:", final_response)
 

--- a/examples/python/snippets/tools/built-in-tools/spanner.py
+++ b/examples/python/snippets/tools/built-in-tools/spanner.py
@@ -56,7 +56,9 @@ spanner_toolset = SpannerToolset(
 # Create a wrapped function tool for the agent on top of the built-in
 # `execute_sql` tool in the Spanner toolset.
 # For example, this customized tool can perform a dynamically-built query.
-def count_rows_tool(
+# `query_tool.execute_sql` is a coroutine function, so the wrapper must be
+# `async def` and `await` it; GoogleTool supports async tool functions.
+async def count_rows_tool(
     table_name: str,
     credentials: Credentials,  # GoogleTool handles `credentials`
     settings: SpannerToolSettings,  # GoogleTool handles `settings`
@@ -80,7 +82,7 @@ def count_rows_tool(
   SELECT count(*) FROM {table_name}
     """
 
-  return query_tool.execute_sql(
+  return await query_tool.execute_sql(
       project_id=PROJECT_ID,
       instance_id=INSTANCE_ID,
       database_id=DATABASE_ID,
@@ -141,7 +143,7 @@ def call_agent(query):
 
     print("USER:", query)
     for event in events:
-        if event.is_final_response():
+        if event.is_final_response() and event.content and event.content.parts:
             final_response = event.content.parts[0].text
             print("AGENT:", final_response)
 

--- a/examples/python/snippets/tools/function-tools/func_tool.py
+++ b/examples/python/snippets/tools/function-tools/func_tool.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+
 from google.adk.agents import Agent
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
@@ -70,11 +72,14 @@ async def call_agent_async(query):
     events = runner.run_async(user_id=USER_ID, session_id=SESSION_ID, new_message=content)
 
     async for event in events:
-        if event.is_final_response():
+        if event.is_final_response() and event.content and event.content.parts:
             final_response = event.content.parts[0].text
             print("Agent Response: ", final_response)
 
 
-# Note: In Colab, you can directly use 'await' at the top level.
-# If running this code as a standalone Python script, you'll need to use asyncio.run() or manage the event loop.
-await call_agent_async("stock price of GOOG")
+async def main():
+    await call_agent_async("stock price of GOOG")
+
+# Note: In Colab, you can directly 'await call_agent_async(...)' at the top level.
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/snippets/tools/function-tools/human_in_the_loop.py
+++ b/examples/python/snippets/tools/function-tools/human_in_the_loop.py
@@ -141,12 +141,13 @@ async def call_agent_async(query):
           
 # --8<-- [end:call_reimbursement_tool]          
 
-# Note: In Colab, you can directly use 'await' at the top level.
-# If running this code as a standalone Python script, you'll need to use asyncio.run() or manage the event loop.
-                   
-# reimbursement that doesn't require approval
-# asyncio.run(call_agent_async("Please reimburse 50$ for meals"))
-await call_agent_async("Please reimburse 50$ for meals") # For Notebooks, uncomment this line and comment the above line
-# reimbursement that requires approval
-# asyncio.run(call_agent_async("Please reimburse 200$ for meals"))
-await call_agent_async("Please reimburse 200$ for meals") # For Notebooks, uncomment this line and comment the above line
+async def main():
+    # reimbursement that doesn't require approval
+    await call_agent_async("Please reimburse 50$ for meals")
+    # reimbursement that requires approval
+    await call_agent_async("Please reimburse 200$ for meals")
+
+# Note: In Colab or another notebook you can await the calls in `main` directly
+# at the top level. As a standalone script, run them through asyncio.run().
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/snippets/tools/function-tools/human_in_the_loop.py
+++ b/examples/python/snippets/tools/function-tools/human_in_the_loop.py
@@ -142,7 +142,7 @@ async def call_agent_async(query):
 # --8<-- [end:call_reimbursement_tool]          
 
 async def main():
-    # reimbursement that doesn't require approval
+    # reimbursement that does not require approval
     await call_agent_async("Please reimburse 50$ for meals")
     # reimbursement that requires approval
     await call_agent_async("Please reimburse 200$ for meals")

--- a/examples/python/snippets/tools/function-tools/summarizer.py
+++ b/examples/python/snippets/tools/function-tools/summarizer.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+
 from google.adk.agents import Agent
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
@@ -51,7 +53,7 @@ async def call_agent_async(query):
     events = runner.run_async(user_id=USER_ID, session_id=SESSION_ID, new_message=content)
 
     async for event in events:
-        if event.is_final_response():
+        if event.is_final_response() and event.content and event.content.parts:
             final_response = event.content.parts[0].text
             print("Agent Response: ", final_response)
 
@@ -66,6 +68,9 @@ as drug discovery, materials science, complex system optimization, and breaking 
 faster than even the most powerful classical supercomputers could ever achieve, although the technology is still largely in its developmental stages."""
 
 
-# Note: In Colab, you can directly use 'await' at the top level.
-# If running this code as a standalone Python script, you'll need to use asyncio.run() or manage the event loop.
-await call_agent_async(long_text)
+async def main():
+    await call_agent_async(long_text)
+
+# Note: In Colab, you can directly 'await call_agent_async(...)' at the top level.
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/snippets/tools/openapi_tool.py
+++ b/examples/python/snippets/tools/openapi_tool.py
@@ -147,7 +147,7 @@ petstore_toolset = OpenAPIToolset(
 root_agent = LlmAgent(
     name=AGENT_NAME_OPENAPI,
     model=GEMINI_MODEL,
-    tools=[petstore_toolset], # Pass the list of RestApiTool objects
+    tools=[petstore_toolset], # Pass the toolset; it supplies the RestApiTool objects
     instruction="""You are a Pet Store assistant managing pets via an API.
     Use the available tools to fulfill user requests.
     When creating a pet, confirm the details echoed back by the API.

--- a/examples/python/snippets/tools/openapi_tool.py
+++ b/examples/python/snippets/tools/openapi_tool.py
@@ -147,7 +147,7 @@ petstore_toolset = OpenAPIToolset(
 root_agent = LlmAgent(
     name=AGENT_NAME_OPENAPI,
     model=GEMINI_MODEL,
-    tools=[petstore_toolset], # Pass the toolset; it supplies the RestApiTool objects
+    tools=[petstore_toolset], # Pass the list of RestApiTool objects
     instruction="""You are a Pet Store assistant managing pets via an API.
     Use the available tools to fulfill user requests.
     When creating a pet, confirm the details echoed back by the API.

--- a/examples/python/snippets/tools/overview/customer_support_agent.py
+++ b/examples/python/snippets/tools/overview/customer_support_agent.py
@@ -45,7 +45,7 @@ support_agent = Agent(
 
 # Pass `sub_agents` to the constructor: that is what links `support_agent` back
 # to `main_agent` as its parent. Assigning `main_agent.sub_agents` afterwards
-# would leave `support_agent.parent_agent` unset and transfers would fail.
+# leaves `support_agent.parent_agent` unset, so transfers fail.
 main_agent = Agent(
     model='gemini-2.0-flash',
     name='main_agent',

--- a/examples/python/snippets/tools/overview/customer_support_agent.py
+++ b/examples/python/snippets/tools/overview/customer_support_agent.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+
 from google.adk.agents import Agent
 from google.adk.tools import FunctionTool
 from google.adk.runners import Runner
@@ -35,20 +37,22 @@ def check_and_transfer(query: str, tool_context: ToolContext) -> str:
 
 escalation_tool = FunctionTool(func=check_and_transfer)
 
-main_agent = Agent(
-    model='gemini-2.0-flash',
-    name='main_agent',
-    instruction="""You are the first point of contact for customer support of an analytics tool. Answer general queries. If the user indicates urgency, use the 'escalation_tool' tool.""",
-    tools=[escalation_tool]
-)
-
 support_agent = Agent(
     model='gemini-2.0-flash',
     name='support_agent',
     instruction="""You are the dedicated support agent. Mentioned you are a support handler and please help the user with their urgent issue."""
 )
 
-main_agent.sub_agents = [support_agent]
+# Pass `sub_agents` to the constructor: that is what links `support_agent` back
+# to `main_agent` as its parent. Assigning `main_agent.sub_agents` afterwards
+# would leave `support_agent.parent_agent` unset and transfers would fail.
+main_agent = Agent(
+    model='gemini-2.0-flash',
+    name='main_agent',
+    instruction="""You are the first point of contact for customer support of an analytics tool. Answer general queries. If the user indicates urgency, use the 'escalation_tool' tool.""",
+    tools=[escalation_tool],
+    sub_agents=[support_agent]
+)
 
 # Session and Runner
 async def setup_session_and_runner():
@@ -64,10 +68,13 @@ async def call_agent_async(query):
     events = runner.run_async(user_id=USER_ID, session_id=SESSION_ID, new_message=content)
 
     async for event in events:
-        if event.is_final_response():
+        if event.is_final_response() and event.content and event.content.parts:
             final_response = event.content.parts[0].text
             print("Agent Response: ", final_response)
 
-# Note: In Colab, you can directly use 'await' at the top level.
-# If running this code as a standalone Python script, you'll need to use asyncio.run() or manage the event loop.
-await call_agent_async("this is urgent, i cant login")
+async def main():
+    await call_agent_async("this is urgent, i cant login")
+
+# Note: In Colab, you can directly 'await call_agent_async(...)' at the top level.
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/snippets/tools/overview/doc_analysis.py
+++ b/examples/python/snippets/tools/overview/doc_analysis.py
@@ -16,14 +16,14 @@ from google.adk.tools import ToolContext, FunctionTool
 from google.genai import types
 
 
-def process_document(
+async def process_document(
     document_name: str, analysis_query: str, tool_context: ToolContext
 ) -> dict:
     """Analyzes a document using context from memory."""
 
     # 1. Load the artifact
     print(f"Tool: Attempting to load artifact: {document_name}")
-    document_part = tool_context.load_artifact(document_name)
+    document_part = await tool_context.load_artifact(document_name)
 
     if not document_part:
         return {"status": "error", "message": f"Document '{document_name}' not found."}
@@ -33,14 +33,14 @@ def process_document(
 
     # 2. Search memory for related context
     print(f"Tool: Searching memory for context related to: '{analysis_query}'")
-    memory_response = tool_context.search_memory(
+    memory_response = await tool_context.search_memory(
         f"Context for analyzing document about {analysis_query}"
     )
     memory_context = "\n".join(
         [
-            m.events[0].content.parts[0].text
+            m.content.parts[0].text
             for m in memory_response.memories
-            if m.events and m.events[0].content
+            if m.content and m.content.parts
         ]
     )  # Simplified extraction
     print(f"Tool: Found memory context: {memory_context[:100]}...")

--- a/examples/python/snippets/tools/overview/weather_sentiment.py
+++ b/examples/python/snippets/tools/overview/weather_sentiment.py
@@ -89,7 +89,7 @@ async def main():
     events = runner.run(user_id=USER_ID, session_id=SESSION_ID, new_message=content)
 
     for event in events:
-        if event.is_final_response():
+        if event.is_final_response() and event.content and event.content.parts:
             final_response = event.content.parts[0].text
             print("Agent Response:", final_response)
 

--- a/examples/python/tutorial/agent_team/adk_tutorial.ipynb
+++ b/examples/python/tutorial/agent_team/adk_tutorial.ipynb
@@ -76,7 +76,7 @@
     "# Install ADK and LiteLLM for multi-model support\n",
     "\n",
     "!pip install google-adk -q\n",
-    "!pip install \"litellm>=1.84\" -q\n",
+    "!pip install litellm -q\n",
     "\n",
     "print(\"Installation complete.\")"
    ]
@@ -1212,7 +1212,7 @@
     "\n",
     "**How Agents Interact with State:**\n",
     "\n",
-    "1. **`ToolContext` (Primary Method):** Tools can accept a `ToolContext` object (automatically provided by ADK for any parameter annotated `ToolContext`, whatever its position). This object gives direct access to the session state via `tool_context.state`, allowing tools to read preferences or save results *during* execution.  \n",
+    "1. **`ToolContext` (Primary Method):** Tools can accept a `ToolContext` object (automatically provided by ADK if declared as the last argument). This object gives direct access to the session state via `tool_context.state`, allowing tools to read preferences or save results *during* execution.  \n",
     "2. **`output_key` (Auto-Save Agent Response):** An `Agent` can be configured with an `output_key=\"your_key\"`. ADK will then automatically save the agent's final textual response for a turn into `session.state[\"your_key\"]`.\n",
     "\n",
     "**In this step, we will enhance our Weather Bot team by:**\n",
@@ -1294,7 +1294,7 @@
     "Now, we create a new version of the weather tool. Its key feature is accepting `tool_context: ToolContext` which allows it to access `tool_context.state`. It will read the `user_preference_temperature_unit` and format the temperature accordingly.\n",
     "\n",
     "\n",
-    "* **Key Concept: `ToolContext`** This object is the bridge allowing your tool logic to interact with the session's context, including reading and writing state variables. ADK finds the parameter by its `ToolContext` annotation and injects it automatically, so it can sit at any position in your tool function's signature. The annotated parameter is also hidden from the schema the LLM sees.\n",
+    "* **Key Concept: `ToolContext`** This object is the bridge allowing your tool logic to interact with the session's context, including reading and writing state variables. ADK injects it automatically if defined as the last parameter of your tool function.\n",
     "\n",
     "\n",
     "* **Best Practice:** When reading from state, use `dictionary.get('key', default_value)` to handle cases where the key might not exist yet, ensuring your tool doesn't crash."
@@ -1490,8 +1490,8 @@
     "2.  **Manually update state:** We will *directly modify* the state stored within the `InMemorySessionService` instance (`session_service_stateful`).\n",
     "    *   **Why direct modification?** The `session_service.get_session()` method returns a *copy* of the session. Modifying that copy wouldn't affect the state used in subsequent agent runs. For this testing scenario with `InMemorySessionService`, we access the internal `sessions` dictionary to change the *actual* stored state value for `user_preference_temperature_unit` to \"Fahrenheit\". *Note: In real applications, state changes are typically triggered by tools or agent logic returning `EventActions(state_delta=...)`, not direct manual updates.*\n",
     "3.  **Check weather again (New York):** The `get_weather_stateful` tool should now read the updated \"Fahrenheit\" preference from the state and convert the temperature accordingly. The root agent's *new* response (weather in Fahrenheit) will overwrite the previous value in `state['last_weather_report']` due to the `output_key`.\n",
-    "4.  **Greet the agent:** Verify that delegation to the `greeting_agent` still works correctly alongside the stateful operations.\n",
-    "5.  **Inspect final state:** After the conversation, we retrieve the session one last time (getting a copy) and print its state to confirm the `user_preference_temperature_unit` is indeed \"Fahrenheit\", observe the final value saved by `output_key` (which will be the previous weather report in this run), and see the `last_city_checked_stateful` value written by the tool.\n"
+    "4.  **Greet the agent:** Verify that delegation to the `greeting_agent` still works correctly alongside the stateful operations. This interaction will become the *last* response saved by `output_key` in this specific sequence.\n",
+    "5.  **Inspect final state:** After the conversation, we retrieve the session one last time (getting a copy) and print its state to confirm the `user_preference_temperature_unit` is indeed \"Fahrenheit\", observe the final value saved by `output_key` (which will be the greeting in this run), and see the `last_city_checked_stateful` value written by the tool.\n"
    ]
   },
   {
@@ -1558,8 +1558,7 @@
     "        )\n",
     "\n",
     "        # 4. Test basic delegation (should still work)\n",
-    "        # The greeting is authored by the delegated sub-agent, not the root agent,\n",
-    "        # so output_key does NOT fire: 'last_weather_report' keeps the NY report.\n",
+    "        # This will update 'last_weather_report' again, overwriting the NY weather report\n",
     "        print(\"\\n--- Turn 3: Sending a greeting ---\")\n",
     "        await call_agent_async(\n",
     "            query=\"Hi!\",\n",
@@ -1638,7 +1637,7 @@
     "*   **State Read (Updated):** The tool subsequently read \"Fahrenheit\" when asked for New York's weather and performed the conversion.\n",
     "*   **Tool State Write:** The tool successfully wrote the `last_city_checked_stateful` (\"New York\" after the second weather check) into the state via `tool_context.state`.\n",
     "*   **Delegation:** The delegation to the `greeting_agent` for \"Hi!\" functioned correctly even after state modifications.\n",
-    "*   **`output_key`:** The `output_key=\"last_weather_report\"` successfully saved the root agent's *final* response for *each turn* where the root agent was the one ultimately responding. In this sequence, the final greeting (\"Hello, there!\") was generated by the delegated sub-agent rather than the root agent, so `output_key` was not triggered on that final turn, leaving the previous weather report intact in the session state.\n",
+    "*   **`output_key`:** The `output_key=\"last_weather_report\"` successfully saved the root agent's *final* response for *each turn* where the root agent was the one ultimately responding. In this sequence, the last response was the greeting (\"Hello, there!\"), so that overwrote the weather report in the state key.\n",
     "*   **Final State:** The final check confirms the preference persisted as \"Fahrenheit\".\n",
     "\n",
     "You've now successfully integrated session state to personalize agent behavior using `ToolContext`, manually manipulated state for testing `InMemorySessionService`, and observed how `output_key` provides a simple mechanism for saving the agent's last response to state. This foundational understanding of state management is key as we proceed to implement safety guardrails using callbacks in the next steps.\n",
@@ -2452,7 +2451,7 @@
     "    *   Use `after_tool_callback` to process or log the results returned by a tool.\n",
     "    *   Implement `before_agent_callback` or `after_agent_callback` for agent-level entry/exit logic.\n",
     "5.  **Error Handling:** Improve how the agent handles tool errors or unexpected API responses. Maybe add retry logic within a tool.\n",
-    "6.  **Persistent Session Storage:** Swap `InMemorySessionService` for one of ADK's persistent implementations – `DatabaseSessionService`, which is SQLAlchemy-backed and installed with `pip install google-adk[db]`, or `VertexAiSessionService`. See [Session](https://adk.dev/sessions/session/) for details.\n",
+    "6.  **Persistent Session Storage:** Explore alternatives to `InMemorySessionService` for storing session state persistently (e.g., using databases like Firestore or Cloud SQL – requires custom implementation or future ADK integrations).\n",
     "7.  **Streaming UI:** Integrate your agent team with a web framework (like FastAPI, as shown in the ADK Streaming Quickstart) to create a real-time chat interface.\n",
     "\n",
     "The Agent Development Kit provides a robust foundation for building sophisticated LLM-powered applications. By mastering the concepts covered in this tutorial – tools, state, delegation, and callbacks – you are well-equipped to tackle increasingly complex agentic systems.\n",

--- a/examples/python/tutorial/agent_team/adk_tutorial.ipynb
+++ b/examples/python/tutorial/agent_team/adk_tutorial.ipynb
@@ -76,7 +76,7 @@
     "# Install ADK and LiteLLM for multi-model support\n",
     "\n",
     "!pip install google-adk -q\n",
-    "!pip install litellm -q\n",
+    "!pip install \"litellm>=1.84\" -q\n",
     "\n",
     "print(\"Installation complete.\")"
    ]
@@ -1212,7 +1212,7 @@
     "\n",
     "**How Agents Interact with State:**\n",
     "\n",
-    "1. **`ToolContext` (Primary Method):** Tools can accept a `ToolContext` object (automatically provided by ADK if declared as the last argument). This object gives direct access to the session state via `tool_context.state`, allowing tools to read preferences or save results *during* execution.  \n",
+    "1. **`ToolContext` (Primary Method):** Tools can accept a `ToolContext` object (automatically provided by ADK for any parameter annotated `ToolContext`, whatever its position). This object gives direct access to the session state via `tool_context.state`, allowing tools to read preferences or save results *during* execution.  \n",
     "2. **`output_key` (Auto-Save Agent Response):** An `Agent` can be configured with an `output_key=\"your_key\"`. ADK will then automatically save the agent's final textual response for a turn into `session.state[\"your_key\"]`.\n",
     "\n",
     "**In this step, we will enhance our Weather Bot team by:**\n",
@@ -1294,7 +1294,7 @@
     "Now, we create a new version of the weather tool. Its key feature is accepting `tool_context: ToolContext` which allows it to access `tool_context.state`. It will read the `user_preference_temperature_unit` and format the temperature accordingly.\n",
     "\n",
     "\n",
-    "* **Key Concept: `ToolContext`** This object is the bridge allowing your tool logic to interact with the session's context, including reading and writing state variables. ADK injects it automatically if defined as the last parameter of your tool function.\n",
+    "* **Key Concept: `ToolContext`** This object is the bridge allowing your tool logic to interact with the session's context, including reading and writing state variables. ADK finds the parameter by its `ToolContext` annotation and injects it automatically, so it can sit at any position in your tool function's signature. The annotated parameter is also hidden from the schema the LLM sees.\n",
     "\n",
     "\n",
     "* **Best Practice:** When reading from state, use `dictionary.get('key', default_value)` to handle cases where the key might not exist yet, ensuring your tool doesn't crash."
@@ -1490,8 +1490,8 @@
     "2.  **Manually update state:** We will *directly modify* the state stored within the `InMemorySessionService` instance (`session_service_stateful`).\n",
     "    *   **Why direct modification?** The `session_service.get_session()` method returns a *copy* of the session. Modifying that copy wouldn't affect the state used in subsequent agent runs. For this testing scenario with `InMemorySessionService`, we access the internal `sessions` dictionary to change the *actual* stored state value for `user_preference_temperature_unit` to \"Fahrenheit\". *Note: In real applications, state changes are typically triggered by tools or agent logic returning `EventActions(state_delta=...)`, not direct manual updates.*\n",
     "3.  **Check weather again (New York):** The `get_weather_stateful` tool should now read the updated \"Fahrenheit\" preference from the state and convert the temperature accordingly. The root agent's *new* response (weather in Fahrenheit) will overwrite the previous value in `state['last_weather_report']` due to the `output_key`.\n",
-    "4.  **Greet the agent:** Verify that delegation to the `greeting_agent` still works correctly alongside the stateful operations. This interaction will become the *last* response saved by `output_key` in this specific sequence.\n",
-    "5.  **Inspect final state:** After the conversation, we retrieve the session one last time (getting a copy) and print its state to confirm the `user_preference_temperature_unit` is indeed \"Fahrenheit\", observe the final value saved by `output_key` (which will be the greeting in this run), and see the `last_city_checked_stateful` value written by the tool.\n"
+    "4.  **Greet the agent:** Verify that delegation to the `greeting_agent` still works correctly alongside the stateful operations.\n",
+    "5.  **Inspect final state:** After the conversation, we retrieve the session one last time (getting a copy) and print its state to confirm the `user_preference_temperature_unit` is indeed \"Fahrenheit\", observe the final value saved by `output_key` (which will be the previous weather report in this run), and see the `last_city_checked_stateful` value written by the tool.\n"
    ]
   },
   {
@@ -1558,7 +1558,8 @@
     "        )\n",
     "\n",
     "        # 4. Test basic delegation (should still work)\n",
-    "        # This will update 'last_weather_report' again, overwriting the NY weather report\n",
+    "        # The greeting is authored by the delegated sub-agent, not the root agent,\n",
+    "        # so output_key does NOT fire: 'last_weather_report' keeps the NY report.\n",
     "        print(\"\\n--- Turn 3: Sending a greeting ---\")\n",
     "        await call_agent_async(\n",
     "            query=\"Hi!\",\n",
@@ -1637,7 +1638,7 @@
     "*   **State Read (Updated):** The tool subsequently read \"Fahrenheit\" when asked for New York's weather and performed the conversion.\n",
     "*   **Tool State Write:** The tool successfully wrote the `last_city_checked_stateful` (\"New York\" after the second weather check) into the state via `tool_context.state`.\n",
     "*   **Delegation:** The delegation to the `greeting_agent` for \"Hi!\" functioned correctly even after state modifications.\n",
-    "*   **`output_key`:** The `output_key=\"last_weather_report\"` successfully saved the root agent's *final* response for *each turn* where the root agent was the one ultimately responding. In this sequence, the last response was the greeting (\"Hello, there!\"), so that overwrote the weather report in the state key.\n",
+    "*   **`output_key`:** The `output_key=\"last_weather_report\"` successfully saved the root agent's *final* response for *each turn* where the root agent was the one ultimately responding. In this sequence, the final greeting (\"Hello, there!\") was generated by the delegated sub-agent rather than the root agent, so `output_key` was not triggered on that final turn, leaving the previous weather report intact in the session state.\n",
     "*   **Final State:** The final check confirms the preference persisted as \"Fahrenheit\".\n",
     "\n",
     "You've now successfully integrated session state to personalize agent behavior using `ToolContext`, manually manipulated state for testing `InMemorySessionService`, and observed how `output_key` provides a simple mechanism for saving the agent's last response to state. This foundational understanding of state management is key as we proceed to implement safety guardrails using callbacks in the next steps.\n",
@@ -2451,7 +2452,7 @@
     "    *   Use `after_tool_callback` to process or log the results returned by a tool.\n",
     "    *   Implement `before_agent_callback` or `after_agent_callback` for agent-level entry/exit logic.\n",
     "5.  **Error Handling:** Improve how the agent handles tool errors or unexpected API responses. Maybe add retry logic within a tool.\n",
-    "6.  **Persistent Session Storage:** Explore alternatives to `InMemorySessionService` for storing session state persistently (e.g., using databases like Firestore or Cloud SQL – requires custom implementation or future ADK integrations).\n",
+    "6.  **Persistent Session Storage:** Swap `InMemorySessionService` for one of ADK's persistent implementations – `DatabaseSessionService`, which is SQLAlchemy-backed and installed with `pip install google-adk[db]`, or `VertexAiSessionService`. See [Session](https://adk.dev/sessions/session/) for details.\n",
     "7.  **Streaming UI:** Integrate your agent team with a web framework (like FastAPI, as shown in the ADK Streaming Quickstart) to create a real-time chat interface.\n",
     "\n",
     "The Agent Development Kit provides a robust foundation for building sophisticated LLM-powered applications. By mastering the concepts covered in this tutorial – tools, state, delegation, and callbacks – you are well-equipped to tackle increasingly complex agentic systems.\n",


### PR DESCRIPTION
The `examples/python/**` snippets are pulled into the docs with `--8<--`, so a
broken snippet renders as broken documentation. 14 of them did not run, and one
did not even parse.

Verified against `google/adk-python` @ main by importing and introspecting every
symbol, not by reading. Compile sweep over `examples/python/**`: **50/64 files
parsed before, 64/64 after**.

## What was wrong

- `tools/overview/doc_analysis.py` — `await` inside a plain `def`, so the whole
  file was a `SyntaxError`; `load_artifact` and `search_memory` are coroutines
  and were not awaited; `MemoryEntry.events` does not exist (the field is
  `content`).
- `tools/overview/customer_support_agent.py` — `sub_agents` assigned after
  construction, which skips `model_post_init`'s parent linking, so
  `parent_agent` stayed `None`.
- `tools/auth/agent_cli.py`, `tools/built-in-tools/agent_search.py` —
  `create_session` is a coroutine and was not awaited, so the run raised
  `SessionNotFoundError`.
- `tools/auth/tools_and_agent.py` — `tools=toolset.get_tools()` passed a
  coroutine, raising `TypeError: 'coroutine' object is not iterable`.
- `tools/auth/helpers.py` — read the function-call arg `auth_config`, but ADK
  serialises with `by_alias=True`, so the key is `authConfig`; the helper always
  raised.
- `tools/built-in-tools/{spanner,bigtable}.py` — sync wrappers returned an
  un-awaited coroutine from `execute_sql`.
- `tools/built-in-tools/agent_search.py` — `grounding_attributions` does not
  exist on `types.GroundingMetadata`.
- `callbacks/{before,after}_agent_callback.py` — `event.is_error()` and
  `event.error_details` have never been part of the `Event` API.
- `callbacks/after_agent_callback.py` — comments said the callback *replaces*
  the agent's output; it appends a new event.
- `callbacks/after_tool_callback.py` — comments said `tool_response` is
  `{"result": <value>}`; the callback receives the raw return value.

## Also in this PR

- Files presented as complete runnable code no longer have module-level
  `await`; the driver is wrapped in `async def main()` under
  `if __name__ == "__main__"`, matching the pattern already used in each
  directory.
- 13 unguarded `event.content.parts[0].text` dereferences under
  `is_final_response()` now carry the guard already used elsewhere in this repo.
  `is_final_response()` never inspects `content`, so the unguarded form crashes
  on safety-blocked turns, state-only events and grounding-only responses.
- `tutorial/agent_team/adk_tutorial.ipynb` — the same four defects corrected in
  `docs/tutorials/agent-team.md`, so the notebook and the page agree.