### PR TITLE
fix: make process_document async in doc_analysis example

### DIFF
--- a/examples/python/snippets/tools/overview/doc_analysis.py
+++ b/examples/python/snippets/tools/overview/doc_analysis.py
@@ -16,14 +16,14 @@ from google.adk.tools import ToolContext, FunctionTool
 from google.genai import types
 
 
-def process_document(
+async def process_document(
     document_name: str, analysis_query: str, tool_context: ToolContext
 ) -> dict:
     """Analyzes a document using context from memory."""
 
     # 1. Load the artifact
     print(f"Tool: Attempting to load artifact: {document_name}")
-    document_part = tool_context.load_artifact(document_name)
+    document_part = await tool_context.load_artifact(document_name)
 
     if not document_part:
         return {"status": "error", "message": f"Document '{document_name}' not found."}
@@ -33,7 +33,7 @@ def process_document(
 
     # 2. Search memory for related context
     print(f"Tool: Searching memory for context related to: '{analysis_query}'")
-    memory_response = tool_context.search_memory(
+    memory_response = await tool_context.search_memory(
         f"Context for analyzing document about {analysis_query}"
     )
     memory_context = "\n".join(


### PR DESCRIPTION
## Problem

The \doc_analysis.py\ snippet in \docs/tools-custom/index.md\ is broken:

1. \process_document\ is a synchronous function but uses \wait\ on \	ool_context.save_artifact\ — this is a \SyntaxError\ and the file cannot even be parsed.
2. \	ool_context.load_artifact\ and \	ool_context.search_memory\ are async methods (see \docs/artifacts/index.md\ which uses \wait context.load_artifact(...)\) but are called without \wait\, returning coroutines instead of results.

## Fix

Made \process_document\ an \sync def\ and added \wait\ to all three \ToolContext\ calls, matching the fully-async TypeScript and Java equivalents (\doc_analysis.ts\, \processDocument\).

## Why it matters

The code is embedded verbatim on the Tools overview page. Readers who copy it get a parse error / \RuntimeWarning: coroutine was never awaited\ and assume their setup is wrong.