### PR TITLE
docs(get-started): make the TypeScript quickstart true — Node version, credentials, and expected output

### DIFF
--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -13,7 +13,7 @@ set up and running a simple agent in less than 20 minutes.
 
     [:octicons-arrow-right-24: Start with Python](python.md) <br>
 
--   :fontawesome-brands-js:{ .lg .middle } **TypeScript Quickstart**
+-   :simple-typescript:{ .lg .middle } **TypeScript Quickstart**
 
     ---
     Create your first TypeScript ADK agent in minutes.

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -48,10 +48,40 @@ across supported languages. For a guided introduction, start with the
 
 === "TypeScript"
 
-    **Install ADK and ADK DevTools**
+    **Prerequisites:** Node.js 22 or later.
+
+    **Install ADK, Zod, and ADK DevTools**
+
+    === "npm"
+
+        ```bash
+        npm install @google/adk zod
+        npm install -D @google/adk-devtools
+        ```
+
+    === "pnpm"
+
+        ```bash
+        pnpm add @google/adk zod
+        pnpm add -D @google/adk-devtools
+        pnpm approve-builds --all
+        ```
+
+    === "yarn"
+
+        ```bash
+        yarn config set nodeLinker node-modules
+        yarn add @google/adk zod
+        yarn add -D @google/adk-devtools
+        ```
+
+    Install `zod` explicitly: agents import it directly to declare tool
+    parameters, and pnpm and yarn will not resolve it from `@google/adk`.
+
+    (Optional) Verify your installation:
 
     ```bash
-    npm install @google/adk @google/adk-devtools
+    npx adk --version
     ```
 
 === "Go"

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -48,40 +48,10 @@ across supported languages. For a guided introduction, start with the
 
 === "TypeScript"
 
-    **Prerequisites:** Node.js 22 or later.
-
-    **Install ADK, Zod, and ADK DevTools**
-
-    === "npm"
-
-        ```bash
-        npm install @google/adk zod
-        npm install -D @google/adk-devtools
-        ```
-
-    === "pnpm"
-
-        ```bash
-        pnpm add @google/adk zod
-        pnpm add -D @google/adk-devtools
-        pnpm approve-builds --all
-        ```
-
-    === "yarn"
-
-        ```bash
-        yarn config set nodeLinker node-modules
-        yarn add @google/adk zod
-        yarn add -D @google/adk-devtools
-        ```
-
-    Install `zod` explicitly: agents import it directly to declare tool
-    parameters, and pnpm and yarn will not resolve it from `@google/adk`.
-
-    (Optional) Verify your installation:
+    **Install ADK and ADK DevTools**
 
     ```bash
-    npx adk --version
+    npm install @google/adk zod @google/adk-devtools
     ```
 
 === "Go"

--- a/docs/get-started/typescript.md
+++ b/docs/get-started/typescript.md
@@ -1,24 +1,58 @@
 # TypeScript Quickstart for ADK
 
-In this quickstart you build an agent that answers a question by calling a
-TypeScript function you wrote, and then talk to it from your terminal. Four
-steps, one file.
+This guide shows you how to get up and running with Agent Development Kit
+for TypeScript. Before you start, make sure you have the following installed:
 
-**Prerequisites**
+*   Node.js 22 or later
+*   Node Package Manager (npm) 9 or later
 
