### PR TITLE
docs: clarify that MCP client deps require the [mcp] extra

### DIFF
--- a/docs/tools-custom/mcp-tools.md
+++ b/docs/tools-custom/mcp-tools.md
@@ -48,6 +48,18 @@ Before you begin, ensure you have the following set up:
 
 * **Set up ADK:** Follow the standard ADK [setup instructions](../get-started/index.md) in the quickstart.
 * **Install/update Python/Java:** MCP requires Python version of 3.9 or higher for Python or Java 17 or higher.
+* **Install the MCP client extra (Python only):** A plain `pip install google-adk` does **not** install the MCP client dependencies. Without them, `google.adk.tools.mcp_tool` silently omits its MCP classes, so imports like `from google.adk.tools.mcp_tool import McpToolset` fail with:
+  ```text
+  ImportError: cannot import name 'McpToolset' from 'google.adk.tools.mcp_tool'
+  ```
+  even though ADK itself installed without error. Install ADK with the `mcp` extra instead:
+  ```shell
+  pip install "google-adk[mcp]"
+  ```
+  If you already have `google-adk` installed without the extra, reinstall it:
+  ```shell
+  pip install "google-adk[mcp]" --upgrade
+  ```
 * **Setup Node.js and npx:** **(Python only)** Many community MCP servers are distributed as Node.js packages and run using `npx`. Install Node.js (which includes npx) if you haven't already. For details, see [https://nodejs.org/en](https://nodejs.org/en).
 * **Verify Installations:** **(Python only)** Confirm `adk` and `npx` are in your PATH within the activated virtual environment:
 


### PR DESCRIPTION
## Problem

The Prerequisites section of the MCP Tools guide does not mention that
`google-adk` needs to be installed with its `mcp` extra for the MCP
client classes to be importable.

A plain install:

    pip install google-adk

does **not** pull in the MCP client dependencies. When they're missing,
`google.adk.tools.mcp_tool` silently omits `McpToolset` from its
namespace instead of raising a clear error at install time. Every code
sample on this page does `from google.adk.tools.mcp_tool import McpToolset`
as if it's available by default, so following the guide as written
produces:

    ImportError: cannot import name 'McpToolset' from 'google.adk.tools.mcp_tool'

even though `adk` itself is correctly installed and importable.

## Fix

Add a bullet to the Prerequisites section documenting the correct
install command:

    pip install "google-adk[mcp]"

and a short explanation of why the plain install fails, including the
exact error text so it's searchable for anyone who hits this and lands
on this PR/page via search.

## Testing

Reproduced the ImportError locally with a plain `google-adk` install,
confirmed installing with the `[mcp]` extra resolves it.