### PR TITLE
Add TypeScript API reference generation script; update API audit skill

### DIFF
--- a/.agents/skills/api-reference-audit/README.md
+++ b/.agents/skills/api-reference-audit/README.md
@@ -30,6 +30,6 @@ Ask the agent naturally, for example:
 
 - Ask for the executable plan (commands, `file:line` edits, PR titles); it emits
   this only when you ask.
-- Run the self-serve scripts (Python, Kotlin), wait on the owning team's PR
-  (Java, TypeScript), or update manually (Agent Config).
+- Run the self-serve scripts (Python, Kotlin, TypeScript), wait on the owning
+  team's PR (Java), or update manually (Agent Config).
 - Have the agent execute the plan.

--- a/.agents/skills/api-reference-audit/SKILL.md
+++ b/.agents/skills/api-reference-audit/SKILL.md
@@ -41,7 +41,7 @@ against the latest upstream release and package registry.
 | Python CLI | `docs/api-reference/cli/_static/documentation_options.js` (`VERSION:`) and `docs/api-reference/cli/index.html` ("ADK X.Y.Z") | `google/adk-python` | PyPI `google-adk` |
 | Python REST API | `docs/api-reference/rest/openapi.json` (`info.version`) | `google/adk-python` | PyPI `google-adk` |
 | Python Agent Config | no version marker; diff the type set in `agentconfig/index.html` against upstream `AgentConfig.json` | `google/adk-python` (same release as Python API/CLI/REST) | n/a |
-| TypeScript | `docs/api-reference/typescript/variables/version.html` (the `version` const) | `google/adk-js` (monorepo; see note) | npm `@google/adk` (authoritative) |
+| TypeScript | `docs/api-reference/typescript/variables/version.html` (the `version` const); cross-check `docs/api-reference/typescript/index.html` (`<title>` "... - vX.Y.Z") | `google/adk-js` (monorepo; see note) | npm `@google/adk` (authoritative) |
 | Go | external, hosted on `pkg.go.dev`; verify links in `docs/api-reference/index.md` | `google/adk-go` | `pkg.go.dev` |
 | Java | `docs/api-reference/java/index.html` (`<title>` "Maven Parent POM X.Y.Z API") | `google/adk-java` (authoritative) | Maven Central `com.google.adk:google-adk` (lags; cross-check only) |
 | Kotlin | `docs/api-reference/kotlin/index.html` (version string near the header) | `google/adk-kotlin` (authoritative) | Maven Central `com.google.adk:google-adk-kotlin-core` (lags; cross-check only) |
@@ -60,9 +60,12 @@ Notes:
   vice versa) is drift.
 - TypeScript: use npm `@google/adk` `dist-tags.latest` as the authoritative
   version. adk-js is a monorepo with package-prefixed tags (e.g. `main-v1.4.0`,
-  `integrations-v1.4.0`), so `gh ... releases/latest` can return an unrelated
-  package. The in-repo const and npm share one scheme (`0.5.0` -> `1.4.0`), so a
-  large gap means the docs are genuinely stale, not mis-versioned.
+  `integrations-v1.4.0`), so `gh ... releases/latest` can return a release for a
+  different package instead of `@google/adk`. The in-repo `version` const tracks
+  the same `@google/adk` package npm publishes and releases together with it, so
+  compare the two directly: any version difference means the docs are behind.
+  The generate script clones the `adk-v<version>` tag (the core `@google/adk`
+  package tag).
 - Go docs are not built into this repo. Confirm the release version and that the
   `index.md` links point at the correct major versions (e.g. v2.x and v1.x). Go
   versions are also pinned in `examples/go/go.mod` / `go.sum` and appear as
@@ -117,8 +120,12 @@ process.
 - **Python Agent Config**: regenerated from the adk-python schema with
   `json-schema-for-humans`; no `tools/` generate script exists yet, so treat the
   update as manual.