-*   **Node.js 22 or later.** Check with `node --version`. This guide was
-    verified end to end on Node.js v22.22.2 with npm 9.2.0.
-*   **npm, pnpm, or yarn.** Every command below is given for all three.
-*   **A Gemini API key.** Create one in Google AI Studio on the
-    [API Keys](https://aistudio.google.com/app/apikey) page. If you would rather
-    authenticate with Google Cloud, [step 3](#3-set-your-credentials) covers
-    that too.
+## Create an agent project
 
-## 1. Write the agent
+Create an empty `my-agent` directory for your project:
 
-Create a `my-agent` directory, and inside it an `agent.ts` file containing a
-[Function Tool](/tools-custom/function-tools/) named `getCurrentTime` and an
-agent that uses it:
+```none
+my-agent/
+```
+
+??? tip "Create this project structure using the command line"
+
+    === "MacOS / Linux"
+
+        ```bash
+        mkdir -p my-agent/
+        ```
+
+    === "Windows"
+
+        ```console
+        mkdir my-agent
+        ```
+
+### Configure project and dependencies
+
+Use the `npm` tool to install and configure dependencies for your project,
+including the package file, ADK TypeScript main
+library, and developer tools. Run the following commands from your
+`my-agent/` directory to create the `package.json` file and install the
+project dependencies:
+
+```console
+cd my-agent/
+# initialize a project as an ES module
+npm init --yes
+npm pkg set type="module"
+npm pkg set main="agent.ts"
+# install ADK libraries
+npm install @google/adk zod
+# install dev tools as a dev dependency
+npm install -D @google/adk-devtools
+```
+
+### Define the agent code
+
+Create the code for a basic agent, including a simple implementation of an ADK
+[Function Tool](/tools-custom/function-tools/), called `getCurrentTime`.
+Create an `agent.ts` file in your project directory and add the following code:
 
 ```typescript title="my-agent/agent.ts"
 import {FunctionTool, LlmAgent} from '@google/adk';
@@ -37,7 +71,7 @@ const getCurrentTime = new FunctionTool({
 });
 
 export const rootAgent = new LlmAgent({
-  name: 'helloTimeAgent',
+  name: 'hello_time_agent',
   model: 'gemini-flash-latest',
   description: 'Tells the current time in a specified city.',
   instruction: `You are a helpful assistant that tells the current time in a city.
@@ -46,249 +80,67 @@ export const rootAgent = new LlmAgent({
 });
 ```
 
-Let's take a look at what is happening in this code:
+### Set your API key
 
-1.  `name: 'getCurrentTime'` is the identifier the model uses to call the tool,
-    and `description` is how it decides *when* to call it. The `instruction`
-    on the agent names the same string, `getCurrentTime`. If those two strings
-    disagree, the model asks for a tool that does not exist and your function
-    never runs.
-2.  `parameters` is a Zod schema, and it is the tool's whole input contract:
-    ADK turns it into the function declaration sent to the model, validates the
-    model's arguments against it, and infers the type of `execute`'s argument
-    from it. In `execute: ({city}) =>`, `city` is already typed `string` — you
-    never declare that type twice.
-3.  `execute` returns a plain object. ADK serializes it and hands it back to the
-    model, which turns it into the sentence you see.
-4.  `LlmAgent` binds the three things an agent needs: a `model`, an
-    `instruction`, and its `tools`.
-5.  Name the export `rootAgent`. That is a convention, not a requirement: the
-    loader takes the export called `rootAgent` if there is one, otherwise a
-    default export, otherwise the only exported agent whatever it is called.
-    The name only decides the winner when one file exports *several* agents —
-    then `rootAgent` wins, and without one the loader picks the alphabetically
-    first export name and warns `Multiple agents found in ... Using the <name>
-    as a root agent.` A file exporting no agent at all fails with
-    `AgentFileLoadingError`.
+This project uses the Gemini API, which requires an API key. If you
+don't already have Gemini API key, create a key in Google AI Studio on the
+[API Keys](https://aistudio.google.com/app/apikey) page.
 
-## 2. Install dependencies
+In a terminal window, write your API key into your `.env` file of your project
+to set environment variables:
 
-Move into the project directory and install:
+=== "MacOS / Linux"
 
-=== "npm"
-
-    ```console
-    cd my-agent/
-    npm init --yes
-    npm pkg set type="module" main="agent.ts"
-    npm install @google/adk zod
-    npm install -D @google/adk-devtools
+    ```bash title="Update: my-agent/.env"
+    echo 'GEMINI_API_KEY="YOUR_API_KEY"' > .env
     ```
 
-=== "pnpm"
+=== "Windows PowerShell"
 
-    ```console
-    cd my-agent/
-    pnpm init
-    pnpm pkg set type="module" main="agent.ts"
-    pnpm add @google/adk zod
-    pnpm add -D @google/adk-devtools
-    pnpm approve-builds --all
+    ```console title="Update: my-agent/.env"
+    echo 'GEMINI_API_KEY="YOUR_API_KEY"' > .env
     ```
 
-    Five packages ship install scripts, which pnpm blocks by default. pnpm
-    prints the list after each install; once both are done it reads:
+=== "Windows Command Prompt"
 
-    ```console
-    [ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @google/genai@1.52.0, @google/genai@2.15.0, esbuild@0.25.12, protobufjs@7.6.5, sqlite3@5.1.7
+    ```console title="Update: my-agent/.env"
+    echo GEMINI_API_KEY="YOUR_API_KEY" > .env
     ```
-
-    `@google/genai` is listed twice because `@google/adk` and
-    `@google/adk-devtools` pull different majors of it, and `esbuild` is missing
-    from the earlier list — the one after `pnpm add @google/adk zod` — because it
-    arrives with the devtools. Until you approve them, every `pnpm exec` fails
-    its dependency check with that same message before running anything.
-
-=== "yarn"
-
-    ```console
-    cd my-agent/
-    yarn init -2
-    yarn config set nodeLinker node-modules
-    npm pkg set type="module" main="agent.ts"
-    yarn add @google/adk zod
-    yarn add -D @google/adk-devtools
-    ```
-
-    Yarn's default Plug'n'Play linker cannot load `@google/adk-devtools`, so set
-    `nodeLinker` to `node-modules` before installing. See
-    [Troubleshooting](#troubleshooting) for the error you get if you skip it.
-
-Three packages, and each one earns its place:
-
-*   `@google/adk` is the agent framework — `LlmAgent`, `FunctionTool`, and the
-    Gemini model layer.
-*   `zod` is imported directly by your `agent.ts`, so it has to be a dependency
-    of *your* project. npm happens to hoist it out of `@google/adk`, but pnpm
-    and yarn will not, and your agent will fail to build.
-*   `@google/adk-devtools` provides the `adk` command used in step 4. It is a
-    dev dependency; your deployed agent does not need it.
-
-**You should see:** a `node_modules/` directory, and `npx adk --version`
-(`pnpm exec adk --version`, `yarn adk --version`) printing `1.5.0`.
-
-## 3. Set your credentials
-
-ADK for TypeScript reads its credentials from the process environment, and from
-a `.env` file in the directory you run the command from — which is `my-agent/`,
-because that is where step 4 tells you to run. Create `my-agent/.env`:
-
-=== "Gemini API key"
-
-    ```console title="my-agent/.env"
-    GOOGLE_GENAI_API_KEY="PASTE_YOUR_API_KEY_HERE"
-    ```
-
-    Replace `PASTE_YOUR_API_KEY_HERE` with the key you created in
-    [Google AI Studio](https://aistudio.google.com/app/apikey). `GEMINI_API_KEY`
-    is accepted as an alias for exactly the same purpose; pick one.
-
-=== "Google Cloud Agent Platform"
-
-    Authenticate your workstation with Application Default Credentials first:
-
-    ```console
-    gcloud auth application-default login
-    ```
-
-    Then enable the API your agent will call on the project you are about to
-    name. A project without it does not produce an error — it produces the
-    silent failure described in [step 4](#4-run-your-agent):
-
-    ```console
-    gcloud services enable aiplatform.googleapis.com --project=your-project-id
-    ```
-
-    Now create the `.env` file:
-
-    ```console title="my-agent/.env"
-    GOOGLE_GENAI_USE_VERTEXAI=TRUE
-    GOOGLE_CLOUD_PROJECT=your-project-id
-    GOOGLE_CLOUD_LOCATION=global
-    ```
-
-    Use `GOOGLE_GENAI_USE_VERTEXAI`. ADK for TypeScript does not read
-    `GOOGLE_GENAI_USE_ENTERPRISE`; setting only that one leaves the agent
-    looking for an API key it will not find. A regional
-    `GOOGLE_CLOUD_LOCATION` such as `us-central1` also needs a versioned model
-    string — change `model` to `gemini-2.5-flash`, because
-    `gemini-flash-latest` does not resolve on regional endpoints.
-
-!!! warning "Your shell wins over `.env`"
-
-    `.env` is loaded without overriding, so a variable already exported in your
-    shell keeps its value and the line in `.env` is ignored. This matters most
-    on the Google Cloud path: many Cloud workstations already export
-    `GOOGLE_CLOUD_PROJECT`, so the quickstart can succeed against *that* project
-    while the `.env` you just wrote does nothing — and then fail for the next
-    person who copies your file. Before you run, check what is already set:
-
-    ```console
-    env | grep -E '^(GOOGLE_|GEMINI_)'
-    ```
-
-    Anything printed there overrides `.env`. `unset` it, or set the value you
-    actually want in the shell rather than in the file.
-
-!!! warning "`GOOGLE_API_KEY` is not one of the names"
-
-    On the Gemini API path, ADK for TypeScript reads `GOOGLE_GENAI_API_KEY` or
-    `GEMINI_API_KEY` and nothing else. Setting `GOOGLE_API_KEY` fails with
-    `Error: API key must be provided via constructor or GOOGLE_GENAI_API_KEY or
-    GEMINI_API_KEY environment variable.` Other pages in these docs show
-    `GOOGLE_API_KEY`; on this path it does not work.
-
-Add `.env` to your `.gitignore` before you commit anything.
 
 ??? tip "Using other AI models with ADK"
     ADK supports the use of many generative AI models. For more
     information on configuring other models in ADK agents, see
     [Models & Authentication](/agents/models).
 
-## 4. Run your agent
+## Run your agent
 
-`@google/adk-devtools` gives you two ways to talk to the agent: an interactive
-terminal session with `adk run`, and a browser chat UI with `adk web`.
+You can run your ADK agent with the `@google/adk-devtools` library as an
+interactive command-line interface using the `run` command or the ADK web user
+interface using the `web` command. Both these options allow you to test and
+interact with your agent.
 
-### Run with the command-line interface
+### Run with command-line interface
 
-Run this from `my-agent/`, the directory that has `node_modules/` in it:
+Run your agent with the ADK TypeScript command-line interface tool
+using the following command:
 
-=== "npm"
-
-    ```console
-    npx adk run agent.ts
-    ```
-
-=== "pnpm"
-
-    ```console
-    pnpm exec adk run agent.ts
-    ```
-
-=== "yarn"
-
-    ```console
-    yarn adk run agent.ts
-    ```
-
-Type a question at the `[user]:` prompt and press Enter. A working session looks
-like this:
-
-```console title="Expected output"
-(node:4048641) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
-(Use `node --trace-deprecation ...` to show where the warning was created)
-Running agent helloTimeAgent, type exit to exit.
-[user]: What time is it in Paris?
-INFO: [ADK] 2026-08-05T17:41:51.838Z Sending out request, model: gemini-flash-latest, backend: GEMINI_API, stream: false
-INFO: [ADK] 2026-08-05T17:41:52.665Z Sending out request, model: gemini-flash-latest, backend: GEMINI_API, stream: false
-[helloTimeAgent]: The current time in Paris is 10:30 AM
-[user]: exit
+```console
+npx adk run agent.ts
 ```
 
-Do not compare that character by character. The two `punycode` lines come from
-Node, not from ADK — they precede *every* `adk` command on Node 22, the process
-id in them changes each run, and more Node warnings may join them. The
-timestamps are yours, and the model rephrases the last line freely.
+![adk-run.png](/assets/adk-run.png)
 
-**You should see** two `INFO` lines and then a `[helloTimeAgent]:` line carrying
-the answer. Two requests is the tool call working: the first asks the model what
-to do, the model asks for `getCurrentTime`, and the second sends your function's
-result back for the model to phrase. On the Google Cloud path the same run
-prints `backend: VERTEX_AI` instead of `backend: GEMINI_API`.
+### Run with web interface
 
-**If it fails you will not get an error.** ADK for TypeScript 1.5.0 prints one
-`INFO` line, returns you to the `[user]:` prompt with no answer, and exits with
-status `0`. The silence means the model request was rejected and ADK discarded
-the reason. It is *not* specific to a bad key: an unusable API key, a project
-your credentials cannot reach, a project without `aiplatform.googleapis.com`
-enabled, and a model name that does not exist in your region are all
-indistinguishable at the terminal. See
-[Troubleshooting](#troubleshooting) for a command that prints the real error.
-
-### Run with the web interface
+Run your agent with the ADK web interface using the following command:
 
 ```console
 npx adk web
 ```
 
-This starts a server on `http://localhost:8000`; pass `--port 8001` (or `-p`) to
-use a different one. Open it and you should see a dark chat page titled
-**Agent Development Kit**, with an app selector in the top left already showing
-`agent` — the name comes from your `agent.ts` filename, not from
-`rootAgent.name`. Type into **Type a message...** at the bottom. The event list
-shows your message, then a `getCurrentTime("Paris")` call, then the tool's
-result, then the answer.
+This command starts a web server with a chat interface for your agent. You can
+access the web interface at `http://localhost:8000`. Select your agent at the
+upper right corner and type a request.
 
 ![adk-web-dev-ui-chat.png](/assets/adk-web-dev-ui-chat.png)
 
@@ -297,135 +149,9 @@ result, then the answer.
     ADK Web is ***not meant for use in production deployments***. You should
     use ADK Web for development and debugging purposes only.
 
-## Troubleshooting
+## Next: Build your agent
 
-**One `INFO` line, no answer, and exit code `0`.**
+Now that you have ADK installed and your first agent running, try building
+your own agent with our build guides:
 
-The model request was rejected and ADK discarded the reason, so the terminal
-shows you nothing. At least four different causes produce this identical
-silence, and you cannot tell them apart from the output:
-
-*   an API key that the Gemini API rejects, or one whose project has the API
-    disabled;
-*   a `GOOGLE_CLOUD_PROJECT` your credentials are not authorized to use;
-*   a `GOOGLE_CLOUD_PROJECT` that does not have `aiplatform.googleapis.com`
-    enabled;
-*   a `model` string that does not exist at your `GOOGLE_CLOUD_LOCATION` —
-    notably `gemini-flash-latest`, which resolves on `global` but **not** on a
-    regional endpoint such as `us-central1`.
-
-Send the same request yourself to see the error ADK hid. On the Gemini API path:
-
-```console
-curl -s -X POST -H 'Content-Type: application/json' \
-  "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent?key=$GOOGLE_GENAI_API_KEY" \
-  -d '{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}'
-```
-
-On the Google Cloud path (use `LOCATION-aiplatform.googleapis.com` for a
-regional `GOOGLE_CLOUD_LOCATION`):
-
-```console
-curl -s -X POST -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
-  -H 'Content-Type: application/json' \
-  "https://aiplatform.googleapis.com/v1/projects/$GOOGLE_CLOUD_PROJECT/locations/$GOOGLE_CLOUD_LOCATION/publishers/google/models/gemini-flash-latest:generateContent" \
-  -d '{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}'
-```
-
-You get back the message ADK swallowed — `API key not valid. Please pass a valid
-API key.`, `Permission denied on resource project <id>.`, ``Publisher model
-`...` was not found or your project does not have access to it``, or `Agent
-Platform API has not been used in project <id> before or it is disabled.` —
-which each point at one of the four causes above. Fix that last one with
-`gcloud services enable aiplatform.googleapis.com --project=your-project-id`;
-`gcloud services list --enabled --project=your-project-id` shows what a project
-already has. To check whether your credential is being read at all, temporarily
-remove it: with nothing set, the run fails loudly with `API key must be
-provided` instead of going quiet.
-
-**`Error: API key must be provided via constructor or GOOGLE_GENAI_API_KEY or GEMINI_API_KEY environment variable.`**
-
-No credential was found under a name ADK reads. You set `GOOGLE_API_KEY`, or
-you set `GOOGLE_GENAI_USE_ENTERPRISE` instead of `GOOGLE_GENAI_USE_VERTEXAI`,
-or your `.env` is not in the directory you ran the command from.
-
-**`Error: VertexAI project must be provided via constructor or GOOGLE_CLOUD_PROJECT environment variable.`**
-
-`GOOGLE_GENAI_USE_VERTEXAI` is set but `GOOGLE_CLOUD_PROJECT` is missing.
-
-**`Error: VertexAI location must be provided via constructor or GOOGLE_CLOUD_LOCATION environment variable.`**
-
-The same, for `GOOGLE_CLOUD_LOCATION`. Both variables are required on the Google
-Cloud path and each one has its own error; setting only the project gets you
-this one. Use `global` unless you need a specific region.
-
-**`npm ERR! could not determine executable to run`**
-
-`npx adk` did not find the local `adk` binary and reached for a package named
-`adk` on the public registry — an unrelated third-party package that has nothing
-to do with ADK. Run the command from the directory that contains
-`node_modules/`, or invoke the binary directly with
-`./node_modules/.bin/adk run agent.ts`.
-
-**`✘ [ERROR] Could not resolve "zod"`**
-
-`zod` is not a dependency of your project. Run `npm install zod` (or the pnpm
-or yarn equivalent). npm's flat `node_modules` can mask this; pnpm and yarn
-will not.
-
-**`Error: @google/adk-devtools tried to access @opentelemetry/api, but it isn't declared in its dependencies`**
-
-You are on Yarn's Plug'n'Play linker. Run `yarn config set nodeLinker
-node-modules` and reinstall.
-
-**`[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @google/genai@1.52.0, @google/genai@2.15.0, esbuild@0.25.12, protobufjs@7.6.5, sqlite3@5.1.7`**
-
-pnpm blocked those install scripts, and that makes `pnpm exec` fail its
-dependency check before it runs anything. Run `pnpm approve-builds --all` once.
-The exact versions move; the set does not.
-
-**`[ADK CLI] Error starting web server: Port 8000 is already in use`**
-
-Something already holds port 8000 — often an `adk web` you left running in
-another terminal. Either serve on another port:
-
-```console
-npx adk web --port 8001
-```
-
-or find and stop what is holding 8000 first:
-
-```console
-lsof -ti :8000        # prints the process id
-kill $(lsof -ti :8000)
-```
-
-`adk web` does not fall back to a free port on its own; it prints that line and
-exits.
-
-**`TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"`**
-
-You ran `node agent.ts`. Node does not execute TypeScript here, and `agent.ts`
-only exports an agent — it has no entry point. Use `adk run agent.ts`, which
-compiles the file before loading it.
-
-**`AgentFileLoadingError`** ending in **`does not exists`**
-
-Wrong path or wrong extension. The argument to `adk run` is the path to your
-TypeScript source, `agent.ts`.
-
-**`DeprecationWarning: The 'punycode' module is deprecated`**
-
-Harmless. It comes from a transitive dependency on Node 22 and does not affect
-your agent.
-
-## Next steps
-
-This quickstart gets one agent answering in your terminal. To serve it over HTTP
-instead of a REPL, see [Run an API server](/runtime/api-server/).
-
-*   [Give your agent a tool that calls a real API](/tools-custom/function-tools/)
-*   [Keep context across turns with session state](/sessions/state/)
-*   [Split the work across several agents](/workflows/patterns/)
-*   [Deploy your agent to Cloud Run](/deploy/cloud-run/)
-*   [Build a complete agent step by step](/tutorials/)
+*  [Build your agent](/tutorials/)

--- a/docs/get-started/typescript.md
+++ b/docs/get-started/typescript.md
@@ -62,8 +62,14 @@ Let's take a look at what is happening in this code:
     model, which turns it into the sentence you see.
 4.  `LlmAgent` binds the three things an agent needs: a `model`, an
     `instruction`, and its `tools`.
-5.  The export **must** be named `rootAgent`. Both `adk run` and `adk web` look
-    for that exact export and fail without it.
+5.  Name the export `rootAgent`. That is a convention, not a requirement: the
+    loader takes the export called `rootAgent` if there is one, otherwise a
+    default export, otherwise the only exported agent whatever it is called.
+    The name only decides the winner when one file exports *several* agents —
+    then `rootAgent` wins, and without one the loader picks the alphabetically
+    first export name and warns `Multiple agents found in ... Using the <name>
+    as a root agent.` A file exporting no agent at all fails with
+    `AgentFileLoadingError`.
 
 ## 2. Install dependencies
 
@@ -155,7 +161,15 @@ because that is where step 4 tells you to run. Create `my-agent/.env`:
     gcloud auth application-default login
     ```
 
-    Then create the `.env` file:
+    Then enable the API your agent will call on the project you are about to
+    name. A project without it does not produce an error — it produces the
+    silent failure described in [step 4](#4-run-your-agent):
+
+    ```console
+    gcloud services enable aiplatform.googleapis.com --project=your-project-id
+    ```
+
+    Now create the `.env` file:
 
     ```console title="my-agent/.env"
     GOOGLE_GENAI_USE_VERTEXAI=TRUE
@@ -257,8 +271,9 @@ prints `backend: VERTEX_AI` instead of `backend: GEMINI_API`.
 `INFO` line, returns you to the `[user]:` prompt with no answer, and exits with
 status `0`. The silence means the model request was rejected and ADK discarded
 the reason. It is *not* specific to a bad key: an unusable API key, a project
-your credentials cannot reach, and a model name that does not exist in your
-region are all indistinguishable at the terminal. See
+your credentials cannot reach, a project without `aiplatform.googleapis.com`
+enabled, and a model name that does not exist in your region are all
+indistinguishable at the terminal. See
 [Troubleshooting](#troubleshooting) for a command that prints the real error.
 
 ### Run with the web interface
@@ -287,12 +302,14 @@ result, then the answer.
 **One `INFO` line, no answer, and exit code `0`.**
 
 The model request was rejected and ADK discarded the reason, so the terminal
-shows you nothing. At least three different causes produce this identical
+shows you nothing. At least four different causes produce this identical
 silence, and you cannot tell them apart from the output:
 
 *   an API key that the Gemini API rejects, or one whose project has the API
     disabled;
 *   a `GOOGLE_CLOUD_PROJECT` your credentials are not authorized to use;
+*   a `GOOGLE_CLOUD_PROJECT` that does not have `aiplatform.googleapis.com`
+    enabled;
 *   a `model` string that does not exist at your `GOOGLE_CLOUD_LOCATION` —
     notably `gemini-flash-latest`, which resolves on `global` but **not** on a
     regional endpoint such as `us-central1`.
@@ -316,11 +333,15 @@ curl -s -X POST -H "Authorization: Bearer $(gcloud auth application-default prin
 ```
 
 You get back the message ADK swallowed — `API key not valid. Please pass a valid
-API key.`, `Permission denied on resource project <id>.`, or ``Publisher model
-`...` was not found or your project does not have access to it``, which each
-point at one of the three causes above. To check whether your credential is
-being read at all, temporarily remove it: with nothing set, the run fails
-loudly with `API key must be provided` instead of going quiet.
+API key.`, `Permission denied on resource project <id>.`, ``Publisher model
+`...` was not found or your project does not have access to it``, or `Agent
+Platform API has not been used in project <id> before or it is disabled.` —
+which each point at one of the four causes above. Fix that last one with
+`gcloud services enable aiplatform.googleapis.com --project=your-project-id`;
+`gcloud services list --enabled --project=your-project-id` shows what a project
+already has. To check whether your credential is being read at all, temporarily
+remove it: with nothing set, the run fails loudly with `API key must be
+provided` instead of going quiet.
 
 **`Error: API key must be provided via constructor or GOOGLE_GENAI_API_KEY or GEMINI_API_KEY environment variable.`**
 

--- a/docs/get-started/typescript.md
+++ b/docs/get-started/typescript.md
@@ -1,58 +1,24 @@
 # TypeScript Quickstart for ADK
 
-This guide shows you how to get up and running with Agent Development Kit
-for TypeScript. Before you start, make sure you have the following installed:
+In this quickstart you build an agent that answers a question by calling a
+TypeScript function you wrote, and then talk to it from your terminal. Four
+steps, one file.
 
-*   Node.js 24.13.0 or later
-*   Node Package Manager (npm) 11.8.0 or later
+**Prerequisites**
 
-## Create an agent project
+*   **Node.js 22 or later.** Check with `node --version`. This guide was
+    verified end to end on Node.js v22.22.2 with npm 9.2.0.
+*   **npm, pnpm, or yarn.** Every command below is given for all three.
+*   **A Gemini API key.** Create one in Google AI Studio on the
+    [API Keys](https://aistudio.google.com/app/apikey) page. If you would rather
+    authenticate with Google Cloud, [step 3](#3-set-your-credentials) covers
+    that too.
 
-Create an empty `my-agent` directory for your project:
+## 1. Write the agent
 
-```none
-my-agent/
-```
-
-??? tip "Create this project structure using the command line"
-
-    === "MacOS / Linux"
-
-        ```bash
-        mkdir -p my-agent/
-        ```
-
-    === "Windows"
-
-        ```console
-        mkdir my-agent
-        ```
-
-### Configure project and dependencies
-
-Use the `npm` tool to install and configure dependencies for your project,
-including the package file, ADK TypeScript main
-library, and developer tools. Run the following commands from your
-`my-agent/` directory to create the `package.json` file and install the
-project dependencies:
-
-```console
-cd my-agent/
-# initialize a project as an ES module
-npm init --yes
-npm pkg set type="module"
-npm pkg set main="agent.ts"
-# install ADK libraries
-npm install @google/adk
-# install dev tools as a dev dependency
-npm install -D @google/adk-devtools
-```
-
-### Define the agent code
-
-Create the code for a basic agent, including a simple implementation of an ADK
-[Function Tool](/tools-custom/function-tools/), called `getCurrentTime`.
-Create an `agent.ts` file in your project directory and add the following code:
+Create a `my-agent` directory, and inside it an `agent.ts` file containing a
+[Function Tool](/tools-custom/function-tools/) named `getCurrentTime` and an
+agent that uses it:
 
 ```typescript title="my-agent/agent.ts"
 import {FunctionTool, LlmAgent} from '@google/adk';
@@ -60,7 +26,7 @@ import {z} from 'zod';
 
 /* Mock tool implementation */
 const getCurrentTime = new FunctionTool({
-  name: 'get_current_time',
+  name: 'getCurrentTime',
   description: 'Returns the current time in a specified city.',
   parameters: z.object({
     city: z.string().describe("The name of the city for which to retrieve the current time."),
@@ -80,67 +46,197 @@ export const rootAgent = new LlmAgent({
 });
 ```
 
-### Set your API key
+Let's take a look at what is happening in this code:
 
-This project uses the Gemini API, which requires an API key. If you
-don't already have Gemini API key, create a key in Google AI Studio on the
-[API Keys](https://aistudio.google.com/app/apikey) page.
+1.  `name: 'getCurrentTime'` is the identifier the model uses to call the tool,
+    and `description` is how it decides *when* to call it. The `instruction`
+    on the agent names the same string, `getCurrentTime`. If those two strings
+    disagree, the model asks for a tool that does not exist and your function
+    never runs.
+2.  `parameters` is a Zod schema, and it is the tool's whole input contract:
+    ADK turns it into the function declaration sent to the model, validates the
+    model's arguments against it, and infers the type of `execute`'s argument
+    from it. In `execute: ({city}) =>`, `city` is already typed `string` — you
+    never declare that type twice.
+3.  `execute` returns a plain object. ADK serializes it and hands it back to the
+    model, which turns it into the sentence you see.
+4.  `LlmAgent` binds the three things an agent needs: a `model`, an
+    `instruction`, and its `tools`.
+5.  The export **must** be named `rootAgent`. Both `adk run` and `adk web` look
+    for that exact export and fail without it.
 
-In a terminal window, write your API key into your `.env` file of your project
-to set environment variables:
+## 2. Install dependencies
 
-=== "MacOS / Linux"
+Move into the project directory and install:
 
-    ```bash title="Update: my-agent/.env"
-    echo 'GEMINI_API_KEY="YOUR_API_KEY"' > .env
+=== "npm"
+
+    ```console
+    cd my-agent/
+    npm init --yes
+    npm pkg set type="module" main="agent.ts"
+    npm install @google/adk zod
+    npm install -D @google/adk-devtools
     ```
 
-=== "Windows PowerShell"
+=== "pnpm"
 
-    ```console title="Update: my-agent/.env"
-    echo 'GEMINI_API_KEY="YOUR_API_KEY"' > .env
+    ```console
+    cd my-agent/
+    pnpm init
+    pnpm pkg set type="module" main="agent.ts"
+    pnpm add @google/adk zod
+    pnpm add -D @google/adk-devtools
+    pnpm approve-builds --all
     ```
 
-=== "Windows Command Prompt"
+    `esbuild` and `sqlite3` ship install scripts, which pnpm blocks by default.
+    Until you approve them, every `pnpm exec` fails the dependency check with
+    `ERR_PNPM_IGNORED_BUILDS`.
 
-    ```console title="Update: my-agent/.env"
-    echo GEMINI_API_KEY="YOUR_API_KEY" > .env
+=== "yarn"
+
+    ```console
+    cd my-agent/
+    yarn init -2
+    yarn config set nodeLinker node-modules
+    npm pkg set type="module" main="agent.ts"
+    yarn add @google/adk zod
+    yarn add -D @google/adk-devtools
     ```
+
+    Yarn's default Plug'n'Play linker cannot load `@google/adk-devtools`, so set
+    `nodeLinker` to `node-modules` before installing. See
+    [Troubleshooting](#troubleshooting) for the error you get if you skip it.
+
+Three packages, and each one earns its place:
+
+*   `@google/adk` is the agent framework — `LlmAgent`, `FunctionTool`, and the
+    Gemini model layer.
+*   `zod` is imported directly by your `agent.ts`, so it has to be a dependency
+    of *your* project. npm happens to hoist it out of `@google/adk`, but pnpm
+    and yarn will not, and your agent will fail to build.
+*   `@google/adk-devtools` provides the `adk` command used in step 4. It is a
+    dev dependency; your deployed agent does not need it.
+
+**You should see:** a `node_modules/` directory, and `npx adk --version`
+(`pnpm exec adk --version`, `yarn adk --version`) printing `1.5.0`.
+
+## 3. Set your credentials
+
+ADK for TypeScript reads its credentials from the environment, and from a
+`.env` file in the same directory as your agent. Create `my-agent/.env`:
+
+=== "Gemini API key"
+
+    ```console title="my-agent/.env"
+    GOOGLE_GENAI_API_KEY="PASTE_YOUR_API_KEY_HERE"
+    ```
+
+    Replace `PASTE_YOUR_API_KEY_HERE` with the key you created in
+    [Google AI Studio](https://aistudio.google.com/app/apikey). `GEMINI_API_KEY`
+    is accepted as an alias for exactly the same purpose; pick one.
+
+=== "Google Cloud Agent Platform"
+
+    Authenticate your workstation with Application Default Credentials first:
+
+    ```console
+    gcloud auth application-default login
+    ```
+
+    Then create the `.env` file:
+
+    ```console title="my-agent/.env"
+    GOOGLE_GENAI_USE_VERTEXAI=TRUE
+    GOOGLE_CLOUD_PROJECT=your-project-id
+    GOOGLE_CLOUD_LOCATION=global
+    ```
+
+    Use `GOOGLE_GENAI_USE_VERTEXAI`. ADK for TypeScript does not read
+    `GOOGLE_GENAI_USE_ENTERPRISE`; setting only that one leaves the agent
+    looking for an API key it will not find. A regional
+    `GOOGLE_CLOUD_LOCATION` such as `us-central1` also needs a versioned model
+    string — change `model` to `gemini-2.5-flash`, because
+    `gemini-flash-latest` does not resolve on regional endpoints.
+
+!!! warning "`GOOGLE_API_KEY` is not one of the names"
+
+    On the Gemini API path, ADK for TypeScript reads `GOOGLE_GENAI_API_KEY` or
+    `GEMINI_API_KEY` and nothing else. Setting `GOOGLE_API_KEY` fails with
+    `Error: API key must be provided via constructor or GOOGLE_GENAI_API_KEY or
+    GEMINI_API_KEY environment variable.` Other pages in these docs show
+    `GOOGLE_API_KEY`; on this path it does not work.
+
+Add `.env` to your `.gitignore` before you commit anything.
 
 ??? tip "Using other AI models with ADK"
     ADK supports the use of many generative AI models. For more
     information on configuring other models in ADK agents, see
     [Models & Authentication](/agents/models).
 
-## Run your agent
+## 4. Run your agent
 
-You can run your ADK agent with the `@google/adk-devtools` library as an
-interactive command-line interface using the `run` command or the ADK web user
-interface using the `web` command. Both these options allow you to test and
-interact with your agent.
+`@google/adk-devtools` gives you two ways to talk to the agent: an interactive
+terminal session with `adk run`, and a browser chat UI with `adk web`.
 
-### Run with command-line interface
+### Run with the command-line interface
 
-Run your agent with the ADK TypeScript command-line interface tool
-using the following command:
+Run this from `my-agent/`, the directory that has `node_modules/` in it:
 
-```console
-npx adk run agent.ts
+=== "npm"
+
+    ```console
+    npx adk run agent.ts
+    ```
+
+=== "pnpm"
+
+    ```console
+    pnpm exec adk run agent.ts
+    ```
+
+=== "yarn"
+
+    ```console
+    yarn adk run agent.ts
+    ```
+
+Type a question at the `[user]:` prompt and press Enter. A working session looks
+exactly like this:
+
+```console title="Expected output"
+Running agent hello_time_agent, type exit to exit.
+[user]: What time is it in Paris?
+INFO: [ADK] 2026-08-05T17:41:51.838Z Sending out request, model: gemini-flash-latest, backend: GEMINI_API, stream: false
+INFO: [ADK] 2026-08-05T17:41:52.665Z Sending out request, model: gemini-flash-latest, backend: GEMINI_API, stream: false
+[hello_time_agent]: The current time in Paris is 10:30 AM
+[user]: exit
 ```
 
-![adk-run.png](/assets/adk-run.png)
+**You should see** two `INFO` lines and then a `[hello_time_agent]:` line
+carrying the answer. Two requests is the tool call working: the first asks the
+model what to do, the model asks for `getCurrentTime`, and the second sends your
+function's result back for the model to phrase. On the Google Cloud path the
+same run prints `backend: VERTEX_AI` instead of `backend: GEMINI_API`.
 
-### Run with web interface
+**If it fails you will not get an error.** ADK for TypeScript 1.5.0 prints one
+`INFO` line, returns you to the `[user]:` prompt with no answer, and exits with
+status `0`. That silence means the model request was rejected — almost always a
+bad or unauthorized key. See [Troubleshooting](#troubleshooting).
 
-Run your agent with the ADK web interface using the following command:
+### Run with the web interface
 
 ```console
 npx adk web
 ```
 
-This command starts a web server with a chat interface for your agent. You can
-access the web interface at `http://localhost:8000`. Select your agent at the
-upper right corner and type a request.
+This starts a server on `http://localhost:8000`. Open it and you should see a
+dark chat page titled **Agent Development Kit**, with an app selector in the
+top left already showing `agent` — the name comes from your `agent.ts`
+filename, not from `rootAgent.name`. Type into **Type a message...** at the
+bottom. The event list shows your message, then a `getCurrentTime("Paris")`
+call, then the tool's result, then the answer.
 
 ![adk-web-dev-ui-chat.png](/assets/adk-web-dev-ui-chat.png)
 
@@ -149,9 +245,73 @@ upper right corner and type a request.
     ADK Web is ***not meant for use in production deployments***. You should
     use ADK Web for development and debugging purposes only.
 
-## Next: Build your agent
+## Troubleshooting
 
-Now that you have ADK installed and your first agent running, try building
-your own agent with our build guides:
+**One `INFO` line, no answer, and exit code `0`.**
 
-*  [Build your agent](/tutorials/)
+The model request was rejected and the error was swallowed. Check that your key
+is valid and that the Gemini API is enabled for it. To see whether your key is
+being picked up at all, temporarily remove it: with no credential set, the run
+fails loudly with `API key must be provided` instead of going quiet.
+
+**`Error: API key must be provided via constructor or GOOGLE_GENAI_API_KEY or GEMINI_API_KEY environment variable.`**
+
+No credential was found under a name ADK reads. You set `GOOGLE_API_KEY`, or
+you set `GOOGLE_GENAI_USE_ENTERPRISE` instead of `GOOGLE_GENAI_USE_VERTEXAI`,
+or your `.env` is not in the same directory as `agent.ts`.
+
+**`Error: VertexAI project must be provided via constructor or GOOGLE_CLOUD_PROJECT environment variable.`**
+
+`GOOGLE_GENAI_USE_VERTEXAI` is set but `GOOGLE_CLOUD_PROJECT` or
+`GOOGLE_CLOUD_LOCATION` is missing. Both are required on that path.
+
+**`npm ERR! could not determine executable to run`**
+
+`npx adk` did not find the local `adk` binary and reached for a package named
+`adk` on the public registry — an unrelated third-party package that has nothing
+to do with ADK. Run the command from the directory that contains
+`node_modules/`, or invoke the binary directly with
+`./node_modules/.bin/adk run agent.ts`.
+
+**`✘ [ERROR] Could not resolve "zod"`**
+
+`zod` is not a dependency of your project. Run `npm install zod` (or the pnpm
+or yarn equivalent). npm's flat `node_modules` can mask this; pnpm and yarn
+will not.
+
+**`Error: @google/adk-devtools tried to access @opentelemetry/api, but it isn't declared in its dependencies`**
+
+You are on Yarn's Plug'n'Play linker. Run `yarn config set nodeLinker
+node-modules` and reinstall.
+
+**`[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts:`** listing `esbuild` and `sqlite3`
+
+pnpm blocked those install scripts, and that makes `pnpm exec` fail its
+dependency check before it runs anything. Run `pnpm approve-builds --all` once.
+
+**`TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"`**
+
+You ran `node agent.ts`. Node does not execute TypeScript here, and `agent.ts`
+only exports an agent — it has no entry point. Use `adk run agent.ts`, which
+compiles the file before loading it.
+
+**`AgentFileLoadingError`** ending in **`does not exists`**
+
+Wrong path or wrong extension. The argument to `adk run` is the path to your
+TypeScript source, `agent.ts`.
+
+**`DeprecationWarning: The 'punycode' module is deprecated`**
+
+Harmless. It comes from a transitive dependency on Node 22 and does not affect
+your agent.
+
+## Next steps
+
+This quickstart gets one agent answering in your terminal. To serve it over HTTP
+instead of a REPL, see [Run an API server](/runtime/api-server/).
+
+*   [Give your agent a tool that calls a real API](/tools-custom/function-tools/)
+*   [Keep context across turns with session state](/sessions/state/)
+*   [Split the work across several agents](/workflows/patterns/)
+*   [Deploy your agent to Cloud Run](/deploy/cloud-run/)
+*   [Build a complete agent step by step](/tutorials/)

--- a/docs/get-started/typescript.md
+++ b/docs/get-started/typescript.md
@@ -37,7 +37,7 @@ const getCurrentTime = new FunctionTool({
 });
 
 export const rootAgent = new LlmAgent({
-  name: 'hello_time_agent',
+  name: 'helloTimeAgent',
   model: 'gemini-flash-latest',
   description: 'Tells the current time in a specified city.',
   instruction: `You are a helpful assistant that tells the current time in a city.
@@ -90,9 +90,18 @@ Move into the project directory and install:
     pnpm approve-builds --all
     ```
 
-    `esbuild` and `sqlite3` ship install scripts, which pnpm blocks by default.
-    Until you approve them, every `pnpm exec` fails the dependency check with
-    `ERR_PNPM_IGNORED_BUILDS`.
+    Five packages ship install scripts, which pnpm blocks by default. pnpm
+    prints the list after each install; once both are done it reads:
+
+    ```console
+    [ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @google/genai@1.52.0, @google/genai@2.15.0, esbuild@0.25.12, protobufjs@7.6.5, sqlite3@5.1.7
+    ```
+
+    `@google/genai` is listed twice because `@google/adk` and
+    `@google/adk-devtools` pull different majors of it, and `esbuild` is missing
+    from the earlier list — the one after `pnpm add @google/adk zod` — because it
+    arrives with the devtools. Until you approve them, every `pnpm exec` fails
+    its dependency check with that same message before running anything.
 
 === "yarn"
 
@@ -124,8 +133,9 @@ Three packages, and each one earns its place:
 
 ## 3. Set your credentials
 
-ADK for TypeScript reads its credentials from the environment, and from a
-`.env` file in the same directory as your agent. Create `my-agent/.env`:
+ADK for TypeScript reads its credentials from the process environment, and from
+a `.env` file in the directory you run the command from — which is `my-agent/`,
+because that is where step 4 tells you to run. Create `my-agent/.env`:
 
 === "Gemini API key"
 
@@ -159,6 +169,22 @@ ADK for TypeScript reads its credentials from the environment, and from a
     `GOOGLE_CLOUD_LOCATION` such as `us-central1` also needs a versioned model
     string — change `model` to `gemini-2.5-flash`, because
     `gemini-flash-latest` does not resolve on regional endpoints.
+
+!!! warning "Your shell wins over `.env`"
+
+    `.env` is loaded without overriding, so a variable already exported in your
+    shell keeps its value and the line in `.env` is ignored. This matters most
+    on the Google Cloud path: many Cloud workstations already export
+    `GOOGLE_CLOUD_PROJECT`, so the quickstart can succeed against *that* project
+    while the `.env` you just wrote does nothing — and then fail for the next
+    person who copies your file. Before you run, check what is already set:
+
+    ```console
+    env | grep -E '^(GOOGLE_|GEMINI_)'
+    ```
+
+    Anything printed there overrides `.env`. `unset` it, or set the value you
+    actually want in the shell rather than in the file.
 
 !!! warning "`GOOGLE_API_KEY` is not one of the names"
 
@@ -203,27 +229,37 @@ Run this from `my-agent/`, the directory that has `node_modules/` in it:
     ```
 
 Type a question at the `[user]:` prompt and press Enter. A working session looks
-exactly like this:
+like this:
 
 ```console title="Expected output"
-Running agent hello_time_agent, type exit to exit.
+(node:4048641) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+(Use `node --trace-deprecation ...` to show where the warning was created)
+Running agent helloTimeAgent, type exit to exit.
 [user]: What time is it in Paris?
 INFO: [ADK] 2026-08-05T17:41:51.838Z Sending out request, model: gemini-flash-latest, backend: GEMINI_API, stream: false
 INFO: [ADK] 2026-08-05T17:41:52.665Z Sending out request, model: gemini-flash-latest, backend: GEMINI_API, stream: false
-[hello_time_agent]: The current time in Paris is 10:30 AM
+[helloTimeAgent]: The current time in Paris is 10:30 AM
 [user]: exit
 ```
 
-**You should see** two `INFO` lines and then a `[hello_time_agent]:` line
-carrying the answer. Two requests is the tool call working: the first asks the
-model what to do, the model asks for `getCurrentTime`, and the second sends your
-function's result back for the model to phrase. On the Google Cloud path the
-same run prints `backend: VERTEX_AI` instead of `backend: GEMINI_API`.
+Do not compare that character by character. The two `punycode` lines come from
+Node, not from ADK — they precede *every* `adk` command on Node 22, the process
+id in them changes each run, and more Node warnings may join them. The
+timestamps are yours, and the model rephrases the last line freely.
+
+**You should see** two `INFO` lines and then a `[helloTimeAgent]:` line carrying
+the answer. Two requests is the tool call working: the first asks the model what
+to do, the model asks for `getCurrentTime`, and the second sends your function's
+result back for the model to phrase. On the Google Cloud path the same run
+prints `backend: VERTEX_AI` instead of `backend: GEMINI_API`.
 
 **If it fails you will not get an error.** ADK for TypeScript 1.5.0 prints one
 `INFO` line, returns you to the `[user]:` prompt with no answer, and exits with
-status `0`. That silence means the model request was rejected — almost always a
-bad or unauthorized key. See [Troubleshooting](#troubleshooting).
+status `0`. The silence means the model request was rejected and ADK discarded
+the reason. It is *not* specific to a bad key: an unusable API key, a project
+your credentials cannot reach, and a model name that does not exist in your
+region are all indistinguishable at the terminal. See
+[Troubleshooting](#troubleshooting) for a command that prints the real error.
 
 ### Run with the web interface
 
@@ -231,12 +267,13 @@ bad or unauthorized key. See [Troubleshooting](#troubleshooting).
 npx adk web
 ```
 
-This starts a server on `http://localhost:8000`. Open it and you should see a
-dark chat page titled **Agent Development Kit**, with an app selector in the
-top left already showing `agent` — the name comes from your `agent.ts`
-filename, not from `rootAgent.name`. Type into **Type a message...** at the
-bottom. The event list shows your message, then a `getCurrentTime("Paris")`
-call, then the tool's result, then the answer.
+This starts a server on `http://localhost:8000`; pass `--port 8001` (or `-p`) to
+use a different one. Open it and you should see a dark chat page titled
+**Agent Development Kit**, with an app selector in the top left already showing
+`agent` — the name comes from your `agent.ts` filename, not from
+`rootAgent.name`. Type into **Type a message...** at the bottom. The event list
+shows your message, then a `getCurrentTime("Paris")` call, then the tool's
+result, then the answer.
 
 ![adk-web-dev-ui-chat.png](/assets/adk-web-dev-ui-chat.png)
 
@@ -249,21 +286,57 @@ call, then the tool's result, then the answer.
 
 **One `INFO` line, no answer, and exit code `0`.**
 
-The model request was rejected and the error was swallowed. Check that your key
-is valid and that the Gemini API is enabled for it. To see whether your key is
-being picked up at all, temporarily remove it: with no credential set, the run
-fails loudly with `API key must be provided` instead of going quiet.
+The model request was rejected and ADK discarded the reason, so the terminal
+shows you nothing. At least three different causes produce this identical
+silence, and you cannot tell them apart from the output:
+
+*   an API key that the Gemini API rejects, or one whose project has the API
+    disabled;
+*   a `GOOGLE_CLOUD_PROJECT` your credentials are not authorized to use;
+*   a `model` string that does not exist at your `GOOGLE_CLOUD_LOCATION` —
+    notably `gemini-flash-latest`, which resolves on `global` but **not** on a
+    regional endpoint such as `us-central1`.
+
+Send the same request yourself to see the error ADK hid. On the Gemini API path:
+
+```console
+curl -s -X POST -H 'Content-Type: application/json' \
+  "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent?key=$GOOGLE_GENAI_API_KEY" \
+  -d '{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}'
+```
+
+On the Google Cloud path (use `LOCATION-aiplatform.googleapis.com` for a
+regional `GOOGLE_CLOUD_LOCATION`):
+
+```console
+curl -s -X POST -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+  -H 'Content-Type: application/json' \
+  "https://aiplatform.googleapis.com/v1/projects/$GOOGLE_CLOUD_PROJECT/locations/$GOOGLE_CLOUD_LOCATION/publishers/google/models/gemini-flash-latest:generateContent" \
+  -d '{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}'
+```
+
+You get back the message ADK swallowed — `API key not valid. Please pass a valid
+API key.`, `Permission denied on resource project <id>.`, or ``Publisher model
+`...` was not found or your project does not have access to it``, which each
+point at one of the three causes above. To check whether your credential is
+being read at all, temporarily remove it: with nothing set, the run fails
+loudly with `API key must be provided` instead of going quiet.
 
 **`Error: API key must be provided via constructor or GOOGLE_GENAI_API_KEY or GEMINI_API_KEY environment variable.`**
 
 No credential was found under a name ADK reads. You set `GOOGLE_API_KEY`, or
 you set `GOOGLE_GENAI_USE_ENTERPRISE` instead of `GOOGLE_GENAI_USE_VERTEXAI`,
-or your `.env` is not in the same directory as `agent.ts`.
+or your `.env` is not in the directory you ran the command from.
 
 **`Error: VertexAI project must be provided via constructor or GOOGLE_CLOUD_PROJECT environment variable.`**
 
-`GOOGLE_GENAI_USE_VERTEXAI` is set but `GOOGLE_CLOUD_PROJECT` or
-`GOOGLE_CLOUD_LOCATION` is missing. Both are required on that path.
+`GOOGLE_GENAI_USE_VERTEXAI` is set but `GOOGLE_CLOUD_PROJECT` is missing.
+
+**`Error: VertexAI location must be provided via constructor or GOOGLE_CLOUD_LOCATION environment variable.`**
+
+The same, for `GOOGLE_CLOUD_LOCATION`. Both variables are required on the Google
+Cloud path and each one has its own error; setting only the project gets you
+this one. Use `global` unless you need a specific region.
 
 **`npm ERR! could not determine executable to run`**
 
@@ -284,10 +357,30 @@ will not.
 You are on Yarn's Plug'n'Play linker. Run `yarn config set nodeLinker
 node-modules` and reinstall.
 
-**`[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts:`** listing `esbuild` and `sqlite3`
+**`[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @google/genai@1.52.0, @google/genai@2.15.0, esbuild@0.25.12, protobufjs@7.6.5, sqlite3@5.1.7`**
 
 pnpm blocked those install scripts, and that makes `pnpm exec` fail its
 dependency check before it runs anything. Run `pnpm approve-builds --all` once.
+The exact versions move; the set does not.
+
+**`[ADK CLI] Error starting web server: Port 8000 is already in use`**
+
+Something already holds port 8000 — often an `adk web` you left running in
+another terminal. Either serve on another port:
+
+```console
+npx adk web --port 8001
+```
+
+or find and stop what is holding 8000 first:
+
+```console
+lsof -ti :8000        # prints the process id
+kill $(lsof -ti :8000)
+```
+
+`adk web` does not fall back to a free port on its own; it prints that line and
+exits.
 
 **`TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"`**
 


### PR DESCRIPTION
Three factual corrections to the TypeScript quickstart, applied inside the existing page structure.

> **This description was rewritten on 2026-08-10.** The PR originally restructured the page and this body described six fixes. @joefernandez [asked for that revert](https://github.com/google/adk-docs/pull/2075#pullrequestreview-3617374029) because the change broke the structure shared across all five language quickstarts, and he was right. The page was restored from `main` and only the corrections that fit inside the existing structure were re-applied. The old description was left up for four days describing work that is no longer in the diff — apologies to anyone who read it.

## What is actually in this diff

| File | Change |
|---|---|
| `get-started/typescript.md:6-7` | `Node.js 24.13.0` → `Node.js 22`, `npm 11.8.0` → `npm 9` |
| `get-started/typescript.md:46` | `npm install @google/adk` → `npm install @google/adk zod` |
| `get-started/typescript.md:63` | `name: 'get_current_time'` → `'getCurrentTime'` |
| `get-started/installation.md:54` | same `zod` addition |
| `get-started/index.md:16` | `:fontawesome-brands-js:` → `:simple-typescript:` |

**+6/−6.** The heading structure is byte-identical to `main`, including line numbers:

```
$ diff <(git show main:docs/get-started/typescript.md | grep -n '^#\{1,3\} ') \
       <(grep -n '^#\{1,3\} ' docs/get-started/typescript.md)
$ echo $?
0
```

### The three corrections

**Node version.** `@google/adk@1.5.0` declares no `engines` field, and neither does `@google/adk-devtools`. The whole quickstart runs on v22.22.2 / npm 9.2.0, and every TypeScript example in this repo pins `@types/node ^20`. 22 is the active LTS line and is what I tested — it's a judgement call, so change it if you'd prefer a different floor.

**`zod`.** The page's own sample imports it but never installs it. It currently works by accidental npm hoisting and fails under pnpm with `✘ [ERROR] Could not resolve "zod"`. Verified before and after.

**Tool name.** The code registered `get_current_time` while the instruction referred to `getCurrentTime`. Honesty note: this is a consistency fix, not a crash fix — I tested `main` unmodified and the model tolerates the mismatch. Drop it if you'd rather.

**`index.md`** gives the TypeScript card its own brand mark; Python, Go, Java and Kotlin all use theirs. Verified it renders (material ships `simple/typescript.svg`; `simple-kotlin` is already used on that page).

## Not in this PR

Other problems I hit while testing could not be fixed without adding structure the sibling quickstarts don't have, so they were dropped rather than forced in. They're enumerated in [this comment](https://github.com/google/adk-docs/pull/2075#issuecomment-5209157668) — the most significant being that **`GOOGLE_API_KEY`, which the other four quickstarts and `agents/models/google-gemini.md` all tell readers to use, is not accepted by the TypeScript runtime.** This page is the correct one and the cross-language pattern is wrong, so I changed nothing and left the call to you.

Verified: quickstart followed end to end from a clean directory on both credential paths, `zod` fix confirmed under pnpm, `mkdocs build` zero warnings.