-- **TypeScript**: the adk-js team opens a PR in this repo with the built TypeDoc
-  assets. Not self-serve here.
+- **TypeScript**: self-serve, one PR. Run `bash
+  tools/typescript-api-docs/generate.sh <version>` (where `<version>` is the npm
+  `@google/adk` version from the audit), then open a PR. The script clones the
+  adk-js `adk-v<version>` tag, adds the version to the page title via TypeDoc's
+  `--includeVersion`, and injects the Google Analytics tag into every HTML file
+  (awk post-processing).
 - **Java**: two separate PRs per release. The adk-java team pushes the built
   Javadoc assets (title `chore: update ADK Java doc to version <X>`); the docs
   maintainer bumps the hardcoded dependency versions and `pom.xml` values (title
@@ -137,6 +144,7 @@ process.
     - `gh pr list --repo google/adk-docs --state merged --search "Kotlin"`
     - `gh pr list --repo google/adk-docs --state merged --search "CLI reference"`
     - `gh pr list --repo google/adk-docs --state merged --search "Java"`
+    - `gh pr list --repo google/adk-docs --state merged --search "TypeScript"`
 
 ## Audit workflow
 
@@ -248,8 +256,9 @@ surface:
     - `bash tools/python-cli-docs/generate.sh <new-version>`
     - `bash tools/python-rest-api-docs/generate.sh <new-version>`
     - `bash tools/kotlin-api-docs/generate.sh <new-version>`
-- For team-owned surfaces (Java, TypeScript), state that the update is blocked
-  on the owning team's asset PR and what to request or wait for.
+    - `bash tools/typescript-api-docs/generate.sh <new-version>`
+- For team-owned surfaces (Java), state that the update is blocked on the owning
+  team's asset PR and what to request or wait for.
 - For hardcoded versions, the precise `file:line` edits (old -> new), including
   `examples/java/**/pom.xml`.
 - Which surfaces move together (Python API, CLI, and REST share one `adk-python`
@@ -269,6 +278,7 @@ Match the established titles so history stays searchable:
 - Python API: `Update API reference docs for ADK Python <X.Y.Z>`
 - Python CLI: `Update CLI reference docs for ADK Python <X.Y.Z>`
 - Python REST API: `Update REST API reference docs for ADK Python <X.Y.Z>`
+- TypeScript: `Update API reference docs for ADK TypeScript <X.Y.Z>`
 - Java dependency bump: `Update ADK Java dependency versions to <X.Y.Z>`
 - Kotlin: `Update ADK Kotlin to <X.Y.Z>`
 

--- a/tools/typescript-api-docs/generate.sh
+++ b/tools/typescript-api-docs/generate.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Generates TypeScript API reference documentation for adk-js using TypeDoc.
+# Outputs HTML to docs/api-reference/typescript/.
+#
+# This script runs in an isolated temporary directory and does not
+# modify any existing adk-js clones or local Node environments. The npm
+# cache is redirected into the temp workspace, so nothing on the host is
+# modified (no global installs, no changes to ~/.npm).
+#
+# Prerequisites: node (18+), npm, git
+# Run from: adk-docs repository root
+#
+# The <version> is the @google/adk (core) package version; the script clones
+# the corresponding adk-vX.Y.Z release tag.
+#
+# Usage: bash tools/typescript-api-docs/generate.sh <version>
+# Example: bash tools/typescript-api-docs/generate.sh 1.5.0
+
+set -e
+
+# Validate arguments
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: $0 <version>"
+  echo "Example: $0 1.5.0"
+  exit 1
+fi
+
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: Version must be in X.Y.Z format (e.g., 1.5.0)"
+  exit 1
+fi
+
+# Check prerequisites
+for cmd in node npm git; do
+  if ! command -v "$cmd" &> /dev/null; then
+    echo "Error: $cmd is required but not installed."
+    if [[ "$cmd" == "node" || "$cmd" == "npm" ]]; then
+      echo "  Install with: brew install node"
+    fi
+    exit 1
+  fi
+done
+
+# Validate working directory
+TARGET_DIR="docs/api-reference/typescript"
+if [[ ! -d "$TARGET_DIR" ]]; then
+  echo "Error: Run this script from the adk-docs repository root."
+  exit 1
+fi
+
+# Create temp workspace
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+echo "Using temp workspace: $WORK_DIR"
+
+# Isolate the npm cache inside the temp workspace so the host's ~/.npm is
+# left untouched (throwaway, clean-room build).
+export npm_config_cache="$WORK_DIR/.npm-cache"
+
+# Build docs in temp workspace
+pushd "$WORK_DIR" > /dev/null || exit 1
+
+# Clone adk-js
+#
+# adk-js is a release-please monorepo with per-package, linked-version tags.
+# The core package (@google/adk, whose sources feed the TypeDoc docs) is
+# tagged adk-vX.Y.Z. All component tags for a release point to the same
+# commit, so adk-v<version> is the correct, package-aligned ref.
+echo "Cloning adk-js adk-v${VERSION}..."
+git clone --depth 1 --branch "adk-v${VERSION}" https://github.com/google/adk-js adk-js
+cd adk-js
+
+# Install dependencies (reproducible; package-lock.json ships in the repo)
+echo "Installing dependencies..."
+npm ci
+
+# Build TypeDoc HTML docs (writes to api-reference/typescript/ in the clone).
+# --includeVersion appends the @google/adk package version (from core/package.json,
+# which matches the cloned adk-v<version> tag) to the header title.
+echo "Building TypeScript API docs with TypeDoc..."
+npm run docs:generate -- --includeVersion
+
+popd > /dev/null || exit 1
+
+# Copy to output directory
+echo "Copying to $TARGET_DIR..."
+rm -rf "$TARGET_DIR"/*
+cp -r "$WORK_DIR/adk-js/api-reference/typescript"/* "$TARGET_DIR/"
+
+# Add Google Analytics tag to generated HTML files
+echo "Adding Google Analytics tag..."
+GA_TAG_FILE=$(mktemp)
+cat > "$GA_TAG_FILE" <<'EOF'
+<!-- Google Analytics tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-DKHZS27PHP"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-DKHZS27PHP');
+</script>
+EOF
+GA_TAG=$(<"$GA_TAG_FILE")
+rm -f "$GA_TAG_FILE"
+export GA_TAG
+find "$TARGET_DIR" -name '*.html' -print0 | while IFS= read -r -d '' file; do
+  awk 'BEGIN{tag=ENVIRON["GA_TAG"]} {gsub(/<\/head>/, "\n" tag "\n</head>")}1' "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+done
+
+echo "Done."


### PR DESCRIPTION
This PR adds a self-serve generation script for the TypeScript API reference docs and updates the `api-reference-audit` skill to reflect this new generation script for ADK TS API reference docs. This makes the surface self-serve like Python and Kotlin, and keeps the audit skill's guidance accurate.

The script mirrors the existing API doc generator scripts:

- Takes an adk-js `<version>` as input
- Runs in an isolated temp workspace
- Clones adk-js at the `adk-v<version>` tag
- Builds via the repo's own TypeDoc config (`npm run docs:generate`) with `--includeVersion` so the package version appears in the page title.
- Injects Google Analytics tag into generated HTML files