### PR TITLE
docs(a2a): add A2A exposing and consuming quickstarts for ADK TypeScript

### DIFF
--- a/docs/a2a/index.md
+++ b/docs/a2a/index.md
@@ -20,6 +20,7 @@ Navigate through the guides below to learn about ADK's A2A capabilities:
 
   *   **[A2A Quickstart (Consuming) for Python](./quickstart-consuming.md)**
       * **[A2A Extension - V2 Implementation](./a2a-extension.md)**
+  *   **[A2A Quickstart (Consuming) for TypeScript](./quickstart-consuming-typescript.md)**
   *   **[A2A Quickstart (Consuming) for Go](./quickstart-consuming-go.md)**
   *   **[A2A Quickstart (Consuming) for Java](./quickstart-consuming-java.md)**
 

--- a/docs/a2a/index.md
+++ b/docs/a2a/index.md
@@ -1,7 +1,7 @@
 # ADK with Agent2Agent (A2A) Protocol
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span><span class="lst-go">Go</span><span class="lst-java">Java</span><span class="lst-preview">Experimental</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span><span class="lst-typescript">TypeScript</span><span class="lst-go">Go</span><span class="lst-java">Java</span><span class="lst-preview">Experimental</span>
 </div>
 
 With Agent Development Kit (ADK), you can build complex multi-agent systems where different agents need to collaborate and interact using [Agent2Agent (A2A) Protocol](https://a2a-protocol.org/)! This section provides a comprehensive guide to building powerful multi-agent systems where agents can communicate and collaborate securely and efficiently.
@@ -13,6 +13,7 @@ Navigate through the guides below to learn about ADK's A2A capabilities:
   Start here to learn the fundamentals of A2A by building a multi-agent system with a root agent, a local sub-agent, and a remote A2A agent. The following guides cover how do I expose your agent so that other agents can use it via the A2A protocol:
 
   *   **[A2A Quickstart (Exposing) for Python](./quickstart-exposing.md)**
+  *   **[A2A Quickstart (Exposing) for TypeScript](./quickstart-exposing-typescript.md)**
   *   **[A2A Quickstart (Exposing) for Go](./quickstart-exposing-go.md)**
   *   **[A2A Quickstart (Exposing) for Java](./quickstart-exposing-java.md)**
 

--- a/docs/a2a/intro.md
+++ b/docs/a2a/intro.md
@@ -265,4 +265,4 @@ concerns and easy integration of specialized agents.
 Now that you understand the "why" of A2A, let's dive into the "how."
 
 - **Continue to the next guide:**
-  Quickstart: Exposing Your Agent, [in Python](./quickstart-exposing.md), [in Go](./quickstart-exposing-go.md), [in Java](./quickstart-exposing-java.md)
+  Quickstart: Exposing Your Agent, [in Python](./quickstart-exposing.md), [in TypeScript](./quickstart-exposing-typescript.md), [in Go](./quickstart-exposing-go.md), [in Java](./quickstart-exposing-java.md)

--- a/docs/a2a/quickstart-consuming-typescript.md
+++ b/docs/a2a/quickstart-consuming-typescript.md
@@ -1,94 +1,49 @@
 # Quickstart: Consuming a remote agent via A2A
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-typescript">TypeScript v1.5.0</span><span class="lst-preview">Experimental</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-typescript">TypeScript</span><span class="lst-preview">Experimental</span>
 </div>
 
-An A2A agent runs somewhere else — another process, another machine, another team's
-service — and speaks the [Agent2Agent protocol](intro.md) over HTTP. This page answers the
-first question you hit when you meet one: **how do I call it from my ADK TypeScript agent
-and get a real answer back?**
+This quickstart covers the most common starting point for any developer: **"There is a remote agent, how do I let my ADK agent use it via A2A?"**. This is crucial for building complex multi-agent systems where different agents need to collaborate and interact.
 
-You will build two things, because they are different jobs: a script that calls a remote
-agent **directly**, and a local agent that has the remote agent as a **sub-agent**, so the
-model decides when to route to it. You will also start the remote agent yourself, so
-nothing on this page depends on someone else's server being up.
+## Overview
 
-Here is the whole direct client. This is the complete file — the only thing missing is a
-remote agent to point it at, which you start in step 4.
+This sample demonstrates the **Agent2Agent (A2A)** architecture in the Agent Development Kit (ADK), showcasing how multiple agents can work together to handle complex tasks. The sample implements an agent that can roll dice and check if numbers are prime.
 
-```typescript title="examples/typescript/a2a_basic/direct_client.ts"
---8<-- "examples/typescript/a2a_basic/direct_client.ts:full"
+```text
+┌─────────────────┐    ┌──────────────────┐    ┌────────────────────┐
+│   Root Agent    │───▶│   Roll Agent     │    │   Remote Prime     │
+│  (Local)        │    │   (Local)        │    │   Agent            │
+│                 │    │                  │    │  (localhost:8001)  │
+│                 │───▶│                  │◀───│                    │
+└─────────────────┘    └──────────────────┘    └────────────────────┘
 ```
 
-Let's take a look at what is happening in this code:
+The A2A Basic sample consists of:
 
-1. **`new RemoteA2AAgent({...})`** is the client. It is imported from `@google/adk` — there
-   is no `@google/adk/a2a` subpath — and it extends `BaseAgent`, so anywhere ADK accepts an
-   agent, it accepts this.
-2. **`agentCard: 'http://localhost:8001'` is a base URL, not the URL of the card.**
-   `RemoteA2AAgent` appends `.well-known/agent-card.json` itself. Passing the card URL is
-   the most common way to break this page; see [Troubleshooting](#troubleshooting).
-3. **`name` and `description`** are required by ADK, not fetched from the remote card. The
-   `description` is what a parent agent's model reads when deciding whether to route here,
-   so write it for that audience.
-4. **`Runner`** drives the agent exactly as it drives a local one: `runAsync()` returns an
-   async iterable of events. There is no separate "A2A client" API to learn.
-5. **`event.errorMessage`** is how remote failures arrive. They are *not* thrown, and the
-   process still exits `0`. A loop that only reads `event.content` shows you nothing but
-   your own prompt when the remote agent fails.
-6. **`event.partial`** marks the streamed chunks of an answer that is still being written.
-   Skipping them prints the finished sentence once. Drop that line and the same run prints
-   `Yes, 7 is a`, then ` prime number.`, then `Yes, 7 is a prime number.` again.
+- **Remote Prime Agent** (`remote_prime_agent.ts`): An `LlmAgent` with a `check_prime` tool, published over A2A. It runs in its own Node process and makes its own model calls.
+- **Direct client** (`direct_client.ts`): Points a `RemoteA2AAgent` straight at the remote agent and asks one question. It holds no credentials.
+- **Routing agent** (`consuming_agent.ts`): A local `root_agent` whose sub-agents are a local `roll_agent` and the remote `prime_agent`. The model decides which one handles each request.
 
-## What you are building
+Use `RemoteA2AAgent` when the thing you want to call is an agent you do not run in your own process: another team's service, a vendor's agent, a deployment you scale separately. A2A buys you a process boundary and charges you an HTTP hop plus a JSON-RPC envelope for it. If the capability you want is a function or an HTTP API in your own codebase, define a [function tool](../tools-custom/function-tools.md) instead. Everything below was run on **Node.js 22** — `@google/adk` publishes no `engines` field, so npm will not warn you on an older runtime, but the examples use ESM and top-level `await`.
 
-- **`prime_agent`** — an `LlmAgent` with a `check_prime` tool, published over A2A. It runs
-  in its own Node process and makes its own model calls.
-- **`direct_client.ts`** — points a `RemoteA2AAgent` at it and asks one question.
-- **`consuming_agent.ts`** — a local `root_agent` whose sub-agents are a local `roll_agent`
-  and the remote `prime_agent`. The model routes between them.
+## Exposing Your Agent with the ADK Server
 
-!!! info "When to use `RemoteA2AAgent` — and when not to"
+In TypeScript you expose an agent with `toA2a()`, which auto-generates its agent card and returns an Express application you serve yourself. It is covered in full by [A2A Quickstart (Exposing)](quickstart-exposing-typescript.md).
 
-    Use `RemoteA2AAgent` when the thing you want to call is an agent you do not run in your
-    own process: another team's service, a vendor's agent, a deployment you scale
-    separately. A2A buys you a process boundary, and charges you an HTTP hop plus a
-    JSON-RPC envelope for it.
+In the `a2a_basic` example, you will first need to expose the `prime_agent` via an A2A server, so that the local root agent can use it.
 
-    If the capability you want is a function or an HTTP API in your own codebase, define a
-    [function tool](../tools-custom/function-tools.md) instead — no protocol required. If
-    you want *other* people to call your agent, you want
-    [A2A Quickstart (Exposing)](quickstart-exposing-typescript.md).
+### 1. Getting the Sample Code { #getting-the-sample-code }
 
-## Prerequisites
+You can clone and navigate to the [**`a2a_basic`** sample](https://github.com/google/adk-docs/tree/main/examples/typescript/a2a_basic) here:
 
-- **Node.js 22 or later.** Everything on this page was run on Node v22.22.2 with npm 9.2.0.
-  `@google/adk` publishes no `engines` field, so npm will not warn you on an older runtime —
-  but the examples use ESM and top-level `await`, which need a current Node.
-- **Credentials for Gemini.** Either a Gemini API key from
-  [Google AI Studio](https://aistudio.google.com/apikey), or a Google Cloud project with the
-  Vertex AI API enabled and `gcloud auth application-default login` already run. Step 3 gives
-  the literal `.env` for both.
-- **The exact file is `.env`**, in the same directory as `package.json`. The two examples on
-  this page that need it load it with `dotenv`, which reads that filename and no other.
+```bash
+git clone https://github.com/google/adk-docs.git
+cd adk-docs/examples/typescript/a2a_basic
+npm install
+```
 
-!!! note "Which process needs the key"
-
-    The **remote agent** (step 4) always needs it — it owns the model call. The **direct
-    client** (step 6) needs no credentials at all; that is the point of A2A. The **routing
-    agent** (step 8) needs one too, because it runs its own model to decide where to send
-    each request.
-
-    The split is identical on Vertex AI: the two processes that call a model need
-    `GOOGLE_CLOUD_PROJECT` and application default credentials, and the direct client still
-    needs nothing. `direct_client.ts` does not even import `dotenv`.
-
-## Call a remote agent directly
-
-### 1. Get the example code { #get-the-example-code }
-
-Three runnable files, and the two config files they need:
+As you'll see, the folder structure is as follows:
 
 ```text
 a2a_basic/
@@ -99,94 +54,29 @@ a2a_basic/
 ├── tsconfig.json
 ├── README.md
 └── remote_a2a/
-    └── dice_agent/         # the *other* quickstart's servers — not used here
-        ├── server.ts
-        └── server-with-auth.ts
+    └── dice_agent/         # A2A Quickstart (Exposing) uses these
 ```
 
-`a2a_basic/` is shared with
-[A2A Quickstart (Exposing)](quickstart-exposing-typescript.md); `remote_a2a/dice_agent/` is
-that page's code and you can ignore it here, other than to note that it listens on port 8001
-too, so do not run both quickstarts at once. Everything else except `README.md` is reproduced
-in full on this page, so you can either clone the files or paste them.
+`a2a_basic/` is shared with [A2A Quickstart (Exposing)](quickstart-exposing-typescript.md); `remote_a2a/dice_agent/` is that page's code, and it listens on port 8001 too, so do not run both quickstarts at once.
 
-=== "Clone them"
+#### Main Agents (`a2a_basic/direct_client.ts`, `a2a_basic/consuming_agent.ts`)
 
-    ```bash
-    git clone https://github.com/google/adk-docs.git
-    cd adk-docs/examples/typescript/a2a_basic
-    ```
+- **`primeAgent`**: The `RemoteA2AAgent` configuration — a `name`, a `description`, and the base URL of the remote agent's card.
+- **`rollDie` / `rollAgent`**: A local function tool and the local agent that owns it.
+- **`rootAgent`**: Main orchestrator with delegation logic, mixing the local and remote sub-agents.
 
-    `a2a_basic/` was added to `adk-docs` alongside this page. If `cd` fails with
-    `No such file or directory`, your clone predates it — `git pull`, or use the other tab.
+#### Remote Prime Agent (`a2a_basic/remote_prime_agent.ts`)
 
-=== "Paste them"
+- **`checkPrime`**: Prime number checking algorithm, wrapped as a `FunctionTool`.
+- **`toA2a(primeAgent, {...})`**: Publishes the agent and auto-generates its agent card.
 
-    ```bash
-    mkdir a2a_basic && cd a2a_basic
-    ```
+`@google/adk` brings the A2A stack with it: both the A2A SDK (`@a2a-js/sdk`) and Express are direct dependencies of the package, not peer dependencies, so there is nothing else to install to make A2A work. `zod` defines the tool's input schema and `dotenv` loads `.env`. Keep `zod` on **v4** — `@google/adk` depends on `zod@^4.2.1`, and a `zod@3` in your own `package.json` puts two incompatible copies in `node_modules`, after which `tsc` rejects every tool schema you write.
 
-    Then create each file as you reach it: `package.json` and `tsconfig.json` in step 2,
-    `remote_prime_agent.ts` in step 4, `direct_client.ts` (shown in full at the top of this
-    page) in step 6, `consuming_agent.ts` in step 7. `README.md` and `remote_a2a/` are not
-    needed to run anything on this page.
-
-### 2. Install the dependencies { #install-the-dependencies }
-
-Both config files in full. `"type": "module"` and `"module": "nodenext"` are what allow the
-top-level `await` the examples use:
-
-```json title="examples/typescript/a2a_basic/package.json"
---8<-- "examples/typescript/a2a_basic/package.json"
-```
-
-```json title="examples/typescript/a2a_basic/tsconfig.json"
---8<-- "examples/typescript/a2a_basic/tsconfig.json"
-```
-
-The `serve:dice` scripts and the `remote_a2a/**/*.ts` entry in `include` belong to
-[A2A Quickstart (Exposing)](quickstart-exposing-typescript.md), which shares this directory.
-This page uses `serve:prime`, `direct`, and `consume`; if you are pasting the files rather
-than cloning them, drop the two `serve:dice` lines and the `remote_a2a` include.
-
-Then install:
-
-=== "npm"
-
-    ```bash
-    npm install @google/adk zod dotenv
-    npm install --save-dev typescript tsx @types/node
-    ```
-
-=== "pnpm"
-
-    ```bash
-    pnpm add @google/adk zod dotenv
-    pnpm add --save-dev typescript tsx @types/node
-    ```
-
-=== "yarn"
-
-    ```bash
-    yarn add @google/adk zod dotenv
-    yarn add --dev typescript tsx @types/node
-    ```
-
-`@google/adk` brings the A2A stack with it: both the A2A SDK (`@a2a-js/sdk`) and Express are
-direct dependencies of the package, not peer dependencies, so there is nothing else to
-install to make A2A work. `zod` defines the tool's input schema, and `dotenv` loads `.env`.
-Keep `zod` on **v4**: `@google/adk@1.5.0` depends on `zod@^4.2.1`, and a `zod@3` in your own
-`package.json` puts two incompatible copies in `node_modules`, after which `tsc` rejects
-every tool schema you write.
-
-### 3. Add your credentials { #add-your-credentials }
-
-Pick the backend you have access to. Either way the file is `.env`, next to `package.json`,
-and this is its entire contents:
+Then add your model credentials. Either way the file is `.env`, next to `package.json`, and this is its entire contents:
 
 === "Gemini API key"
 
-    ```bash title="examples/typescript/a2a_basic/.env"
+    ```bash title="a2a_basic/.env"
     GOOGLE_GENAI_API_KEY=your-api-key-here
     ```
 
@@ -196,430 +86,204 @@ and this is its entire contents:
 
 === "Vertex AI"
 
-    ```bash title="examples/typescript/a2a_basic/.env"
+    ```bash title="a2a_basic/.env"
     GOOGLE_GENAI_USE_VERTEXAI=true
     GOOGLE_CLOUD_PROJECT=your-project-id
     GOOGLE_CLOUD_LOCATION=global
     ```
 
-    No key. Credentials come from application default credentials, so run this once:
+    No key. Credentials come from application default credentials, so run
+    `gcloud auth application-default login` once. `GOOGLE_GENAI_USE_VERTEXAI=true` is what
+    switches backends; without it ADK looks for an API key and ignores the project. `global`
+    works for `GOOGLE_CLOUD_LOCATION` unless you need a specific region. To confirm you are on
+    this path, watch for `backend: VERTEX_AI` in the `INFO: [ADK] … Sending out request` line
+    each model call prints — it says `backend: GEMINI_API` on the API-key path.
 
-    ```bash
-    gcloud auth application-default login
-    ```
+!!! note "Which process needs the credentials"
 
-    `GOOGLE_GENAI_USE_VERTEXAI=true` is what switches backends; without it ADK looks for an
-    API key and ignores the project. `global` works for `GOOGLE_CLOUD_LOCATION` unless you
-    need a specific region. To confirm you are on this path, watch for
-    `backend: VERTEX_AI` in the `INFO: [ADK] … Sending out request` line each model call
-    prints — it says `backend: GEMINI_API` on the API-key path.
+    The **remote agent** always needs them — it owns the model call. The **routing agent** needs
+    them too, because it runs its own model to decide where to send each request. The **direct
+    client** needs none at all; that is the point of A2A, and `direct_client.ts` does not even
+    import `dotenv`.
 
-Get this wrong and the two halves fail in ways that look nothing alike. The **remote agent**
-does not throw: it packages the failure into its A2A reply, so your client prints an error
-event and still exits `0`. The **routing agent** builds its model in-process and really does
-throw, with exit `1`. Both are in [Troubleshooting](#troubleshooting).
+### 2. Start the Remote Prime Agent server { #start-the-remote-prime-agent-server }
 
-### 4. Start the remote agent { #start-the-remote-agent }
+To show how your ADK agent can consume a remote agent via A2A, you'll first need to start a remote agent server, which will host the prime agent. It is an ordinary `LlmAgent`; `toA2a()` is the only A2A-specific line, and `app.listen()` is yours to call because `toA2a()`'s `port` option only decorates the agent card.
 
-This is the agent your client will call. It is an ordinary `LlmAgent`; `toA2a()` is the only
-A2A-specific line.
-
-```typescript title="examples/typescript/a2a_basic/remote_prime_agent.ts"
+```typescript title="a2a_basic/remote_prime_agent.ts"
 --8<-- "examples/typescript/a2a_basic/remote_prime_agent.ts:full"
 ```
-
-Let's take a look at what is happening in this code:
-
-1. **`checkPrime`** is a plain `FunctionTool`. Its `parameters` are a `z.object({ numbers:
-   z.array(z.number()) })`, and that schema is what types the `{ numbers }` destructured in
-   `execute` — `numbers` is a `number[]` with no annotation written by hand.
-2. **`primeAgent`** is an `LlmAgent` like any other. Nothing about it is written for A2A.
-3. **`toA2a(primeAgent, {...})`** returns an `express.Application`. It is `await`ed because
-   it builds the agent card asynchronously.
-4. **`allowUnauthenticated: true`** is mandatory here and local-only: without it `toA2a()`
-   throws and refuses to mount, because an unauthenticated A2A endpoint lets any caller that
-   can reach the port invoke the agent and its tools. It logs a loud `SECURITY WARNING` when
-   you use it.
-5. **`app.listen(PORT)`** is yours to call. `toA2a()` never starts a server — its `port`
-   option only decorates the agent card, so the two must agree.
 
 Run it, and leave it running:
 
 ```bash
-npx tsx remote_prime_agent.ts
+npx tsx remote_prime_agent.ts    # or: npm run serve:prime
 ```
 
-```text
-WARN: [ADK] 2026-08-05T17:27:54.112Z SECURITY WARNING: Mounting the A2A server WITHOUT authentication because `allowUnauthenticated: true` was set. The agent and all of its tools are exposed to any network-reachable caller, which can invoke them with arbitrary input and read the output. Do NOT use this outside of local, trusted development.
-(node:4058702) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+Once executed, you should see something like:
+
+```console
+WARN: [ADK] 2026-08-06T21:17:35.200Z SECURITY WARNING: Mounting the A2A server WITHOUT authentication because `allowUnauthenticated: true` was set. The agent and all of its tools are exposed to any network-reachable caller, which can invoke them with arbitrary input and read the output. Do NOT use this outside of local, trusted development.
+(node:2816572) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 [server] prime_agent listening on http://localhost:8001
 [server] agent card: http://localhost:8001/.well-known/agent-card.json
 ```
 
-Those two `punycode` lines come from a transitive dependency and are harmless. Node 22 prints
-them on **every** command on this page; the later transcripts leave them out, along with the
-`INFO: [ADK] … Sending out request, model: gemini-2.5-flash …` line each model call emits.
-Extra Node warning lines do not mean you have gone wrong.
+`allowUnauthenticated: true` is mandatory here and local-only: without it `toA2a()` refuses to mount, because an unauthenticated A2A endpoint lets any caller that can reach the port invoke the agent and its tools. The two `punycode` lines come from a transitive dependency and are harmless — Node 22 prints them on **every** command on this page, and the later transcripts leave them out along with the `INFO: [ADK] … Sending out request` line each model call emits.
 
-### 5. Confirm the agent card is being served { #confirm-the-agent-card }
+!!! note "The remote agent's failures arrive as events, not exceptions"
 
-Every A2A agent publishes a card describing what it can do, and that card is what
-`RemoteA2AAgent` fetches first. ADK generates it from your agent — you never write it by
-hand:
+    If the remote agent has no credentials, or the wrong ones, it does not throw: it packages
+    the failure into its A2A reply, your client prints an error event, and the process still
+    exits `0`. The remote terminal logs nothing at all. So check that `.env` exists next to
+    `package.json` **in the directory you started the remote agent from**. Local agents are the
+    opposite — `consuming_agent.ts` builds its model in-process, so missing credentials there
+    really do throw, with exit `1`.
+
+### 3. Look out for the required agent card of the remote agent { #look-out-for-the-required-agent-card-of-the-remote-agent }
+
+A2A Protocol requires that each agent must have an agent card that describes what it does, and that card is what `RemoteA2AAgent` fetches first.
+
+In the TypeScript ADK, the agent card is generated dynamically when you expose an agent with `toA2a()` — you never write it by hand. You can visit `http://localhost:8001/.well-known/agent-card.json` to see the generated card:
 
 ```bash
-curl -s http://localhost:8001/.well-known/agent-card.json
+curl -s http://localhost:8001/.well-known/agent-card.json \
+  | jq '{name, url, capabilities, skills: [.skills[] | {name, description}]}'
 ```
 
 ```json
 {
-    "name": "prime_agent",
-    "description": "Checks whether numbers are prime.",
-    "protocolVersion": "0.3.0",
-    "version": "1.0.0",
-    "skills": [
-        {
-            "id": "prime_agent",
-            "name": "model",
-            "description": "Checks whether numbers are prime. I check whether numbers are prime. Always call the check_prime tool, then answer in one short sentence.",
-            "tags": ["llm"]
-        },
-        {
-            "id": "prime_agent-check_prime",
-            "name": "check_prime",
-            "description": "Checks which numbers in a list are prime.",
-            "tags": ["llm", "tools"]
-        }
-    ],
-    "url": "http://localhost:8001/jsonrpc",
-    "preferredTransport": "JSONRPC",
-    "capabilities": {
-        "extensions": [],
-        "stateTransitionHistory": false,
-        "pushNotifications": false,
-        "streaming": true
+  "name": "prime_agent",
+  "url": "http://localhost:8001/jsonrpc",
+  "capabilities": {
+    "extensions": [],
+    "stateTransitionHistory": false,
+    "pushNotifications": false,
+    "streaming": true
+  },
+  "skills": [
+    {
+      "name": "model",
+      "description": "Checks whether numbers are prime. I check whether numbers are prime. Always call the check_prime tool, then answer in one short sentence."
     },
-    "defaultInputModes": ["text"],
-    "defaultOutputModes": ["text"],
-    "additionalInterfaces": [
-        {"url": "http://localhost:8001/jsonrpc", "transport": "JSONRPC"},
-        {"url": "http://localhost:8001/rest", "transport": "HTTP+JSON"}
-    ]
+    {
+      "name": "check_prime",
+      "description": "Checks which numbers in a list are prime."
+    }
+  ]
 }
 ```
 
-Two things to notice, because both surprise people the first time:
+Two things to notice, because both surprise people the first time. Your instruction `"You check whether numbers are prime"` is published as `"I check whether numbers are prime"` — card descriptions are rewritten into the first person on purpose. And `capabilities.streaming` is `true`, so `RemoteA2AAgent` uses the streaming transport; that is where the partial events in step 4 come from.
 
-- Your instruction `"You check whether numbers are prime"` is published as `"I check
-  whether numbers are prime"`. Card descriptions are rewritten into the first person on
-  purpose.
-- `capabilities.streaming` is `true`, so `RemoteA2AAgent` will use the streaming transport.
-  That is where the `event.partial` chunks in step 6 come from.
+### 4. Run the Main (Consuming) Agent { #run-the-main-consuming-agent }
 
-### 6. Point a client at it and run { #point-a-client-at-it-and-run }
+With `remote_prime_agent.ts` still running in the first terminal, call it directly:
 
-The client is `direct_client.ts`, shown in full at the top of this page. The part that
-matters is one constructor call:
+```bash
+npx tsx direct_client.ts       # or: npm run direct
+```
 
-```typescript title="examples/typescript/a2a_basic/direct_client.ts"
+Or let a local agent route to it:
+
+```bash
+npx tsx consuming_agent.ts     # or: npm run consume
+```
+
+#### How it works
+
+The main agent uses `RemoteA2AAgent` to consume the remote agent (`prime_agent` in our example). It requires the `name`, the `description`, and the **base URL** of the agent card:
+
+```typescript title="a2a_basic/direct_client.ts"
 --8<-- "examples/typescript/a2a_basic/direct_client.ts:remote-agent"
 ```
 
-In a second terminal:
+!!! warning "`agentCard` is a base URL, not the URL of the card"
 
-```bash
-npx tsx direct_client.ts
+    `RemoteA2AAgent` appends `.well-known/agent-card.json` itself, so passing the card URL
+    doubles the path. Card resolution happens before the error handling that produces
+    `event.errorMessage`, so unlike every other remote failure this one takes the process down:
+    `Error: Failed to fetch Agent Card from http://localhost:8001/.well-known/.well-known/agent-card.json: 404`.
+    The same trap has a second form: if the remote agent was mounted under a `basePath`, your
+    base URL needs a **trailing slash**, because `new URL()` drops the last segment without one.
+
+    ```typescript
+    agentCard: 'http://localhost:8001/.well-known/agent-card.json',  // Wrong — 404s and exits.
+    agentCard: 'http://localhost:8001',                              // Right.
+    ```
+
+`RemoteA2AAgent` extends `BaseAgent`, so anywhere ADK accepts an agent it accepts this one, and a `Runner` drives it exactly as it drives a local agent — `runAsync()` returns an async iterable of events, and there is no separate "A2A client" API to learn:
+
+```typescript title="a2a_basic/direct_client.ts"
+--8<-- "examples/typescript/a2a_basic/direct_client.ts:event-loop"
 ```
+
+!!! warning "Read `event.errorMessage`, or remote failures are silent"
+
+    Remote failures are *not* thrown and the process still exits `0`. A loop that only reads
+    `event.content` shows you nothing but your own prompt: a transport failure gets one line out
+    of ADK's own logger (`ERROR: [ADK] … A2ARemoteAgent prime_agent failed: TypeError: fetch
+    failed`) before the silence, and a failure *inside* the remote agent prints nothing at all.
+    Check `errorMessage` first, as `direct_client.ts` does.
+
+`event.partial` marks the streamed chunks of an answer that is still being written; skipping them prints the finished sentence once. Drop that line and the same run prints the answer in pieces and then again in full — on one run here, `Yes`, then `, 7 is a prime number.`, then `Yes, 7 is a prime number.` Where the chunk boundaries fall varies from run to run.
+
+Because `RemoteA2AAgent` extends `BaseAgent`, it also drops straight into `subAgents`, and ADK's routing treats it like any local sub-agent. That is what `consuming_agent.ts` does:
+
+```typescript title="a2a_basic/consuming_agent.ts"
+--8<-- "examples/typescript/a2a_basic/consuming_agent.ts:remote-agent"
+
+--8<-- "examples/typescript/a2a_basic/consuming_agent.ts:root-agent"
+```
+
+`subAgents: [rollAgent, primeAgent]` mixes local and remote freely. `rootAgent`'s model sees both and emits a `transfer_to_agent` call to pick one; ADK turns that into an A2A request when the target is remote. The `description` on `primeAgent` is doing real work here — it is the text the routing model reads to decide that "is this prime?" belongs to `prime_agent`.
+
+## Example Interactions
+
+Once both your main and remote agents are running, you can interact with the root agent to see how it calls the remote agent via A2A:
+
+**Prime Number Checking:**
+
+This interaction uses a remote agent via A2A, the Prime Agent. `npx tsx direct_client.ts` prints:
 
 ```text
 user > Is 7 a prime number?
 prime_agent > Yes, 7 is a prime number.
 ```
 
-That answer came out of the other process. Look at the terminal running
-`remote_prime_agent.ts` and you will see the tool that produced it actually executed there:
+That answer came out of the other process. The terminal running `remote_prime_agent.ts` shows the tool that produced it actually executing there:
 
 ```text
 [server] check_prime(7) -> 7
 ```
 
-You now have a working A2A call, and the client that made it holds no API key.
+**Combined Operations:**
 
-## Route to the remote agent from a local agent
-
-Calling a remote agent directly is useful when you already know you want it. The more
-interesting shape is handing it to a model as one option among several: because
-`RemoteA2AAgent` extends `BaseAgent`, it drops into `subAgents` and ADK's routing treats it
-like any local sub-agent.
-
-### 7. Add a root agent with the remote agent as a sub-agent { #add-a-root-agent }
-
-```typescript title="examples/typescript/a2a_basic/consuming_agent.ts"
---8<-- "examples/typescript/a2a_basic/consuming_agent.ts:imports"
-
---8<-- "examples/typescript/a2a_basic/consuming_agent.ts:roll-agent"
-
---8<-- "examples/typescript/a2a_basic/consuming_agent.ts:remote-agent"
-
---8<-- "examples/typescript/a2a_basic/consuming_agent.ts:root-agent"
-```
-
-Let's take a look at what is happening in this code:
-
-1. **`rollAgent`** is a local `LlmAgent` with a local `roll_die` tool. It runs in this
-   process.
-2. **`primeAgent`** is the same `RemoteA2AAgent` as before, unchanged. Nothing about
-   composition requires a different construction.
-3. **`subAgents: [rollAgent, primeAgent]`** mixes local and remote freely. `rootAgent`'s
-   model sees both and emits a `transfer_to_agent` call to pick one; ADK turns that into an
-   A2A request when the target is remote.
-4. **`description`** on `primeAgent` is doing real work now — it is the text the routing
-   model reads to decide that "is this prime?" belongs to `prime_agent`.
-
-The loop that prints the run is the same one from `direct_client.ts`, plus one branch so
-you can watch the routing happen:
-
-```typescript title="examples/typescript/a2a_basic/consuming_agent.ts"
---8<-- "examples/typescript/a2a_basic/consuming_agent.ts:run"
-```
-
-`part.functionCall` catches both the `transfer_to_agent` handoffs and the tool calls the
-remote agent makes on its own side, which stream back to you as ordinary events.
-
-### 8. Run it { #run-it }
-
-With `remote_prime_agent.ts` still running in the first terminal:
-
-```bash
-npx tsx consuming_agent.ts
-```
+This interaction uses both the local Roll Agent and the remote Prime Agent. `npx tsx consuming_agent.ts` prints:
 
 ```text
 user > Roll a 6-sided die and tell me whether the result is prime.
 root_agent calls transfer_to_agent({"agentName":"roll_agent"})
 roll_agent calls roll_die({"sides":6})
-roll_agent > The result of your 6-sided die roll is 6.
+roll_agent > I rolled a 6-sided die and got 1.
 roll_agent calls transfer_to_agent({"agentName":"prime_agent"})
-prime_agent calls check_prime({"numbers":[6]})
-prime_agent > 6 is not a prime number.
+prime_agent calls check_prime({"numbers":[1]})
+prime_agent > 1 is not a prime number.
 ```
-
-Read that trace bottom-up and you can see the whole point: `check_prime({"numbers":[6]})`
-was decided by a model in *your* process, executed by a tool in a *different* process, and
-the sentence came back over A2A as an event your loop printed. The remote terminal confirms
-its half:
 
 ```text
-[server] check_prime(6) -> none
+[server] check_prime(1) -> none
 ```
 
-**Compare the shape, not the words.** The four `calls` lines are the same on every run, in
-that order; that is the part worth checking. The two `>` lines are model prose and will be
-worded differently for you. Across eight consecutive runs here the four `calls` lines were
-identical eight times and the two sentences never were: `roll_agent` said
-`I rolled a 5.`, `The result of your 6-sided die roll is 6.` and
-`I rolled a 6-sided die and got 2.`, and `prime_agent` answered `Yes, 5 is prime.`,
-`4 is not prime.` and `2 is a prime number.` Do not diff this transcript character by
-character.
+That trace is the whole point: `check_prime` was decided by a model in *your* process, executed by a tool in a *different* process, and the sentence came back over A2A as an event your loop printed.
 
-Routing is still a model decision, and it can go wrong: given a vaguer instruction,
-`roll_agent` sometimes handed straight back to `root_agent` without rolling and the run
-ended with `root_agent` asking what the number was — no A2A call at all. That is what the
-`Never transfer to another agent before you have reported a number` clause in `roll_agent`'s
-instruction is for.
+**Compare the shape, not the words.** The four `calls` lines are the same on every run, in that order; that is the part worth checking. The two `>` lines are model prose and will be worded differently for you — and the rolled number changes every time. Routing is a model decision and it can go wrong: given a vaguer instruction, `roll_agent` sometimes handed straight back to `root_agent` without rolling, and the run ended with no A2A call at all. That is what the `Never transfer to another agent before you have reported a number` clause in `roll_agent`'s instruction is for.
 
-## Troubleshooting
+## Next Steps
 
-### `Failed to fetch Agent Card from …/.well-known/.well-known/agent-card.json: 404`
+Now that you have created an agent that's using a remote agent via an A2A server, the next step is to learn how to expose your own agent.
 
-You passed the **card URL** as `agentCard` instead of the **base URL**. The resolver appends
-`.well-known/agent-card.json` to whatever you give it, so the path doubles. This one does
-not surface as an error event — it takes the process down:
-
-```text
-Error: Failed to fetch Agent Card from http://localhost:8001/.well-known/.well-known/agent-card.json: 404
-    at DefaultAgentCardResolver.resolve (…/@a2a-js/sdk/dist/client/index.js:723:13)
-    at async resolveAgentCard (…/@google/adk/dist/esm/a2a/agent_card.js:28:12)
-    at async RemoteA2AAgent.init (…/@google/adk/dist/esm/a2a/a2a_remote_agent.js:43:19)
-
-Node.js v22.22.2
-```
-
-Card resolution happens before the error handling that produces `event.errorMessage`, which
-is why this crashes when every other remote failure does not.
-
-```typescript
-// Wrong — 404s and exits.
-agentCard: 'http://localhost:8001/.well-known/agent-card.json',
-
-// Right.
-agentCard: 'http://localhost:8001',
-```
-
-The same trap has a second form. If the remote agent was mounted under a `basePath`, your
-base URL needs a **trailing slash**, because `new URL()` drops the last segment without one:
-
-```text
-http://localhost:8001/a2a   ->  http://localhost:8001/.well-known/agent-card.json      # "a2a" silently dropped
-http://localhost:8001/a2a/  ->  http://localhost:8001/a2a/.well-known/agent-card.json  # correct
-```
-
-### `TypeError: fetch failed`
-
-Nothing answered at the address. Two different causes, and the difference is where it
-appears:
-
-- **Your `agentCard` URL points at a port nothing is listening on.** The card fetch itself
-  fails, so it crashes the process the same way the 404 above does, with
-  `[cause]: AggregateError [ECONNREFUSED]`. Check the port in `agentCard` against the one
-  the remote terminal printed.
-- **The card resolved, but the URL inside it is dead.** This one arrives as an error event:
-
-    ```text
-    ERROR: [ADK] 2026-08-05T18:41:10.405Z A2ARemoteAgent prime_agent failed: TypeError: fetch failed
-    [error] prime_agent: fetch failed
-    ```
-
-    That means the remote server's `toA2a({ port })` and its `app.listen(port)` disagree.
-    `toA2a`'s `port` only writes the `"url"` field of the agent card; it starts nothing. If
-    they differ, the card fetch succeeds and every RPC afterwards goes to a port with no
-    server on it.
-
-### The client prints your prompt, then almost nothing, and exits 0
-
-Your event loop reads `event.content` but never `event.errorMessage`. Remote failures do not
-throw and do not produce content, so a loop like this shows you a near-empty screen:
-
-```typescript
-for await (const event of runner.runAsync({ /* ... */ })) {
-  // Nothing here will ever run when the remote agent fails.
-  for (const part of event.content?.parts ?? []) {
-    if (part.text) console.log(part.text);
-  }
-}
-```
-
-You are not left with *nothing*, but with almost nothing, and only for some failures.
-A transport failure gets one line out of ADK's own logger before the silence:
-
-```text
-user > Is 7 a prime number?
-ERROR: [ADK] 2026-08-05T18:41:14.373Z A2ARemoteAgent prime_agent failed: TypeError: fetch failed
-```
-
-A failure *inside* the remote agent — a bad model call, a throwing tool — prints nothing at
-all. Either way the exit code is `0`.
-
-Always check `errorMessage` first, as `direct_client.ts` does:
-
-```typescript
-if (event.errorMessage) {
-  console.error(`[error] ${event.author}: ${event.errorMessage}`);
-  continue;
-}
-```
-
-### `500 Internal Server Error. RPC Error: General processing error. (Code: -32603)`
-
-The remote agent is authenticated and rejected you. The full event text is:
-
-```text
-[error] prime_agent: HTTP error establishing stream for message/stream: 500 Internal Server Error. RPC Error: General processing error. (Code: -32603)
-```
-
-**Do not go looking for a 401.** A rejected A2A request comes back as HTTP 500 with JSON-RPC
-code `-32603` and no hint that credentials were the problem. Confusing matters further, the
-agent card endpoint is *never* authenticated — only `/jsonrpc` and `/rest` are — so
-`curl`ing the card returns `200` even when every call you make is being refused.
-
-`RemoteA2AAgent` has no token option, so there is nowhere obvious to put a credential.
-Attaching one means replacing the client's transport:
-
-??? note "Sending an Authorization header from a RemoteA2AAgent"
-
-    Swap the `primeAgent` constant in `direct_client.ts` for the version below. Only the
-    `@a2a-js/sdk/client` import is new — `RemoteA2AAgent` is already imported at the top of
-    that file.
-
-    ```typescript title="examples/typescript/a2a_basic/direct_client.ts"
-    import {
-      ClientFactory,
-      ClientFactoryOptions,
-      JsonRpcTransportFactory,
-    } from '@a2a-js/sdk/client';
-
-    const authFetch: typeof fetch = (input, init = {}) =>
-      fetch(input, {
-        ...init,
-        headers: { ...(init.headers ?? {}), Authorization: `Bearer ${process.env.A2A_TOKEN}` },
-      });
-
-    const primeAgent = new RemoteA2AAgent({
-      name: 'prime_agent',
-      description: 'Remote agent that checks whether numbers are prime.',
-      agentCard: 'http://localhost:8001',
-      clientFactory: new ClientFactory(
-        ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
-          transports: [new JsonRpcTransportFactory({ fetchImpl: authFetch })],
-        }),
-      ),
-    });
-    ```
-
-    Add `@a2a-js/sdk` to your own `package.json` if you import from it like this. It resolves
-    today through `@google/adk`'s own dependency tree, but that is npm hoisting doing you a
-    favour, and pnpm will not.
-
-### `[error] prime_agent: Agent run failed: API key must be provided …`
-
-The **remote agent** has no credentials. This is the one people expect to throw, and it does
-not:
-
-```text
-user > Is 7 a prime number?
-[error] prime_agent: Agent run failed: API key must be provided via constructor or GOOGLE_GENAI_API_KEY or GEMINI_API_KEY environment variable.
-```
-
-Exit code `0`, and the remote terminal logs nothing at all — the error is packaged into the
-A2A response instead. Check that `.env` exists next to `package.json` **in the directory you
-started the remote agent from** (see [step 3](#add-your-credentials)).
-
-The local agents are the opposite. `consuming_agent.ts` builds its own model in-process, so
-missing credentials there really do throw — same message, but as an uncaught
-`Error:` whose first stack frame is `at new Gemini (…/models/google_llm.js:52:13)`, and
-exit `1`.
-
-### A ~30-line JSON dump starting `[error] prime_agent: {`
-
-The remote agent's key exists but is **wrong**. The provider's raw error is passed through
-verbatim, so it does not look like an ADK message at all:
-
-```text
-[error] prime_agent: {
-  "error": {
-    "code": 400,
-    "message": "API key not valid. Please pass a valid API key.",
-    "status": "INVALID_ARGUMENT",
-    …
-```
-
-Exit code `0` again. Twenty or so more lines of `details` follow, ending with a
-`DebugInfo` entry that echoes the key you actually sent — worth reading, because it is
-usually a truncated paste or a stale key rather than the one in `.env`.
-
-## Next steps
-
-- **Let other agents call the agent you just wrote** —
-  [A2A Quickstart (Exposing)](quickstart-exposing-typescript.md) covers `toA2a()`,
-  authentication that is not `allowUnauthenticated`, and what ends up in your agent card.
-- **Understand what is actually on the wire** —
-  [Introduction to A2A](intro.md) walks through agent cards, tasks, and the JSON-RPC
-  messages your client is exchanging.
-- **Give the routing model something local to choose instead** — define a
-  [function tool](../tools-custom/function-tools.md) so `root_agent` can answer some
-  requests itself rather than delegating every one of them.
-- **Hand the remote agent to a model as a tool rather than a destination** —
-  [Agent-as-a-Tool](../tools-custom/function-tools.md#agent-tool) wraps an agent — and a
-  `RemoteA2AAgent` is a `BaseAgent` like any other — so the caller gets the answer back and
-  keeps control instead of transferring away.
+- [**A2A Quickstart (Exposing)**](quickstart-exposing-typescript.md): Learn how to expose your existing agent so that other agents can use it via the A2A Protocol, including authentication that is not `allowUnauthenticated`.
+- [**Introduction to A2A**](intro.md): agent cards, tasks, and the JSON-RPC messages your client is exchanging.
+- [**Agent-as-a-Tool**](../tools-custom/function-tools.md#agent-tool): wrap the remote agent as a tool rather than a destination, so the caller gets the answer back and keeps control instead of transferring away.

--- a/docs/a2a/quickstart-consuming-typescript.md
+++ b/docs/a2a/quickstart-consuming-typescript.md
@@ -34,22 +34,14 @@ Let's take a look at what is happening in this code:
    so write it for that audience.
 4. **`Runner`** drives the agent exactly as it drives a local one: `runAsync()` returns an
    async iterable of events. There is no separate "A2A client" API to learn.
-5. **`event.errorMessage`** is how remote failures arrive. They are *not* thrown. A loop
-   that only reads `event.content` prints nothing at all when the remote agent fails.
+5. **`event.errorMessage`** is how remote failures arrive. They are *not* thrown, and the
+   process still exits `0`. A loop that only reads `event.content` shows you nothing but
+   your own prompt when the remote agent fails.
 6. **`event.partial`** marks the streamed chunks of an answer that is still being written.
    Skipping them prints the finished sentence once. Drop that line and the same run prints
    `Yes, 7 is a`, then ` prime number.`, then `Yes, 7 is a prime number.` again.
 
 ## What you are building
-
-```text
-┌──────────────────────┐        A2A / JSON-RPC        ┌────────────────────────┐
-│  Your ADK app        │  ──────────────────────────▶ │  prime_agent           │
-│  (direct_client.ts   │                              │  (remote_prime_agent   │
-│   or consuming_      │  ◀────────────────────────── │   .ts, localhost:8001) │
-│   agent.ts)          │        events + answer       │  owns the model call   │
-└──────────────────────┘                              └────────────────────────┘
-```
 
 - **`prime_agent`** — an `LlmAgent` with a `check_prime` tool, published over A2A. It runs
   in its own Node process and makes its own model calls.
@@ -74,18 +66,12 @@ Let's take a look at what is happening in this code:
 - **Node.js 22 or later.** Everything on this page was run on Node v22.22.2 with npm 9.2.0.
   `@google/adk` publishes no `engines` field, so npm will not warn you on an older runtime —
   but the examples use ESM and top-level `await`, which need a current Node.
-- **A Gemini API key.** Get one from [Google AI Studio](https://aistudio.google.com/apikey).
-- **The exact file is `.env`**, in the same directory as `package.json`, containing exactly
-  this line:
-
-    ```bash title="examples/typescript/a2a_basic/.env"
-    GOOGLE_GENAI_API_KEY=your-api-key-here
-    ```
-
-    Replace `your-api-key-here` with the key you just copied. ADK reads
-    `GOOGLE_GENAI_API_KEY` or `GEMINI_API_KEY`, in that order. If neither is set, the first
-    model call throws
-    `Error: API key must be provided via constructor or GOOGLE_GENAI_API_KEY or GEMINI_API_KEY environment variable.`
+- **Credentials for Gemini.** Either a Gemini API key from
+  [Google AI Studio](https://aistudio.google.com/apikey), or a Google Cloud project with the
+  Vertex AI API enabled and `gcloud auth application-default login` already run. Step 3 gives
+  the literal `.env` for both.
+- **The exact file is `.env`**, in the same directory as `package.json`. The examples load it
+  with `dotenv`, which reads that filename and no other.
 
 !!! note "Which process needs the key"
 
@@ -94,14 +80,13 @@ Let's take a look at what is happening in this code:
     agent** (step 8) needs one too, because it runs its own model to decide where to send
     each request.
 
+    The split is identical on Vertex AI: the two processes that call a model need
+    `GOOGLE_CLOUD_PROJECT` and application default credentials, and the direct client still
+    needs nothing. `direct_client.ts` does not even import `dotenv`.
+
 ## Call a remote agent directly
 
 ### 1. Get the example code { #get-the-example-code }
-
-```bash
-git clone https://github.com/google/adk-docs.git
-cd adk-docs/examples/typescript/a2a_basic
-```
 
 Three runnable files, and the two config files they need:
 
@@ -115,7 +100,44 @@ a2a_basic/
 └── README.md
 ```
 
+Everything above except `README.md` is reproduced in full on this page, so you can either
+clone the files or paste them.
+
+=== "Clone them"
+
+    ```bash
+    git clone https://github.com/google/adk-docs.git
+    cd adk-docs/examples/typescript/a2a_basic
+    ```
+
+    `a2a_basic/` was added to `adk-docs` alongside this page. If `cd` fails with
+    `No such file or directory`, your clone predates it — `git pull`, or use the other tab.
+
+=== "Paste them"
+
+    ```bash
+    mkdir a2a_basic && cd a2a_basic
+    ```
+
+    Then create each file as you reach it: `package.json` and `tsconfig.json` in step 2,
+    `remote_prime_agent.ts` in step 4, `direct_client.ts` (shown in full at the top of this
+    page) in step 6, `consuming_agent.ts` in step 7. `README.md` is not needed to run
+    anything.
+
 ### 2. Install the dependencies { #install-the-dependencies }
+
+Both config files in full. `"type": "module"` and `"module": "nodenext"` are what allow the
+top-level `await` the examples use:
+
+```json title="examples/typescript/a2a_basic/package.json"
+--8<-- "examples/typescript/a2a_basic/package.json"
+```
+
+```json title="examples/typescript/a2a_basic/tsconfig.json"
+--8<-- "examples/typescript/a2a_basic/tsconfig.json"
+```
+
+Then install:
 
 === "npm"
 
@@ -141,36 +163,49 @@ a2a_basic/
 `@google/adk` brings the A2A stack with it: both the A2A SDK (`@a2a-js/sdk`) and Express are
 direct dependencies of the package, not peer dependencies, so there is nothing else to
 install to make A2A work. `zod` defines the tool's input schema, and `dotenv` loads `.env`.
-Pin `zod` to **v4** — `@google/adk@1.5.0` depends on `zod@^4.2.1`, and a `zod@3` in your own
-`package.json` produces two incompatible copies (see [Troubleshooting](#troubleshooting)).
+Keep `zod` on **v4**: `@google/adk@1.5.0` depends on `zod@^4.2.1`, and a `zod@3` in your own
+`package.json` puts two incompatible copies in `node_modules`, after which `tsc` rejects
+every tool schema you write.
 
-Two settings the examples depend on, both already set in the checked-in files. Only the
-relevant keys are shown; the rest of each file is unchanged:
+### 3. Add your credentials { #add-your-credentials }
 
-```json title="examples/typescript/a2a_basic/package.json (excerpt)"
-{
-  "type": "module"
-}
-```
+Pick the backend you have access to. Either way the file is `.env`, next to `package.json`,
+and this is its entire contents:
 
-```json title="examples/typescript/a2a_basic/tsconfig.json (excerpt)"
-{
-  "compilerOptions": {
-    "module": "nodenext",
-    "moduleResolution": "nodenext"
-  }
-}
-```
+=== "Gemini API key"
 
-`"type": "module"` and `"module": "nodenext"` are what allow the top-level `await` these
-files use. Set `"module": "commonjs"` instead and `tsc` stops with
-`error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.`
+    ```bash title="examples/typescript/a2a_basic/.env"
+    GOOGLE_GENAI_API_KEY=your-api-key-here
+    ```
 
-### 3. Add your API key { #add-your-api-key }
+    Replace `your-api-key-here` with a key from
+    [Google AI Studio](https://aistudio.google.com/apikey). ADK reads `GOOGLE_GENAI_API_KEY`
+    or `GEMINI_API_KEY`, in that order — and **not** `GOOGLE_API_KEY`.
 
-```bash
-echo "GOOGLE_GENAI_API_KEY=your-api-key-here" > .env
-```
+=== "Vertex AI"
+
+    ```bash title="examples/typescript/a2a_basic/.env"
+    GOOGLE_GENAI_USE_VERTEXAI=true
+    GOOGLE_CLOUD_PROJECT=your-project-id
+    GOOGLE_CLOUD_LOCATION=global
+    ```
+
+    No key. Credentials come from application default credentials, so run this once:
+
+    ```bash
+    gcloud auth application-default login
+    ```
+
+    `GOOGLE_GENAI_USE_VERTEXAI=true` is what switches backends; without it ADK looks for an
+    API key and ignores the project. `global` works for `GOOGLE_CLOUD_LOCATION` unless you
+    need a specific region. To confirm you are on this path, watch for
+    `backend: VERTEX_AI` in the `INFO: [ADK] … Sending out request` line each model call
+    prints — it says `backend: GEMINI_API` on the API-key path.
+
+Get this wrong and the two halves fail in ways that look nothing alike. The **remote agent**
+does not throw: it packages the failure into its A2A reply, so your client prints an error
+event and still exits `0`. The **routing agent** builds its model in-process and really does
+throw, with exit `1`. Both are in [Troubleshooting](#troubleshooting).
 
 ### 4. Start the remote agent { #start-the-remote-agent }
 
@@ -204,9 +239,16 @@ npx tsx remote_prime_agent.ts
 
 ```text
 WARN: [ADK] 2026-08-05T17:27:54.112Z SECURITY WARNING: Mounting the A2A server WITHOUT authentication because `allowUnauthenticated: true` was set. The agent and all of its tools are exposed to any network-reachable caller, which can invoke them with arbitrary input and read the output. Do NOT use this outside of local, trusted development.
+(node:4058702) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+(Use `node --trace-deprecation ...` to show where the warning was created)
 [server] prime_agent listening on http://localhost:8001
 [server] agent card: http://localhost:8001/.well-known/agent-card.json
 ```
+
+Those two `punycode` lines come from a transitive dependency and are harmless. Node 22 prints
+them on **every** command on this page; the later transcripts leave them out, along with the
+`INFO: [ADK] … Sending out request, model: gemini-2.5-flash …` line each model call emits.
+Extra Node warning lines do not mean you have gone wrong.
 
 ### 5. Confirm the agent card is being served { #confirm-the-agent-card }
 
@@ -302,6 +344,8 @@ like any local sub-agent.
 ### 7. Add a root agent with the remote agent as a sub-agent { #add-a-root-agent }
 
 ```typescript title="examples/typescript/a2a_basic/consuming_agent.ts"
+--8<-- "examples/typescript/a2a_basic/consuming_agent.ts:imports"
+
 --8<-- "examples/typescript/a2a_basic/consuming_agent.ts:roll-agent"
 
 --8<-- "examples/typescript/a2a_basic/consuming_agent.ts:remote-agent"
@@ -343,15 +387,11 @@ npx tsx consuming_agent.ts
 user > Roll a 6-sided die and tell me whether the result is prime.
 root_agent calls transfer_to_agent({"agentName":"roll_agent"})
 roll_agent calls roll_die({"sides":6})
-roll_agent > I rolled a 6-sided die and got a 6.
-
+roll_agent > The result of your 6-sided die roll is 6.
 roll_agent calls transfer_to_agent({"agentName":"prime_agent"})
 prime_agent calls check_prime({"numbers":[6]})
 prime_agent > 6 is not a prime number.
 ```
-
-(ADK also prints `INFO: [ADK] … Sending out request, model: gemini-2.5-flash …` lines
-between these, one per model call. They are left out here for readability.)
 
 Read that trace bottom-up and you can see the whole point: `check_prime({"numbers":[6]})`
 was decided by a model in *your* process, executed by a tool in a *different* process, and
@@ -362,7 +402,20 @@ its half:
 [server] check_prime(6) -> none
 ```
 
-The die roll is random, so your number will differ.
+**Compare the shape, not the words.** The four `calls` lines are the same on every run, in
+that order; that is the part worth checking. The two `>` lines are model prose and will be
+worded differently for you. Across eight consecutive runs here the four `calls` lines were
+identical eight times and the two sentences never were: `roll_agent` said
+`I rolled a 5.`, `The result of your 6-sided die roll is 6.` and
+`I rolled a 6-sided die and got 2.`, and `prime_agent` answered `Yes, 5 is prime.`,
+`4 is not prime.` and `2 is a prime number.` Do not diff this transcript character by
+character.
+
+Routing is still a model decision, and it can go wrong: given a vaguer instruction,
+`roll_agent` sometimes handed straight back to `root_agent` without rolling and the run
+ended with `root_agent` asking what the number was — no A2A call at all. That is what the
+`Never transfer to another agent before you have reported a number` clause in `roll_agent`'s
+instruction is for.
 
 ## Troubleshooting
 
@@ -412,7 +465,7 @@ appears:
 - **The card resolved, but the URL inside it is dead.** This one arrives as an error event:
 
     ```text
-    ERROR: [ADK] A2ARemoteAgent prime_agent failed: TypeError: fetch failed
+    ERROR: [ADK] 2026-08-05T18:41:10.405Z A2ARemoteAgent prime_agent failed: TypeError: fetch failed
     [error] prime_agent: fetch failed
     ```
 
@@ -421,10 +474,10 @@ appears:
     they differ, the card fetch succeeds and every RPC afterwards goes to a port with no
     server on it.
 
-### The client prints your prompt, then nothing, and exits 0
+### The client prints your prompt, then almost nothing, and exits 0
 
 Your event loop reads `event.content` but never `event.errorMessage`. Remote failures do not
-throw and do not produce content, so a loop like this shows you an empty screen:
+throw and do not produce content, so a loop like this shows you a near-empty screen:
 
 ```typescript
 for await (const event of runner.runAsync({ /* ... */ })) {
@@ -435,9 +488,16 @@ for await (const event of runner.runAsync({ /* ... */ })) {
 }
 ```
 
+You are not left with *nothing*, but with almost nothing, and only for some failures.
+A transport failure gets one line out of ADK's own logger before the silence:
+
 ```text
 user > Is 7 a prime number?
+ERROR: [ADK] 2026-08-05T18:41:14.373Z A2ARemoteAgent prime_agent failed: TypeError: fetch failed
 ```
+
+A failure *inside* the remote agent — a bad model call, a throwing tool — prints nothing at
+all. Either way the exit code is `0`.
 
 Always check `errorMessage` first, as `direct_client.ts` does:
 
@@ -461,51 +521,80 @@ code `-32603` and no hint that credentials were the problem. Confusing matters f
 agent card endpoint is *never* authenticated — only `/jsonrpc` and `/rest` are — so
 `curl`ing the card returns `200` even when every call you make is being refused.
 
-`RemoteA2AAgent` has no token option. Credentials go in by building a client whose transport
-uses your own `fetch`:
+`RemoteA2AAgent` has no token option, so there is nowhere obvious to put a credential.
+Attaching one means replacing the client's transport:
 
-```typescript
-import { RemoteA2AAgent } from '@google/adk';
-import {
-  ClientFactory,
-  ClientFactoryOptions,
-  JsonRpcTransportFactory,
-} from '@a2a-js/sdk/client';
+??? note "Sending an Authorization header from a RemoteA2AAgent"
 
-const authFetch: typeof fetch = (input, init = {}) =>
-  fetch(input, {
-    ...init,
-    headers: { ...(init.headers ?? {}), Authorization: `Bearer ${process.env.A2A_TOKEN}` },
-  });
+    Swap the `primeAgent` constant in `direct_client.ts` for the version below. Only the
+    `@a2a-js/sdk/client` import is new — `RemoteA2AAgent` is already imported at the top of
+    that file.
 
-const primeAgent = new RemoteA2AAgent({
-  name: 'prime_agent',
-  description: 'Remote agent that checks whether numbers are prime.',
-  agentCard: 'http://localhost:8001',
-  clientFactory: new ClientFactory(
-    ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
-      transports: [new JsonRpcTransportFactory({ fetchImpl: authFetch })],
-    }),
-  ),
-});
-```
+    ```typescript title="examples/typescript/a2a_basic/direct_client.ts"
+    import {
+      ClientFactory,
+      ClientFactoryOptions,
+      JsonRpcTransportFactory,
+    } from '@a2a-js/sdk/client';
 
-Add `@a2a-js/sdk` to your own `package.json` if you import from it like this. It resolves
-today through `@google/adk`'s own dependency tree, but that is npm hoisting doing you a
-favour, and pnpm will not.
+    const authFetch: typeof fetch = (input, init = {}) =>
+      fetch(input, {
+        ...init,
+        headers: { ...(init.headers ?? {}), Authorization: `Bearer ${process.env.A2A_TOKEN}` },
+      });
 
-### `error TS2322: … is not assignable to type 'ToolInputParameters'`
+    const primeAgent = new RemoteA2AAgent({
+      name: 'prime_agent',
+      description: 'Remote agent that checks whether numbers are prime.',
+      agentCard: 'http://localhost:8001',
+      clientFactory: new ClientFactory(
+        ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
+          transports: [new JsonRpcTransportFactory({ fetchImpl: authFetch })],
+        }),
+      ),
+    });
+    ```
 
-Two copies of `zod`. `@google/adk@1.5.0` depends on `zod@^4.2.1`; if your `package.json`
-asks for `zod@^3`, TypeScript compares a `zod@3` schema against a `zod@4` type and reports
-a private-property mismatch:
+    Add `@a2a-js/sdk` to your own `package.json` if you import from it like this. It resolves
+    today through `@google/adk`'s own dependency tree, but that is npm hoisting doing you a
+    favour, and pnpm will not.
+
+### `[error] prime_agent: Agent run failed: API key must be provided …`
+
+The **remote agent** has no credentials. This is the one people expect to throw, and it does
+not:
 
 ```text
-Property '_cached' is private in type 'ZodObject<{ numbers: ZodArray<ZodNumber, "many">; }, …>'
-but not in type 'ZodObject<ZodRawShape, UnknownKeysParam, ZodTypeAny, …>'.
+user > Is 7 a prime number?
+[error] prime_agent: Agent run failed: API key must be provided via constructor or GOOGLE_GENAI_API_KEY or GEMINI_API_KEY environment variable.
 ```
 
-Change your dependency to `"zod": "^4.2.1"` and reinstall.
+Exit code `0`, and the remote terminal logs nothing at all — the error is packaged into the
+A2A response instead. Check that `.env` exists next to `package.json` **in the directory you
+started the remote agent from** (see [step 3](#add-your-credentials)).
+
+The local agents are the opposite. `consuming_agent.ts` builds its own model in-process, so
+missing credentials there really do throw — same message, but as an uncaught
+`Error:` whose first stack frame is `at new Gemini (…/models/google_llm.js:52:13)`, and
+exit `1`.
+
+### A ~30-line JSON dump starting `[error] prime_agent: {`
+
+The remote agent's key exists but is **wrong**. The provider's raw error is passed through
+verbatim, so it does not look like an ADK message at all:
+
+```text
+[error] prime_agent: {
+  "error": {
+    "code": 400,
+    "message": "API key not valid. Please pass a valid API key.",
+    "status": "INVALID_ARGUMENT",
+    …
+```
+
+Exit code `0` again. Twenty or so more lines of `details` follow, ending with a
+`DebugInfo` entry that echoes the key you actually sent — worth reading, because it is
+usually a truncated paste or a stale key rather than the one in `.env`.
 
 ## Next steps
 

--- a/docs/a2a/quickstart-consuming-typescript.md
+++ b/docs/a2a/quickstart-consuming-typescript.md
@@ -1,0 +1,524 @@
+# Quickstart: Consuming a remote agent via A2A
+
+<div class="language-support-tag">
+  <span class="lst-supported">Supported in ADK</span><span class="lst-typescript">TypeScript v1.5.0</span><span class="lst-preview">Experimental</span>
+</div>
+
+An A2A agent runs somewhere else — another process, another machine, another team's
+service — and speaks the [Agent2Agent protocol](intro.md) over HTTP. This page answers the
+first question you hit when you meet one: **how do I call it from my ADK TypeScript agent
+and get a real answer back?**
+
+You will build two things, because they are different jobs: a script that calls a remote
+agent **directly**, and a local agent that has the remote agent as a **sub-agent**, so the
+model decides when to route to it. You will also start the remote agent yourself, so
+nothing on this page depends on someone else's server being up.
+
+Here is the whole direct client. This is the complete file — the only thing missing is a
+remote agent to point it at, which you start in step 4.
+
+```typescript title="examples/typescript/a2a_basic/direct_client.ts"
+--8<-- "examples/typescript/a2a_basic/direct_client.ts:full"
+```
+
+Let's take a look at what is happening in this code:
+
+1. **`new RemoteA2AAgent({...})`** is the client. It is imported from `@google/adk` — there
+   is no `@google/adk/a2a` subpath — and it extends `BaseAgent`, so anywhere ADK accepts an
+   agent, it accepts this.
+2. **`agentCard: 'http://localhost:8001'` is a base URL, not the URL of the card.**
+   `RemoteA2AAgent` appends `.well-known/agent-card.json` itself. Passing the card URL is
+   the most common way to break this page; see [Troubleshooting](#troubleshooting).
+3. **`name` and `description`** are required by ADK, not fetched from the remote card. The
+   `description` is what a parent agent's model reads when deciding whether to route here,
+   so write it for that audience.
+4. **`Runner`** drives the agent exactly as it drives a local one: `runAsync()` returns an
+   async iterable of events. There is no separate "A2A client" API to learn.
+5. **`event.errorMessage`** is how remote failures arrive. They are *not* thrown. A loop
+   that only reads `event.content` prints nothing at all when the remote agent fails.
+6. **`event.partial`** marks the streamed chunks of an answer that is still being written.
+   Skipping them prints the finished sentence once. Drop that line and the same run prints
+   `Yes, 7 is a`, then ` prime number.`, then `Yes, 7 is a prime number.` again.
+
+## What you are building
+
+```text
+┌──────────────────────┐        A2A / JSON-RPC        ┌────────────────────────┐
+│  Your ADK app        │  ──────────────────────────▶ │  prime_agent           │
+│  (direct_client.ts   │                              │  (remote_prime_agent   │
+│   or consuming_      │  ◀────────────────────────── │   .ts, localhost:8001) │
+│   agent.ts)          │        events + answer       │  owns the model call   │
+└──────────────────────┘                              └────────────────────────┘
+```
+
+- **`prime_agent`** — an `LlmAgent` with a `check_prime` tool, published over A2A. It runs
+  in its own Node process and makes its own model calls.
+- **`direct_client.ts`** — points a `RemoteA2AAgent` at it and asks one question.
+- **`consuming_agent.ts`** — a local `root_agent` whose sub-agents are a local `roll_agent`
+  and the remote `prime_agent`. The model routes between them.
+
+!!! info "When to use `RemoteA2AAgent` — and when not to"
+
+    Use `RemoteA2AAgent` when the thing you want to call is an agent you do not run in your
+    own process: another team's service, a vendor's agent, a deployment you scale
+    separately. A2A buys you a process boundary, and charges you an HTTP hop plus a
+    JSON-RPC envelope for it.
+
+    If the capability you want is a function or an HTTP API in your own codebase, define a
+    [function tool](../tools-custom/function-tools.md) instead — no protocol required. If
+    you want *other* people to call your agent, you want
+    [A2A Quickstart (Exposing)](quickstart-exposing-typescript.md).
+
+## Prerequisites
+
+- **Node.js 22 or later.** Everything on this page was run on Node v22.22.2 with npm 9.2.0.
+  `@google/adk` publishes no `engines` field, so npm will not warn you on an older runtime —
+  but the examples use ESM and top-level `await`, which need a current Node.
+- **A Gemini API key.** Get one from [Google AI Studio](https://aistudio.google.com/apikey).
+- **The exact file is `.env`**, in the same directory as `package.json`, containing exactly
+  this line:
+
+    ```bash title="examples/typescript/a2a_basic/.env"
+    GOOGLE_GENAI_API_KEY=your-api-key-here
+    ```
+
+    Replace `your-api-key-here` with the key you just copied. ADK reads
+    `GOOGLE_GENAI_API_KEY` or `GEMINI_API_KEY`, in that order. If neither is set, the first
+    model call throws
+    `Error: API key must be provided via constructor or GOOGLE_GENAI_API_KEY or GEMINI_API_KEY environment variable.`
+
+!!! note "Which process needs the key"
+
+    The **remote agent** (step 4) always needs it — it owns the model call. The **direct
+    client** (step 6) needs no credentials at all; that is the point of A2A. The **routing
+    agent** (step 8) needs one too, because it runs its own model to decide where to send
+    each request.
+
+## Call a remote agent directly
+
+### 1. Get the example code { #get-the-example-code }
+
+```bash
+git clone https://github.com/google/adk-docs.git
+cd adk-docs/examples/typescript/a2a_basic
+```
+
+Three runnable files, and the two config files they need:
+
+```text
+a2a_basic/
+├── remote_prime_agent.ts   # the remote agent, served over A2A on port 8001
+├── direct_client.ts        # calls it directly
+├── consuming_agent.ts      # routes to it from a local agent
+├── package.json
+├── tsconfig.json
+└── README.md
+```
+
+### 2. Install the dependencies { #install-the-dependencies }
+
+=== "npm"
+
+    ```bash
+    npm install @google/adk zod dotenv
+    npm install --save-dev typescript tsx @types/node
+    ```
+
+=== "pnpm"
+
+    ```bash
+    pnpm add @google/adk zod dotenv
+    pnpm add --save-dev typescript tsx @types/node
+    ```
+
+=== "yarn"
+
+    ```bash
+    yarn add @google/adk zod dotenv
+    yarn add --dev typescript tsx @types/node
+    ```
+
+`@google/adk` brings the A2A stack with it: both the A2A SDK (`@a2a-js/sdk`) and Express are
+direct dependencies of the package, not peer dependencies, so there is nothing else to
+install to make A2A work. `zod` defines the tool's input schema, and `dotenv` loads `.env`.
+Pin `zod` to **v4** — `@google/adk@1.5.0` depends on `zod@^4.2.1`, and a `zod@3` in your own
+`package.json` produces two incompatible copies (see [Troubleshooting](#troubleshooting)).
+
+Two settings the examples depend on, both already set in the checked-in files. Only the
+relevant keys are shown; the rest of each file is unchanged:
+
+```json title="examples/typescript/a2a_basic/package.json (excerpt)"
+{
+  "type": "module"
+}
+```
+
+```json title="examples/typescript/a2a_basic/tsconfig.json (excerpt)"
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
+  }
+}
+```
+
+`"type": "module"` and `"module": "nodenext"` are what allow the top-level `await` these
+files use. Set `"module": "commonjs"` instead and `tsc` stops with
+`error TS1378: Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.`
+
+### 3. Add your API key { #add-your-api-key }
+
+```bash
+echo "GOOGLE_GENAI_API_KEY=your-api-key-here" > .env
+```
+
+### 4. Start the remote agent { #start-the-remote-agent }
+
+This is the agent your client will call. It is an ordinary `LlmAgent`; `toA2a()` is the only
+A2A-specific line.
+
+```typescript title="examples/typescript/a2a_basic/remote_prime_agent.ts"
+--8<-- "examples/typescript/a2a_basic/remote_prime_agent.ts:full"
+```
+
+Let's take a look at what is happening in this code:
+
+1. **`checkPrime`** is a plain `FunctionTool`. Its `parameters` are a `z.object({ numbers:
+   z.array(z.number()) })`, and that schema is what types the `{ numbers }` destructured in
+   `execute` — `numbers` is a `number[]` with no annotation written by hand.
+2. **`primeAgent`** is an `LlmAgent` like any other. Nothing about it is written for A2A.
+3. **`toA2a(primeAgent, {...})`** returns an `express.Application`. It is `await`ed because
+   it builds the agent card asynchronously.
+4. **`allowUnauthenticated: true`** is mandatory here and local-only: without it `toA2a()`
+   throws and refuses to mount, because an unauthenticated A2A endpoint lets any caller that
+   can reach the port invoke the agent and its tools. It logs a loud `SECURITY WARNING` when
+   you use it.
+5. **`app.listen(PORT)`** is yours to call. `toA2a()` never starts a server — its `port`
+   option only decorates the agent card, so the two must agree.
+
+Run it, and leave it running:
+
+```bash
+npx tsx remote_prime_agent.ts
+```
+
+```text
+WARN: [ADK] 2026-08-05T17:27:54.112Z SECURITY WARNING: Mounting the A2A server WITHOUT authentication because `allowUnauthenticated: true` was set. The agent and all of its tools are exposed to any network-reachable caller, which can invoke them with arbitrary input and read the output. Do NOT use this outside of local, trusted development.
+[server] prime_agent listening on http://localhost:8001
+[server] agent card: http://localhost:8001/.well-known/agent-card.json
+```
+
+### 5. Confirm the agent card is being served { #confirm-the-agent-card }
+
+Every A2A agent publishes a card describing what it can do, and that card is what
+`RemoteA2AAgent` fetches first. ADK generates it from your agent — you never write it by
+hand:
+
+```bash
+curl -s http://localhost:8001/.well-known/agent-card.json
+```
+
+```json
+{
+    "name": "prime_agent",
+    "description": "Checks whether numbers are prime.",
+    "protocolVersion": "0.3.0",
+    "version": "1.0.0",
+    "skills": [
+        {
+            "id": "prime_agent",
+            "name": "model",
+            "description": "Checks whether numbers are prime. I check whether numbers are prime. Always call the check_prime tool, then answer in one short sentence.",
+            "tags": ["llm"]
+        },
+        {
+            "id": "prime_agent-check_prime",
+            "name": "check_prime",
+            "description": "Checks which numbers in a list are prime.",
+            "tags": ["llm", "tools"]
+        }
+    ],
+    "url": "http://localhost:8001/jsonrpc",
+    "preferredTransport": "JSONRPC",
+    "capabilities": {
+        "extensions": [],
+        "stateTransitionHistory": false,
+        "pushNotifications": false,
+        "streaming": true
+    },
+    "defaultInputModes": ["text"],
+    "defaultOutputModes": ["text"],
+    "additionalInterfaces": [
+        {"url": "http://localhost:8001/jsonrpc", "transport": "JSONRPC"},
+        {"url": "http://localhost:8001/rest", "transport": "HTTP+JSON"}
+    ]
+}
+```
+
+Two things to notice, because both surprise people the first time:
+
+- Your instruction `"You check whether numbers are prime"` is published as `"I check
+  whether numbers are prime"`. Card descriptions are rewritten into the first person on
+  purpose.
+- `capabilities.streaming` is `true`, so `RemoteA2AAgent` will use the streaming transport.
+  That is where the `event.partial` chunks in step 6 come from.
+
+### 6. Point a client at it and run { #point-a-client-at-it-and-run }
+
+The client is `direct_client.ts`, shown in full at the top of this page. The part that
+matters is one constructor call:
+
+```typescript title="examples/typescript/a2a_basic/direct_client.ts"
+--8<-- "examples/typescript/a2a_basic/direct_client.ts:remote-agent"
+```
+
+In a second terminal:
+
+```bash
+npx tsx direct_client.ts
+```
+
+```text
+user > Is 7 a prime number?
+prime_agent > Yes, 7 is a prime number.
+```
+
+That answer came out of the other process. Look at the terminal running
+`remote_prime_agent.ts` and you will see the tool that produced it actually executed there:
+
+```text
+[server] check_prime(7) -> 7
+```
+
+You now have a working A2A call, and the client that made it holds no API key.
+
+## Route to the remote agent from a local agent
+
+Calling a remote agent directly is useful when you already know you want it. The more
+interesting shape is handing it to a model as one option among several: because
+`RemoteA2AAgent` extends `BaseAgent`, it drops into `subAgents` and ADK's routing treats it
+like any local sub-agent.
+
+### 7. Add a root agent with the remote agent as a sub-agent { #add-a-root-agent }
+
+```typescript title="examples/typescript/a2a_basic/consuming_agent.ts"
+--8<-- "examples/typescript/a2a_basic/consuming_agent.ts:roll-agent"
+
+--8<-- "examples/typescript/a2a_basic/consuming_agent.ts:remote-agent"
+
+--8<-- "examples/typescript/a2a_basic/consuming_agent.ts:root-agent"
+```
+
+Let's take a look at what is happening in this code:
+
+1. **`rollAgent`** is a local `LlmAgent` with a local `roll_die` tool. It runs in this
+   process.
+2. **`primeAgent`** is the same `RemoteA2AAgent` as before, unchanged. Nothing about
+   composition requires a different construction.
+3. **`subAgents: [rollAgent, primeAgent]`** mixes local and remote freely. `rootAgent`'s
+   model sees both and emits a `transfer_to_agent` call to pick one; ADK turns that into an
+   A2A request when the target is remote.
+4. **`description`** on `primeAgent` is doing real work now — it is the text the routing
+   model reads to decide that "is this prime?" belongs to `prime_agent`.
+
+The loop that prints the run is the same one from `direct_client.ts`, plus one branch so
+you can watch the routing happen:
+
+```typescript title="examples/typescript/a2a_basic/consuming_agent.ts"
+--8<-- "examples/typescript/a2a_basic/consuming_agent.ts:run"
+```
+
+`part.functionCall` catches both the `transfer_to_agent` handoffs and the tool calls the
+remote agent makes on its own side, which stream back to you as ordinary events.
+
+### 8. Run it { #run-it }
+
+With `remote_prime_agent.ts` still running in the first terminal:
+
+```bash
+npx tsx consuming_agent.ts
+```
+
+```text
+user > Roll a 6-sided die and tell me whether the result is prime.
+root_agent calls transfer_to_agent({"agentName":"roll_agent"})
+roll_agent calls roll_die({"sides":6})
+roll_agent > I rolled a 6-sided die and got a 6.
+
+roll_agent calls transfer_to_agent({"agentName":"prime_agent"})
+prime_agent calls check_prime({"numbers":[6]})
+prime_agent > 6 is not a prime number.
+```
+
+(ADK also prints `INFO: [ADK] … Sending out request, model: gemini-2.5-flash …` lines
+between these, one per model call. They are left out here for readability.)
+
+Read that trace bottom-up and you can see the whole point: `check_prime({"numbers":[6]})`
+was decided by a model in *your* process, executed by a tool in a *different* process, and
+the sentence came back over A2A as an event your loop printed. The remote terminal confirms
+its half:
+
+```text
+[server] check_prime(6) -> none
+```
+
+The die roll is random, so your number will differ.
+
+## Troubleshooting
+
+### `Failed to fetch Agent Card from …/.well-known/.well-known/agent-card.json: 404`
+
+You passed the **card URL** as `agentCard` instead of the **base URL**. The resolver appends
+`.well-known/agent-card.json` to whatever you give it, so the path doubles. This one does
+not surface as an error event — it takes the process down:
+
+```text
+Error: Failed to fetch Agent Card from http://localhost:8001/.well-known/.well-known/agent-card.json: 404
+    at DefaultAgentCardResolver.resolve (…/@a2a-js/sdk/dist/client/index.js:723:13)
+    at async resolveAgentCard (…/@google/adk/dist/esm/a2a/agent_card.js:28:12)
+    at async RemoteA2AAgent.init (…/@google/adk/dist/esm/a2a/a2a_remote_agent.js:43:19)
+
+Node.js v22.22.2
+```
+
+Card resolution happens before the error handling that produces `event.errorMessage`, which
+is why this crashes when every other remote failure does not.
+
+```typescript
+// Wrong — 404s and exits.
+agentCard: 'http://localhost:8001/.well-known/agent-card.json',
+
+// Right.
+agentCard: 'http://localhost:8001',
+```
+
+The same trap has a second form. If the remote agent was mounted under a `basePath`, your
+base URL needs a **trailing slash**, because `new URL()` drops the last segment without one:
+
+```text
+http://localhost:8001/a2a   ->  http://localhost:8001/.well-known/agent-card.json      # "a2a" silently dropped
+http://localhost:8001/a2a/  ->  http://localhost:8001/a2a/.well-known/agent-card.json  # correct
+```
+
+### `TypeError: fetch failed`
+
+Nothing answered at the address. Two different causes, and the difference is where it
+appears:
+
+- **Your `agentCard` URL points at a port nothing is listening on.** The card fetch itself
+  fails, so it crashes the process the same way the 404 above does, with
+  `[cause]: AggregateError [ECONNREFUSED]`. Check the port in `agentCard` against the one
+  the remote terminal printed.
+- **The card resolved, but the URL inside it is dead.** This one arrives as an error event:
+
+    ```text
+    ERROR: [ADK] A2ARemoteAgent prime_agent failed: TypeError: fetch failed
+    [error] prime_agent: fetch failed
+    ```
+
+    That means the remote server's `toA2a({ port })` and its `app.listen(port)` disagree.
+    `toA2a`'s `port` only writes the `"url"` field of the agent card; it starts nothing. If
+    they differ, the card fetch succeeds and every RPC afterwards goes to a port with no
+    server on it.
+
+### The client prints your prompt, then nothing, and exits 0
+
+Your event loop reads `event.content` but never `event.errorMessage`. Remote failures do not
+throw and do not produce content, so a loop like this shows you an empty screen:
+
+```typescript
+for await (const event of runner.runAsync({ /* ... */ })) {
+  // Nothing here will ever run when the remote agent fails.
+  for (const part of event.content?.parts ?? []) {
+    if (part.text) console.log(part.text);
+  }
+}
+```
+
+```text
+user > Is 7 a prime number?
+```
+
+Always check `errorMessage` first, as `direct_client.ts` does:
+
+```typescript
+if (event.errorMessage) {
+  console.error(`[error] ${event.author}: ${event.errorMessage}`);
+  continue;
+}
+```
+
+### `500 Internal Server Error. RPC Error: General processing error. (Code: -32603)`
+
+The remote agent is authenticated and rejected you. The full event text is:
+
+```text
+[error] prime_agent: HTTP error establishing stream for message/stream: 500 Internal Server Error. RPC Error: General processing error. (Code: -32603)
+```
+
+**Do not go looking for a 401.** A rejected A2A request comes back as HTTP 500 with JSON-RPC
+code `-32603` and no hint that credentials were the problem. Confusing matters further, the
+agent card endpoint is *never* authenticated — only `/jsonrpc` and `/rest` are — so
+`curl`ing the card returns `200` even when every call you make is being refused.
+
+`RemoteA2AAgent` has no token option. Credentials go in by building a client whose transport
+uses your own `fetch`:
+
+```typescript
+import { RemoteA2AAgent } from '@google/adk';
+import {
+  ClientFactory,
+  ClientFactoryOptions,
+  JsonRpcTransportFactory,
+} from '@a2a-js/sdk/client';
+
+const authFetch: typeof fetch = (input, init = {}) =>
+  fetch(input, {
+    ...init,
+    headers: { ...(init.headers ?? {}), Authorization: `Bearer ${process.env.A2A_TOKEN}` },
+  });
+
+const primeAgent = new RemoteA2AAgent({
+  name: 'prime_agent',
+  description: 'Remote agent that checks whether numbers are prime.',
+  agentCard: 'http://localhost:8001',
+  clientFactory: new ClientFactory(
+    ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
+      transports: [new JsonRpcTransportFactory({ fetchImpl: authFetch })],
+    }),
+  ),
+});
+```
+
+Add `@a2a-js/sdk` to your own `package.json` if you import from it like this. It resolves
+today through `@google/adk`'s own dependency tree, but that is npm hoisting doing you a
+favour, and pnpm will not.
+
+### `error TS2322: … is not assignable to type 'ToolInputParameters'`
+
+Two copies of `zod`. `@google/adk@1.5.0` depends on `zod@^4.2.1`; if your `package.json`
+asks for `zod@^3`, TypeScript compares a `zod@3` schema against a `zod@4` type and reports
+a private-property mismatch:
+
+```text
+Property '_cached' is private in type 'ZodObject<{ numbers: ZodArray<ZodNumber, "many">; }, …>'
+but not in type 'ZodObject<ZodRawShape, UnknownKeysParam, ZodTypeAny, …>'.
+```
+
+Change your dependency to `"zod": "^4.2.1"` and reinstall.
+
+## Next steps
+
+- **Let other agents call the agent you just wrote** —
+  [A2A Quickstart (Exposing)](quickstart-exposing-typescript.md) covers `toA2a()`,
+  authentication that is not `allowUnauthenticated`, and what ends up in your agent card.
+- **Understand what is actually on the wire** —
+  [Introduction to A2A](intro.md) walks through agent cards, tasks, and the JSON-RPC
+  messages your client is exchanging.
+- **Give the routing model something local to choose instead** — define a
+  [function tool](../tools-custom/function-tools.md) so `root_agent` can answer some
+  requests itself rather than delegating every one of them.
+- **Hand the remote agent to a model as a tool rather than a destination** —
+  [Agent-as-a-Tool](../tools-custom/function-tools.md#agent-tool) wraps an agent — and a
+  `RemoteA2AAgent` is a `BaseAgent` like any other — so the caller gets the answer back and
+  keeps control instead of transferring away.

--- a/docs/a2a/quickstart-exposing-typescript.md
+++ b/docs/a2a/quickstart-exposing-typescript.md
@@ -22,7 +22,7 @@ real request over JSON-RPC and getting a dice roll back.
 ```
 
 Here is the whole server. The rest of this page walks through it, but this file is complete —
-paste it into `server.ts`, add an API key, and it runs:
+paste it into `server.ts`, add credentials, and it runs:
 
 ```typescript title="my-a2a-agent/server.ts"
 --8<-- "examples/typescript/a2a_basic/remote_a2a/dice_agent/server.ts:full"
@@ -31,19 +31,38 @@ paste it into `server.ts`, add an API key, and it runs:
 ## Prerequisites
 
 *   **Node.js 22 or later.** `@google/adk` declares no `engines` field, so nothing will warn you
-    if your Node is too old. This page uses `--env-file` to load your API key, which is stable
-    as of Node 22.
-*   **A Gemini API key.** Create one in Google AI Studio on the
-    [API Keys](https://aistudio.google.com/app/apikey) page.
-*   **A `.env` file** in your project root containing exactly this line, with your own key
-    substituted for `YOUR_API_KEY`:
+    if your Node is too old. This page uses `--env-file` to load your credentials, which is
+    stable as of Node 22.
+*   **Model credentials** — either a Google AI Studio API key or a Google Cloud project with
+    Vertex AI enabled. Both are shown below, and nothing else on this page changes between them.
+*   **`jq`**, used here to pretty-print and filter the JSON responses (`sudo apt install jq`,
+    `brew install jq`). If you'd rather not install it, drop the `| jq …` from every command —
+    the responses are still valid JSON, and `python3 -m json.tool` pretty-prints them.
+
+Create a **`.env` file** in your project root containing exactly this:
+
+=== "Google AI Studio"
 
     ```bash title="my-a2a-agent/.env"
     GEMINI_API_KEY="YOUR_API_KEY"
     ```
 
-    ADK reads `GOOGLE_GENAI_API_KEY` first and falls back to `GEMINI_API_KEY`. Either name
-    works; `GOOGLE_API_KEY` alone does not.
+    Create the key on the [API Keys](https://aistudio.google.com/app/apikey) page. ADK reads
+    `GOOGLE_GENAI_API_KEY` first and falls back to `GEMINI_API_KEY`. Either name works;
+    `GOOGLE_API_KEY` alone does not.
+
+=== "Google Cloud / Vertex AI"
+
+    ```bash title="my-a2a-agent/.env"
+    GOOGLE_GENAI_USE_VERTEXAI=true
+    GOOGLE_CLOUD_PROJECT="your-project-id"
+    GOOGLE_CLOUD_LOCATION="global"
+    ```
+
+    There is no key on this path: the model call is authenticated with Application Default
+    Credentials, so run `gcloud auth application-default login` once and make sure the Vertex AI
+    API is enabled on the project. `GOOGLE_GENAI_USE_VERTEXAI=true` is the switch — with it set,
+    ADK routes `gemini-2.5-flash` to Vertex AI and ignores `GEMINI_API_KEY` entirely.
 
 !!! note "There is no separate A2A package to install"
 
@@ -147,22 +166,24 @@ Here's what is happening in this code:
 npx tsx --env-file=.env server.ts
 ```
 
-`--env-file=.env` is what loads your API key. ADK does not read `.env` for you when you run a
-script directly, so without this flag the agent starts fine and then fails on the first model
+`--env-file=.env` is what loads your credentials. ADK does not read `.env` for you when you run
+a script directly, so without this flag the agent starts fine and then fails on the first model
 call.
 
-You should see:
+You should see all five of these lines, in this order:
 
 ```console
-WARN: [ADK] SECURITY WARNING: Mounting the A2A server WITHOUT authentication because
-`allowUnauthenticated: true` was set. The agent and all of its tools are exposed to any
-network-reachable caller, which can invoke them with arbitrary input and read the output.
-Do NOT use this outside of local, trusted development.
+WARN: [ADK] 2026-08-05T18:36:22.793Z SECURITY WARNING: Mounting the A2A server WITHOUT authentication because `allowUnauthenticated: true` was set. The agent and all of its tools are exposed to any network-reachable caller, which can invoke them with arbitrary input and read the output. Do NOT use this outside of local, trusted development.
+(node:4060397) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+(Use `node --trace-deprecation ...` to show where the warning was created)
 [dice_agent] A2A server listening on http://localhost:8001
 [dice_agent] agent card: http://localhost:8001/.well-known/agent-card.json
 ```
 
-The warning is expected — it is `allowUnauthenticated: true` telling you what it did.
+Your timestamp and the `node:NNNNNNN` process id will differ; everything else is byte-for-byte
+what you get. All three warning lines are expected and none of them means you did something
+wrong: the `SECURITY WARNING` is `allowUnauthenticated: true` telling you what it did, and the
+`punycode` deprecation is Node 22 complaining about one of ADK's transitive dependencies.
 
 ### 6. Fetch the agent card
 
@@ -242,7 +263,9 @@ Three things in that card are worth noticing:
 
 ### 7. Send it a real request
 
-Now call the agent over the wire, the same way another agent would:
+Now call the agent over the wire, the same way another agent would. The response is an A2A
+**task**; the `jq` filter below pulls out the three things that prove it worked — the task's
+state, the shape of its `artifacts` array, and the agent's final answer:
 
 ```bash
 curl -s -X POST http://localhost:8001/jsonrpc \
@@ -259,99 +282,111 @@ curl -s -X POST http://localhost:8001/jsonrpc \
         "parts": [{"kind": "text", "text": "Roll a 20-sided die."}]
       }
     }
-  }' | jq
+  }' | jq -c '.result.status.state,
+              [.result.artifacts[].parts[0] | .metadata.adk_type // "text"],
+              .result.artifacts[-1].parts[0].text'
 ```
-
-The response is an A2A **task**. Its `artifacts` array carries the tool call, the tool result,
-and the agent's final answer:
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": "1",
-  "result": {
-    "kind": "task",
-    "id": "56c9f559-f06b-4340-9eae-305fa2915bc4",
-    "contextId": "e5d5ebaa-64a6-4e4a-b349-d2b278711784",
-    "history": [
-      {
-        "kind": "message",
-        "messageId": "msg-1",
-        "role": "user",
-        "parts": [
-          {
-            "kind": "text",
-            "text": "Roll a 20-sided die."
-          }
-        ],
-        "contextId": "e5d5ebaa-64a6-4e4a-b349-d2b278711784",
-        "taskId": "56c9f559-f06b-4340-9eae-305fa2915bc4"
-      }
-    ],
-    "status": {
-      "state": "completed",
-      "timestamp": "2026-08-05T17:22:09.580Z"
-    },
-    "artifacts": [
-      {
-        "artifactId": "f891684f-f842-412a-b8bb-5916e5297b6b",
-        "parts": [
-          {
-            "kind": "data",
-            "data": {
-              "name": "roll_dice",
-              "args": {
-                "sides": 20
-              },
-              "id": "adk-cd79ede2-5c93-4e85-9fb8-9adbbbfd80b0"
-            },
-            "metadata": {
-              "adk_type": "function_call"
-            }
-          }
-        ]
-      },
-      {
-        "artifactId": "90b1d991-692b-45b2-9fb9-48c975210147",
-        "parts": [
-          {
-            "kind": "data",
-            "data": {
-              "id": "adk-cd79ede2-5c93-4e85-9fb8-9adbbbfd80b0",
-              "name": "roll_dice",
-              "response": {
-                "result": 17
-              }
-            },
-            "metadata": {
-              "adk_type": "function_response"
-            }
-          }
-        ]
-      },
-      {
-        "artifactId": "a4ed76ad-ca58-47cd-8e0b-28da13070459",
-        "parts": [
-          {
-            "kind": "text",
-            "text": "You rolled a 17."
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-`"state": "completed"` and `"You rolled a 17."` mean the whole path worked: the request arrived,
-the agent ran, the tool fired, and the model's answer came back over A2A. Your server terminal
-shows the matching tool call:
 
 ```console
-[dice_agent] roll_dice(sides=20) -> 17
+"completed"
+["function_call","function_response","text"]
+"You rolled a 5."
 ```
 
-Your agent is now callable by any A2A client. Roll again and you'll get a different number.
+`"completed"` and `"You rolled a 5."` mean the whole path worked: the request arrived, the agent
+ran, the tool fired, and the model's answer came back over A2A. The middle line is the artifacts
+array — one artifact for the tool call, one for the tool's result, one for the final text, in
+that order. Your server terminal shows the matching tool call:
+
+```console
+[dice_agent] roll_dice(sides=20) -> 5
+```
+
+??? example "The full task JSON, if you want to see everything the filter dropped"
+
+    Drop the filter (`| jq` on its own) to get the whole response. Every `id` is a fresh UUID,
+    so yours will differ:
+
+    ```json
+    {
+      "jsonrpc": "2.0",
+      "id": "1",
+      "result": {
+        "kind": "task",
+        "id": "f8da1506-6992-4c46-9861-863aba63ca37",
+        "contextId": "129d06d3-42f4-4756-8648-dc0cdb0e5157",
+        "history": [
+          {
+            "kind": "message",
+            "messageId": "msg-1",
+            "role": "user",
+            "parts": [
+              {
+                "kind": "text",
+                "text": "Roll a 20-sided die."
+              }
+            ],
+            "contextId": "129d06d3-42f4-4756-8648-dc0cdb0e5157",
+            "taskId": "f8da1506-6992-4c46-9861-863aba63ca37"
+          }
+        ],
+        "status": {
+          "state": "completed",
+          "timestamp": "2026-08-05T18:37:03.703Z"
+        },
+        "artifacts": [
+          {
+            "artifactId": "f50add34-787f-4fd4-bc82-455e05028ab8",
+            "parts": [
+              {
+                "kind": "data",
+                "data": {
+                  "name": "roll_dice",
+                  "args": {
+                    "sides": 20
+                  },
+                  "id": "adk-7f1f2371-1b31-48ec-b417-425a452079f6"
+                },
+                "metadata": {
+                  "adk_type": "function_call"
+                }
+              }
+            ]
+          },
+          {
+            "artifactId": "9ff19b01-2b52-431a-af5f-730b44630bfa",
+            "parts": [
+              {
+                "kind": "data",
+                "data": {
+                  "id": "adk-7f1f2371-1b31-48ec-b417-425a452079f6",
+                  "name": "roll_dice",
+                  "response": {
+                    "result": 5
+                  }
+                },
+                "metadata": {
+                  "adk_type": "function_response"
+                }
+              }
+            ]
+          },
+          {
+            "artifactId": "64dcfddb-c571-4480-a68b-4c2b75159eb1",
+            "parts": [
+              {
+                "kind": "text",
+                "text": "You rolled a 5."
+              }
+            ]
+          }
+        ]
+      }
+    }
+    ```
+
+Your agent is now callable by any A2A client. Roll again and you'll get a different number, and
+possibly a different sentence around it — the last artifact is the model's own wording.
 
 ## What `toA2a` mounted
 
@@ -363,14 +398,14 @@ Your agent is now callable by any A2A client. Roll again and you'll get a differ
 | `/jsonrpc` | JSON-RPC transport (the card's `preferredTransport`) | Yes, once you configure it |
 | `/rest` | HTTP+JSON transport | Yes, once you configure it |
 
-!!! warning "The `basePath` option's documented default is wrong"
+!!! note "Moving the routes with `basePath`"
 
-    The JSDoc on `ToA2aOptions.basePath` says the default is `"a2a"`. The implementation is
-    `options.basePath || ''`, so the real default is an empty string and the routes above sit
-    at the root — which is what the card you just fetched shows. If you *do* set
-    `basePath: '/a2a'`, the routes move to `/a2a/.well-known/agent-card.json` and clients must
-    use a base URL with a **trailing slash** (`http://localhost:8001/a2a/`); without the slash
-    `new URL()` drops the segment and the card fetch 404s.
+    By default there is no prefix: all three routes sit at the root, which is what the card you
+    just fetched shows. Passing `basePath: '/a2a'` moves them — the card is then at
+    `/a2a/.well-known/agent-card.json` and its `url` becomes
+    `http://localhost:8001/a2a/jsonrpc`. Clients must give that base URL a **trailing slash**
+    (`http://localhost:8001/a2a/`); without it `new URL()` drops the last segment and the card
+    fetch 404s.
 
 ## Turn on authentication before you ship
 
@@ -379,17 +414,31 @@ and every one of its tools to any caller who can reach the port. For anything be
 loop, replace it with an `authentication` callback — a `UserBuilder` that receives the Express
 request, validates its credentials, and returns the authenticated user. Throw to reject.
 
-```typescript title="my-a2a-agent/server.ts"
---8<-- "examples/typescript/a2a_basic/remote_a2a/dice_agent/server-with-auth.ts:auth"
+Save the following alongside `server.ts` as `server-with-auth.ts`. This is a **complete file**,
+not a fragment — it is the same dice agent as before, with `allowUnauthenticated: true` replaced
+by a bearer-token `authentication` callback:
+
+```typescript title="my-a2a-agent/server-with-auth.ts"
+--8<-- "examples/typescript/a2a_basic/remote_a2a/dice_agent/server-with-auth.ts:full"
 ```
 
-The `req: Request` annotation is why `@types/express` is in the dev dependencies — Express
-ships with `@google/adk` but its type definitions do not.
+Three details in there are worth copying rather than simplifying:
 
-Start it with `A2A_SHARED_TOKEN=s3cret-token npx tsx --env-file=.env server.ts`, then reuse the
-request body from step 7 to see all three outcomes:
+*   **The `req: Request` annotation** is why `@types/express` is in the dev dependencies —
+    Express ships with `@google/adk` but its type definitions do not.
+*   **The token comes from the environment.** Add `A2A_SHARED_TOKEN="s3cret-token"` to the same
+    `.env` you already have, rather than prefixing the command with it: command-line arguments
+    are visible to anyone who can run `ps`, and they stay in your shell history.
+*   **The comparison is constant-time.** `token === EXPECTED_TOKEN` returns as soon as the two
+    strings diverge, which leaks how much of the secret a caller has guessed. Hashing both sides
+    to a fixed-length digest and comparing them with `crypto.timingSafeEqual` does not.
+
+Start it, then reuse the request body from step 7 to see all four outcomes:
 
 ```console
+$ npx tsx --env-file=.env server-with-auth.ts
+[dice_agent] authenticated A2A server on http://localhost:8001
+
 $ BODY='{"jsonrpc":"2.0","id":"1","method":"message/send","params":{"message":{"kind":"message","messageId":"msg-1","role":"user","parts":[{"kind":"text","text":"Roll a 20-sided die."}]}}}'
 
 $ curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:8001/.well-known/agent-card.json
@@ -400,12 +449,18 @@ $ curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:8001/jsonrpc \
 {"jsonrpc":"2.0","id":"1","error":{"code":-32603,"message":"General processing error."}}
 HTTP 500
 
+$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:8001/jsonrpc \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer wrong-token" -d "$BODY"
+{"jsonrpc":"2.0","id":"1","error":{"code":-32603,"message":"General processing error."}}
+HTTP 500
+
 $ curl -s -X POST http://localhost:8001/jsonrpc \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer s3cret-token" -d "$BODY" \
   | jq -c '.result.status.state, .result.artifacts[-1].parts[0].text'
 "completed"
-"You rolled a 13."
+"You rolled a 14."
 ```
 
 Two things to plan for:
@@ -415,6 +470,9 @@ Two things to plan for:
     description, or instruction.
 *   **A rejected request is an HTTP 500, not a 401.** The body is JSON-RPC error code
     `-32603`, `"General processing error."`, with no hint that credentials were the problem.
+    The real reason is only on the server's own stderr, which prints
+    `Unhandled error in JSON-RPC POST handler: Error: A2A request rejected: bad bearer token.`
+    and a stack trace.
 
 ## Should you use `toA2a`?
 
@@ -469,10 +527,24 @@ termination, and the process manager.
     {"jsonrpc":"2.0","id":"1","error":{"code":-32603,"message":"General processing error."}}
     ```
 
-    This *is* the authentication failure. A rejected `UserBuilder` surfaces as a generic
-    JSON-RPC internal error, not a 401 or 403, and the message says nothing about credentials —
-    so don't go looking for a 401 in your logs. Check that the caller is sending the header your
-    `authentication` callback reads, then log inside the callback to see the value it received.
+    `-32603` means *your `authentication` callback threw* — it does not say why, and it is not
+    a 401 or 403, so don't go looking for one in your logs. The two causes look identical from
+    the client:
+
+    *   the callback rejected the caller's credentials, which is the intended behaviour; or
+    *   the callback itself crashed — a typo, an undefined variable, a missing import — in which
+        case correctly-authenticated callers get this too.
+
+    The server's own stderr distinguishes them. It logs the thrown error and a stack trace:
+
+    ```console
+    Unhandled error in JSON-RPC POST handler: Error: A2A request rejected: bad bearer token.
+        at Object.authentication (/path/to/server-with-auth.ts:53:13)
+    ```
+
+    If that first line is your own `throw`, the credentials were wrong: check that the caller is
+    sending the header your callback reads. If it is a `ReferenceError` or `TypeError`, the
+    callback is broken and *every* caller is being rejected regardless of their token.
 
 ??? failure "`Failed to fetch Agent Card from http://localhost:8001/.well-known/.well-known/agent-card.json: 404`"
 
@@ -505,7 +577,10 @@ termination, and the process manager.
     The A2A layer is fine; the model call is not. This error arrives as a `"state": "failed"`
     task, which means the request reached your agent and the failure travelled back correctly.
     Either the key in `.env` is wrong, or you started the server without `--env-file=.env` and
-    ADK never saw it.
+    ADK never saw it. On the Vertex AI path the equivalent failure is a credentials or
+    permission error from `aiplatform.googleapis.com`; re-run
+    `gcloud auth application-default login` and check the API is enabled on
+    `GOOGLE_CLOUD_PROJECT`.
 
 ## Next steps
 

--- a/docs/a2a/quickstart-exposing-typescript.md
+++ b/docs/a2a/quickstart-exposing-typescript.md
@@ -6,45 +6,109 @@
 
 This quickstart covers the most common starting point for any developer: **"I have an agent. How do I expose it so that other agents can use my agent via A2A?"**. This is crucial for building complex multi-agent systems where different agents need to collaborate and interact.
 
-## What you'll build
+## Overview
 
-You'll take an ADK agent that rolls dice, wrap it with `toA2a()`, and serve it on
-`http://localhost:8001`. By the end you'll have proved it works twice with `curl`: once by
-fetching the agent card that A2A clients use to discover your agent, and once by sending it a
-real request over JSON-RPC and getting a dice roll back.
+This sample demonstrates how you can easily expose an ADK agent so that it can be then consumed by another agent using the A2A Protocol.
+
+In TypeScript, you expose an agent with the `toA2a()` function, which auto-generates the agent card and returns an Express application that you serve yourself.
 
 ```text
 ┌─────────────────────┐                             ┌───────────────────────────────┐
 │  Any A2A client     │       A2A Protocol          │  A2A-Exposed Dice Agent       │
 │  (curl, another     │────────────────────────────▶│  toA2a(diceAgent)             │
-│   ADK agent)        │                             │  (localhost:8001)             │
+│   ADK agent)        │                             │      (localhost: 8001)        │
 └─────────────────────┘                             └───────────────────────────────┘
 ```
 
-Here is the whole server. The rest of this page walks through it, but this file is complete —
-paste it into `server.ts`, add credentials, and it runs:
+The sample consists of:
 
-```typescript title="my-a2a-agent/server.ts"
+- **Remote Dice Agent** (`remote_a2a/dice_agent/server.ts`): This is the agent that you want to expose so that other agents can use it via A2A. It is an agent that rolls dice. It becomes exposed using the `toA2a()` function and served with `app.listen()`.
+- **Authenticated variant** (`remote_a2a/dice_agent/server-with-auth.ts`): The same agent behind a bearer-token check, covered in [Advanced Configuration](#advanced-configuration-authenticating-the-a2a-endpoint).
+
+Reach for `toA2a()` when you want *another agent* to call yours over the network and you want to own the HTTP server — you pick the port, the middleware, and the TLS termination. If the two agents run in the **same process**, you do not need A2A at all: compose them directly with [sub-agents and workflow agents](../workflows/index.md). You need **Node.js 22 or later** — `@google/adk` declares no `engines` field, so nothing warns you on an older runtime, and the sample uses ESM and top-level `await`. The `curl` commands below pipe through [`jq`](https://jqlang.github.io/jq/); if you would rather not install it, drop the `| jq …` and the responses are still valid JSON.
+
+## Exposing the Remote Agent with the `toA2a()` function
+
+You can take an existing agent built using ADK and make it A2A-compatible by wrapping it with `toA2a()`. Nothing about the agent itself has to change — any `BaseAgent` can be exposed this way. `toA2a()` builds the agent card in memory by extracting the name, description, instruction and tools from your ADK agent, so the well-known agent card endpoint is served as soon as you start listening.
+
+!!! note "There is no separate A2A package to install"
+
+    Express and `@a2a-js/sdk` — the HTTP server and the A2A protocol implementation — are direct
+    dependencies of `@google/adk`, not peer dependencies, so installing `@google/adk` installs
+    everything A2A needs. There is also no `@google/adk/a2a` subpath: every A2A symbol is
+    exported from the package root.
+
+### Under the hood: the routes `toA2a()` mounts
+
+`toA2a()` installs three routes on the Express app it returns:
+
+| Route | Purpose | Authenticated? |
+|---|---|---|
+| `/.well-known/agent-card.json` | Agent discovery | **No — always public** |
+| `/jsonrpc` | JSON-RPC transport (the card's `preferredTransport`) | Yes, once you configure it |
+| `/rest` | HTTP+JSON transport | Yes, once you configure it |
+
+??? note "Moving the routes with `basePath`"
+
+    By default all three sit at the root. `basePath: '/a2a'` moves them: the card is then at
+    `/a2a/.well-known/agent-card.json`, the root card 404s, and the card's `url` becomes
+    `http://localhost:8001/a2a/jsonrpc`. Clients must give that base URL a **trailing slash**
+    (`http://localhost:8001/a2a/`) — without one, `new URL()` drops the last segment.
+
+### 1. Getting the Sample Code { #getting-the-sample-code }
+
+You can clone and navigate to the [**`a2a_basic`** sample](https://github.com/google/adk-docs/tree/main/examples/typescript/a2a_basic) here:
+
+```bash
+git clone https://github.com/google/adk-docs.git
+cd adk-docs/examples/typescript/a2a_basic
+npm install
+```
+
+As you'll see, the folder structure is as follows:
+
+```text
+a2a_basic/
+├── remote_a2a/
+│   └── dice_agent/
+│       ├── server.ts            # Remote Dice Agent
+│       └── server-with-auth.ts  # The same agent, behind a bearer token
+├── package.json
+├── tsconfig.json
+├── README.md
+├── remote_prime_agent.ts        # ─┐
+├── direct_client.ts             #  ├─ A2A Quickstart (Consuming) uses these
+└── consuming_agent.ts           # ─┘
+```
+
+`a2a_basic/` is shared with [A2A Quickstart (Consuming)](./quickstart-consuming-typescript.md). Every server in it listens on port 8001, so run one at a time.
+
+#### Remote Dice Agent (`a2a_basic/remote_a2a/dice_agent/server.ts`)
+
+- **`rollDice`**: A `FunctionTool` whose zod `parameters` type the `{ sides }` argument destructured inside `execute`, and are what A2A clients see as a declared skill.
+- **`diceAgent`**: An ordinary `LlmAgent`. Nothing about it is A2A-specific.
+- **`toA2a(diceAgent, {...})`**: Returns a `Promise<express.Application>` with the A2A routes mounted. It never listens for you, so **`app.listen(PORT)`** is yours to call — which is also what lets you mount the A2A routes onto an Express app you already have, by passing it as the `app` option.
+
+```typescript title="a2a_basic/remote_a2a/dice_agent/server.ts"
 --8<-- "examples/typescript/a2a_basic/remote_a2a/dice_agent/server.ts:full"
 ```
 
-## Prerequisites
+If you are building this from scratch instead of cloning, run `npm init --yes && npm pkg set type="module"`, then `npm install @google/adk zod` and `npm install -D tsx typescript @types/node @types/express`, and copy the sample's `tsconfig.json`. Two settings are load-bearing: `"type": "module"` in `package.json` and `"module": "nodenext"` in `tsconfig.json`, because the server uses top-level `await`. Keep `zod` on **v4** — `@google/adk` depends on `zod@^4.2.1`, and a zod 3 install makes `tsc` reject every tool schema you write.
 
-*   **Node.js 22 or later.** `@google/adk` declares no `engines` field, so nothing will warn you
-    if your Node is too old. This page uses `--env-file` to load your credentials, which is
-    stable as of Node 22.
-*   **Model credentials** — either a Google AI Studio API key or a Google Cloud project with
-    Vertex AI enabled. Both are shown below, and nothing else on this page changes between them.
-*   **`jq`**, used here to pretty-print and filter the JSON responses (`sudo apt install jq`,
-    `brew install jq`). If you'd rather not install it, drop the `| jq …` from every command —
-    the responses are still valid JSON, and `python3 -m json.tool` pretty-prints them.
+!!! warning "`toA2a()` fails closed without authentication"
 
-Create a **`.env` file** in your project root containing exactly this:
+    `allowUnauthenticated: true` is a local-development shortcut. Without it, and without an
+    `authentication` callback, `toA2a()` refuses to mount and the returned promise rejects with
+    `toA2a: refusing to mount the A2A server without authentication`. See
+    [Advanced Configuration](#advanced-configuration-authenticating-the-a2a-endpoint) before you
+    put the agent on a network anyone else can reach.
+
+Finally, create a **`.env` file** next to `package.json` with your model credentials:
 
 === "Google AI Studio"
 
-    ```bash title="my-a2a-agent/.env"
-    GEMINI_API_KEY="YOUR_API_KEY"
+    ```bash title="a2a_basic/.env"
+    GOOGLE_GENAI_API_KEY="YOUR_API_KEY"
     ```
 
     Create the key on the [API Keys](https://aistudio.google.com/app/apikey) page. ADK reads
@@ -53,7 +117,7 @@ Create a **`.env` file** in your project root containing exactly this:
 
 === "Google Cloud / Vertex AI"
 
-    ```bash title="my-a2a-agent/.env"
+    ```bash title="a2a_basic/.env"
     GOOGLE_GENAI_USE_VERTEXAI=true
     GOOGLE_CLOUD_PROJECT="your-project-id"
     GOOGLE_CLOUD_LOCATION="global"
@@ -64,379 +128,136 @@ Create a **`.env` file** in your project root containing exactly this:
     API is enabled on the project. `GOOGLE_GENAI_USE_VERTEXAI=true` is the switch — with it set,
     ADK routes `gemini-2.5-flash` to Vertex AI and ignores `GEMINI_API_KEY` entirely.
 
-!!! note "There is no separate A2A package to install"
+### 2. Start the Remote A2A Agent server { #start-the-remote-a2a-agent-server }
 
-    Express and `@a2a-js/sdk` — the HTTP server and the A2A protocol implementation — are
-    direct dependencies of `@google/adk`, not peer dependencies. Installing `@google/adk`
-    installs everything the A2A server needs. There is also no `@google/adk/a2a` subpath:
-    `toA2a` and every other A2A symbol are exported from the package root.
-
-## Expose your agent
-
-### 1. Create the project
+You can now start the remote agent server, which will host the A2A app wrapping the dice agent:
 
 ```bash
-mkdir my-a2a-agent && cd my-a2a-agent
-npm init --yes
-npm pkg set type="module"
+npx tsx --env-file=.env remote_a2a/dice_agent/server.ts    # or: npm run serve:dice
 ```
 
-`type: "module"` is required. The server uses top-level `await`, which only works in an ES
-module.
-
-### 2. Install the dependencies
-
-=== "npm"
-
-    ```bash
-    npm install @google/adk zod
-    npm install -D tsx typescript @types/node @types/express
-    ```
-
-=== "pnpm"
-
-    ```bash
-    pnpm add @google/adk zod
-    pnpm add -D tsx typescript @types/node @types/express
-    ```
-
-=== "yarn"
-
-    ```bash
-    yarn add @google/adk zod
-    yarn add -D tsx typescript @types/node @types/express
-    ```
-
-`zod` defines the tool's parameter schema. Install **zod 4** — `@google/adk` depends on
-`zod@^4.2.1`, and a zod 3 install will not typecheck. `tsx` runs TypeScript directly so you
-don't need a build step. `@types/express` is only needed if you annotate the request object
-when you [add authentication](#turn-on-authentication-before-you-ship); Express itself is
-already installed as a dependency of `@google/adk`.
-
-### 3. Add a `tsconfig.json`
-
-```json title="my-a2a-agent/tsconfig.json"
-{
-  "compilerOptions": {
-    "target": "es2022",
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
-    "strict": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "types": ["node"]
-  }
-}
-```
-
-`module: "nodenext"` is the setting that matters: with `commonjs` the top-level `await` in
-`server.ts` fails to compile.
-
-### 4. Write the agent and expose it
-
-Create `server.ts` with the code from the top of this page.
-
-```typescript title="my-a2a-agent/server.ts"
---8<-- "examples/typescript/a2a_basic/remote_a2a/dice_agent/server.ts:full"
-```
-
-Here's what is happening in this code:
-
-1.  **`rollDice`** is an ordinary ADK `FunctionTool`. The `parameters` schema —
-    `z.object({ sides: z.number() })` — is what types the `{ sides }` argument destructured
-    inside `execute`, and it is also what A2A clients see as a declared skill.
-2.  **`diceAgent`** is an ordinary `LlmAgent`. Nothing about it is A2A-specific; any
-    `BaseAgent` can be exposed this way.
-3.  **`toA2a(diceAgent, options)`** returns a `Promise<express.Application>`. It builds the agent
-    card, mounts the A2A routes, and hands the app back to you.
-4.  **`port: PORT`** writes `http://localhost:8001/jsonrpc` into the agent card. It does *not*
-    open a socket. It must agree with the port you pass to `app.listen()` below, or clients
-    will read the card successfully and then fail to reach the address it advertises.
-5.  **`allowUnauthenticated: true`** is a local-development shortcut: without it, or without an
-    `authentication` callback, `toA2a` refuses to start at all. See
-    [Turn on authentication before you ship](#turn-on-authentication-before-you-ship) before you expose this on any
-    network someone else can reach.
-6.  **`app.listen(PORT)`** is yours to call. `toA2a` never listens for you — the application it
-    returns is inert until you start it. This is deliberate: it means you can mount the A2A
-    routes onto an Express app you already have by passing it as the `app` option.
-
-### 5. Start the server
-
-```bash
-npx tsx --env-file=.env server.ts
-```
-
-`--env-file=.env` is what loads your credentials. ADK does not read `.env` for you when you run
-a script directly, so without this flag the agent starts fine and then fails on the first model
-call.
-
-You should see all five of these lines, in this order:
+Once executed, you should see something like:
 
 ```console
-WARN: [ADK] 2026-08-05T18:36:22.793Z SECURITY WARNING: Mounting the A2A server WITHOUT authentication because `allowUnauthenticated: true` was set. The agent and all of its tools are exposed to any network-reachable caller, which can invoke them with arbitrary input and read the output. Do NOT use this outside of local, trusted development.
-(node:4060397) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+WARN: [ADK] 2026-08-06T21:16:38.297Z SECURITY WARNING: Mounting the A2A server WITHOUT authentication because `allowUnauthenticated: true` was set. The agent and all of its tools are exposed to any network-reachable caller, which can invoke them with arbitrary input and read the output. Do NOT use this outside of local, trusted development.
+(node:2807369) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
 (Use `node --trace-deprecation ...` to show where the warning was created)
 [dice_agent] A2A server listening on http://localhost:8001
 [dice_agent] agent card: http://localhost:8001/.well-known/agent-card.json
 ```
 
-Your timestamp and the `node:NNNNNNN` process id will differ; everything else is byte-for-byte
-what you get. All three warning lines are expected and none of them means you did something
-wrong: the `SECURITY WARNING` is `allowUnauthenticated: true` telling you what it did, and the
-`punycode` deprecation is Node 22 complaining about one of ADK's transitive dependencies.
+All three warning lines are expected: the `SECURITY WARNING` is `allowUnauthenticated: true` telling you what it did, and the `punycode` deprecation is Node 22 complaining about one of ADK's transitive dependencies.
 
-### 6. Fetch the agent card
+!!! warning "`--env-file=.env` is what loads your credentials"
 
-The agent card is how other agents discover yours: its name, its skills, and the URL to call.
-ADK generates it from your agent code; you don't write it by hand. Leave the server running and,
-in a second terminal:
+    ADK does not read `.env` for you when you run a script directly, which is why the command
+    above passes Node's `--env-file`. Start the server without it and it comes up perfectly, then
+    fails on the first model call — the request reaches your agent and comes back as a
+    `"state": "failed"` task carrying `API key not valid. Please pass a valid API key.` (or, on
+    the Vertex AI path, a credentials error from `aiplatform.googleapis.com`).
+
+??? note "Why use port 8001?"
+    In this quickstart, when testing locally, your agents will be using localhost, so the `port` for the A2A server for the exposed agent must be different from the consuming agent's port. The default port for `adk web` is `8000`, which is why the A2A server is created using a separate port, `8001`.
+
+### 3. Check that your remote agent is running { #check-that-your-remote-agent-is-running }
+
+You can check that your agent is up and running by visiting the agent card that `toA2a()` auto-generated. The card is how other agents discover yours — its name, its skills, and the URL to call — and you never write it by hand:
+
+[http://localhost:8001/.well-known/agent-card.json](http://localhost:8001/.well-known/agent-card.json)
+
+You should see the contents of the agent card. Leave the server running and, in a second terminal, pull out the identity and the skills:
 
 ```bash
-curl -s http://localhost:8001/.well-known/agent-card.json | jq
+curl -s http://localhost:8001/.well-known/agent-card.json \
+  | jq '{name, description, url, skills: [.skills[] | {id, name, description}]}'
 ```
-
-You should see exactly this (the endpoint is served at the `AGENT_CARD_PATH` constant,
-`.well-known/agent-card.json`):
 
 ```json
 {
   "name": "dice_agent",
   "description": "An agent that rolls dice on request.",
-  "protocolVersion": "0.3.0",
-  "version": "1.0.0",
+  "url": "http://localhost:8001/jsonrpc",
   "skills": [
     {
       "id": "dice_agent",
       "name": "model",
-      "description": "An agent that rolls dice on request. I roll dice for the user. Always use the roll_dice tool. Report the resulting number in one short sentence.",
-      "tags": [
-        "llm"
-      ]
+      "description": "An agent that rolls dice on request. I roll dice for the user. Always use the roll_dice tool. Report the resulting number in one short sentence."
     },
     {
       "id": "dice_agent-roll_dice",
       "name": "roll_dice",
-      "description": "Rolls an N-sided die and returns the result.",
-      "tags": [
-        "llm",
-        "tools"
-      ]
-    }
-  ],
-  "url": "http://localhost:8001/jsonrpc",
-  "preferredTransport": "JSONRPC",
-  "capabilities": {
-    "extensions": [],
-    "stateTransitionHistory": false,
-    "pushNotifications": false,
-    "streaming": true
-  },
-  "defaultInputModes": [
-    "text"
-  ],
-  "defaultOutputModes": [
-    "text"
-  ],
-  "additionalInterfaces": [
-    {
-      "url": "http://localhost:8001/jsonrpc",
-      "transport": "JSONRPC"
-    },
-    {
-      "url": "http://localhost:8001/rest",
-      "transport": "HTTP+JSON"
+      "description": "Rolls an N-sided die and returns the result."
     }
   ]
 }
 ```
 
-Three things in that card are worth noticing:
+Two things in that card are worth noticing. **One skill per capability:** `dice_agent` (the model itself) and `dice_agent-roll_dice` (the tool) are advertised separately, so a calling agent can tell what yours can do. And **your instruction came back in the first person** — you wrote *"You roll dice for the user"*, the card says *"I roll dice for the user"*. ADK rewrites the pronouns when it publishes your instruction as a description; the card speaks as the agent.
 
-*   **One skill per capability.** `dice_agent` (the model itself) and `dice_agent-roll_dice`
-    (the tool) are advertised separately, so a calling agent can tell what yours can do.
-*   **Your instruction came back in the first person.** You wrote *"You roll dice for the
-    user"*; the card says *"I roll dice for the user"*. ADK rewrites the pronouns when it
-    publishes your instruction as a description. This is intentional — the card speaks as the
-    agent.
-*   **`url` is `http://localhost:8001/jsonrpc`,** built from the `port` you passed to `toA2a`.
-    If that URL doesn't match where you're actually listening, this is where you'll spot it.
+The rest of the card, which ADK fills in for you, is the protocol plumbing:
 
-### 7. Send it a real request
+```json
+{"protocolVersion":"0.3.0","version":"1.0.0","preferredTransport":"JSONRPC","capabilities":{"extensions":[],"stateTransitionHistory":false,"pushNotifications":false,"streaming":true},"defaultInputModes":["text"],"defaultOutputModes":["text"],"additionalInterfaces":[{"url":"http://localhost:8001/jsonrpc","transport":"JSONRPC"},{"url":"http://localhost:8001/rest","transport":"HTTP+JSON"}]}
+```
 
-Now call the agent over the wire, the same way another agent would. The response is an A2A
-**task**; the `jq` filter below pulls out the three things that prove it worked — the task's
-state, the shape of its `artifacts` array, and the agent's final answer:
+!!! warning "Check the card's `url` before you blame the client"
+
+    `url` is built from the `port` you passed to `toA2a()`, not from the socket `app.listen()`
+    opened. If they disagree, a client reads the card, POSTs to the dead address it advertises,
+    and reports nothing more useful than `TypeError: fetch failed`. Use one `PORT` for both.
+
+### 4. Run the Main (Consuming) Agent { #run-the-main-consuming-agent }
+
+Now call the agent over the wire, the same way another agent would. Any A2A client works; `curl` keeps it to one command. The response is an A2A **task**, and the `jq` filter below pulls out the three things that prove it worked — the task's state, the shape of its `artifacts` array, and the agent's final answer:
 
 ```bash
-curl -s -X POST http://localhost:8001/jsonrpc \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "jsonrpc": "2.0",
-    "id": "1",
-    "method": "message/send",
-    "params": {
-      "message": {
-        "kind": "message",
-        "messageId": "msg-1",
-        "role": "user",
-        "parts": [{"kind": "text", "text": "Roll a 20-sided die."}]
-      }
-    }
-  }' | jq -c '.result.status.state,
-              [.result.artifacts[].parts[0] | .metadata.adk_type // "text"],
-              .result.artifacts[-1].parts[0].text'
+curl -s -X POST http://localhost:8001/jsonrpc -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":"1","method":"message/send","params":{"message":{
+        "kind":"message","messageId":"msg-1","role":"user",
+        "parts":[{"kind":"text","text":"Roll a 20-sided die."}]}}}' \
+  | jq -c '.result.status.state,
+           [.result.artifacts[].parts[0] | .metadata.adk_type // "text"],
+           .result.artifacts[-1].parts[0].text'
 ```
+
+To do the same thing from an ADK agent instead of `curl` — a `RemoteA2AAgent` that a parent agent can delegate to — follow [A2A Quickstart (Consuming)](./quickstart-consuming-typescript.md).
+
+## Example Interactions
+
+Once the server is running, you can send it requests to see how an A2A client drives your agent.
+
+**Simple Dice Rolling:**
 
 ```console
 "completed"
 ["function_call","function_response","text"]
-"You rolled a 5."
+"You rolled a 3."
 ```
 
-`"completed"` and `"You rolled a 5."` mean the whole path worked: the request arrived, the agent
-ran, the tool fired, and the model's answer came back over A2A. The middle line is the artifacts
-array — one artifact for the tool call, one for the tool's result, one for the final text, in
-that order. Your server terminal shows the matching tool call:
+`"completed"` and `"You rolled a 3."` mean the whole path worked: the request arrived, the agent ran, the tool fired, and the model's answer came back over A2A. The middle line is the artifacts array — one artifact for the tool call, one for the tool's result, one for the final text, in that order. Your server terminal shows the matching tool call:
 
 ```console
-[dice_agent] roll_dice(sides=20) -> 5
+[dice_agent] roll_dice(sides=20) -> 3
 ```
 
-??? example "The full task JSON, if you want to see everything the filter dropped"
+Roll again and you'll get a different number, and possibly a different sentence around it: the last artifact is the model's own wording, so compare the shape of the response rather than its exact words.
 
-    Drop the filter (`| jq` on its own) to get the whole response. Every `id` is a fresh UUID,
-    so yours will differ:
+## Advanced Configuration: Authenticating the A2A endpoint
 
-    ```json
-    {
-      "jsonrpc": "2.0",
-      "id": "1",
-      "result": {
-        "kind": "task",
-        "id": "f8da1506-6992-4c46-9861-863aba63ca37",
-        "contextId": "129d06d3-42f4-4756-8648-dc0cdb0e5157",
-        "history": [
-          {
-            "kind": "message",
-            "messageId": "msg-1",
-            "role": "user",
-            "parts": [
-              {
-                "kind": "text",
-                "text": "Roll a 20-sided die."
-              }
-            ],
-            "contextId": "129d06d3-42f4-4756-8648-dc0cdb0e5157",
-            "taskId": "f8da1506-6992-4c46-9861-863aba63ca37"
-          }
-        ],
-        "status": {
-          "state": "completed",
-          "timestamp": "2026-08-05T18:37:03.703Z"
-        },
-        "artifacts": [
-          {
-            "artifactId": "f50add34-787f-4fd4-bc82-455e05028ab8",
-            "parts": [
-              {
-                "kind": "data",
-                "data": {
-                  "name": "roll_dice",
-                  "args": {
-                    "sides": 20
-                  },
-                  "id": "adk-7f1f2371-1b31-48ec-b417-425a452079f6"
-                },
-                "metadata": {
-                  "adk_type": "function_call"
-                }
-              }
-            ]
-          },
-          {
-            "artifactId": "9ff19b01-2b52-431a-af5f-730b44630bfa",
-            "parts": [
-              {
-                "kind": "data",
-                "data": {
-                  "id": "adk-7f1f2371-1b31-48ec-b417-425a452079f6",
-                  "name": "roll_dice",
-                  "response": {
-                    "result": 5
-                  }
-                },
-                "metadata": {
-                  "adk_type": "function_response"
-                }
-              }
-            ]
-          },
-          {
-            "artifactId": "64dcfddb-c571-4480-a68b-4c2b75159eb1",
-            "parts": [
-              {
-                "kind": "text",
-                "text": "You rolled a 5."
-              }
-            ]
-          }
-        ]
-      }
-    }
-    ```
+`allowUnauthenticated: true` is a quickstart shortcut and nothing more: it exposes your agent and every one of its tools to any caller who can reach the port. For anything beyond a local loop, replace it with an `authentication` callback — a `UserBuilder` that receives the Express request, validates its credentials, and returns the authenticated user. Throw to reject.
 
-Your agent is now callable by any A2A client. Roll again and you'll get a different number, and
-possibly a different sentence around it — the last artifact is the model's own wording.
+`server-with-auth.ts` is a **complete file**, not a fragment — the same dice agent as before, with `allowUnauthenticated: true` replaced by a bearer-token `authentication` callback:
 
-## What `toA2a` mounted
-
-`toA2a` installs three routes on the Express app it returns:
-
-| Route | Purpose | Authenticated? |
-|---|---|---|
-| `/.well-known/agent-card.json` | Agent discovery | **No — always public** |
-| `/jsonrpc` | JSON-RPC transport (the card's `preferredTransport`) | Yes, once you configure it |
-| `/rest` | HTTP+JSON transport | Yes, once you configure it |
-
-!!! note "Moving the routes with `basePath`"
-
-    By default there is no prefix: all three routes sit at the root, which is what the card you
-    just fetched shows. Passing `basePath: '/a2a'` moves them — the card is then at
-    `/a2a/.well-known/agent-card.json` and its `url` becomes
-    `http://localhost:8001/a2a/jsonrpc`. Clients must give that base URL a **trailing slash**
-    (`http://localhost:8001/a2a/`); without it `new URL()` drops the last segment and the card
-    fetch 404s.
-
-## Turn on authentication before you ship
-
-`allowUnauthenticated: true` is a quickstart shortcut and nothing more: it exposes your agent
-and every one of its tools to any caller who can reach the port. For anything beyond a local
-loop, replace it with an `authentication` callback — a `UserBuilder` that receives the Express
-request, validates its credentials, and returns the authenticated user. Throw to reject.
-
-Save the following alongside `server.ts` as `server-with-auth.ts`. This is a **complete file**,
-not a fragment — it is the same dice agent as before, with `allowUnauthenticated: true` replaced
-by a bearer-token `authentication` callback:
-
-```typescript title="my-a2a-agent/server-with-auth.ts"
+```typescript title="a2a_basic/remote_a2a/dice_agent/server-with-auth.ts"
 --8<-- "examples/typescript/a2a_basic/remote_a2a/dice_agent/server-with-auth.ts:full"
 ```
 
-Three details in there are worth copying rather than simplifying:
+Three details in there are worth copying rather than simplifying. **The `req: Request` annotation** is why `@types/express` is a dev dependency — Express ships with `@google/adk` but its type definitions do not. **The token comes from the environment**: add `A2A_SHARED_TOKEN="s3cret-token"` to the same `.env` you already have, rather than prefixing the command with it, because command-line arguments are visible to anyone who can run `ps` and stay in your shell history. And **the comparison is constant-time** — `token === EXPECTED_TOKEN` returns as soon as the two strings diverge, which leaks how much of the secret a caller has guessed; hashing both sides to a fixed-length digest and comparing them with `crypto.timingSafeEqual` does not.
 
-*   **The `req: Request` annotation** is why `@types/express` is in the dev dependencies —
-    Express ships with `@google/adk` but its type definitions do not.
-*   **The token comes from the environment.** Add `A2A_SHARED_TOKEN="s3cret-token"` to the same
-    `.env` you already have, rather than prefixing the command with it: command-line arguments
-    are visible to anyone who can run `ps`, and they stay in your shell history.
-*   **The comparison is constant-time.** `token === EXPECTED_TOKEN` returns as soon as the two
-    strings diverge, which leaks how much of the secret a caller has guessed. Hashing both sides
-    to a fixed-length digest and comparing them with `crypto.timingSafeEqual` does not.
-
-Start it, then reuse the request body from step 7 to see all four outcomes:
+Start it, then reuse the request body from step 4 to see the difference the header makes (Node's `punycode` lines are omitted below):
 
 ```console
-$ npx tsx --env-file=.env server-with-auth.ts
+$ npx tsx --env-file=.env remote_a2a/dice_agent/server-with-auth.ts
 [dice_agent] authenticated A2A server on http://localhost:8001
 
 $ BODY='{"jsonrpc":"2.0","id":"1","method":"message/send","params":{"message":{"kind":"message","messageId":"msg-1","role":"user","parts":[{"kind":"text","text":"Roll a 20-sided die."}]}}}'
@@ -449,151 +270,30 @@ $ curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:8001/jsonrpc \
 {"jsonrpc":"2.0","id":"1","error":{"code":-32603,"message":"General processing error."}}
 HTTP 500
 
-$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:8001/jsonrpc \
-    -H "Content-Type: application/json" \
-    -H "Authorization: Bearer wrong-token" -d "$BODY"
-{"jsonrpc":"2.0","id":"1","error":{"code":-32603,"message":"General processing error."}}
-HTTP 500
-
 $ curl -s -X POST http://localhost:8001/jsonrpc \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer s3cret-token" -d "$BODY" \
   | jq -c '.result.status.state, .result.artifacts[-1].parts[0].text'
 "completed"
-"You rolled a 14."
+"You rolled a 17."
 ```
 
-Two things to plan for:
+A wrong token (`Authorization: Bearer wrong-token`) is byte-for-byte the same rejection as sending no header at all. Two things to plan for:
 
-*   **The agent card stays public.** `authentication` gates `/jsonrpc` and `/rest` only.
-    Discovery is meant to be open, so do not put anything secret in your agent's name,
-    description, or instruction.
-*   **A rejected request is an HTTP 500, not a 401.** The body is JSON-RPC error code
-    `-32603`, `"General processing error."`, with no hint that credentials were the problem.
-    The real reason is only on the server's own stderr, which prints
+*   **The agent card stays public.** `authentication` gates `/jsonrpc` and `/rest` only, which
+    is why the first `curl` above returns `200`. Discovery is meant to be open, so do not put
+    anything secret in your agent's name, description, or instruction.
+*   **A rejected request is an HTTP 500, not a 401.** The body is JSON-RPC error code `-32603`,
+    `"General processing error."`, with no hint that credentials were the problem — and a
+    callback that *crashes* (a typo, a missing import) looks identical to the caller, so check
+    that correctly-authenticated callers still get through. The real reason is only on the
+    server's own stderr, which prints
     `Unhandled error in JSON-RPC POST handler: Error: A2A request rejected: bad bearer token.`
     and a stack trace.
 
-## Should you use `toA2a`?
+## Next Steps
 
-Use `toA2a` when you want *another agent* to call yours over the network, and you want to own
-the HTTP server — you get an Express app, so you choose the port, the middleware, the TLS
-termination, and the process manager.
+Now that you have created an agent that's exposing a remote agent via an A2A server, the next step is to learn how to consume it from another agent.
 
-*   If you want a **local dev loop with a chat UI** rather than a network endpoint, run
-    `adk web` from `@google/adk-devtools` instead; see the
-    [TypeScript quickstart](../get-started/typescript.md).
-*   If you want your agent to **call** a remote A2A agent rather than be called, you want
-    [A2A Quickstart (Consuming)](./quickstart-consuming-typescript.md) — `RemoteA2AAgent`, not
-    `toA2a`.
-*   If the two agents are in the **same process**, you don't need A2A at all. Compose them
-    directly with [sub-agents and workflow agents](../workflows/index.md).
-
-## Troubleshooting
-
-??? failure "`fetch failed`, with no other detail"
-
-    The port in the agent card doesn't match the port you're actually listening on. `toA2a`'s
-    `port` option only writes the URL into the card; `app.listen()` is what opens the socket.
-    When they disagree the client fetches the card successfully, POSTs to the dead address it
-    advertises, and reports:
-
-    ```console
-    ERROR: [ADK] A2ARemoteAgent remote_echo failed: TypeError: fetch failed
-    ```
-
-    Confirm with `curl -s http://localhost:8001/.well-known/agent-card.json | grep '"url"'` —
-    if the URL names a port nothing is bound to, that's the bug. Use one `PORT` constant for
-    both.
-
-??? failure "`toA2a: refusing to mount the A2A server without authentication`"
-
-    You called `toA2a(agent)` without `allowUnauthenticated` and without `authentication`.
-    `toA2a` fails closed, and the rejected promise reads:
-
-    ```console
-    toA2a: refusing to mount the A2A server without authentication. The A2A surface lets any
-    network-reachable caller invoke this agent and its tools with arbitrary input and read the
-    output, so it must be authenticated. Provide `authentication` (a UserBuilder that validates
-    the request, e.g. a bearer token or OIDC credential) or, only for local/trusted development,
-    explicitly set `allowUnauthenticated: true`.
-    ```
-
-    Pass `allowUnauthenticated: true` locally, or an `authentication` callback anywhere else.
-
-??? failure "HTTP 500 and `-32603` on every request once auth is on"
-
-    ```console
-    {"jsonrpc":"2.0","id":"1","error":{"code":-32603,"message":"General processing error."}}
-    ```
-
-    `-32603` means *your `authentication` callback threw* — it does not say why, and it is not
-    a 401 or 403, so don't go looking for one in your logs. The two causes look identical from
-    the client:
-
-    *   the callback rejected the caller's credentials, which is the intended behaviour; or
-    *   the callback itself crashed — a typo, an undefined variable, a missing import — in which
-        case correctly-authenticated callers get this too.
-
-    The server's own stderr distinguishes them. It logs the thrown error and a stack trace:
-
-    ```console
-    Unhandled error in JSON-RPC POST handler: Error: A2A request rejected: bad bearer token.
-        at Object.authentication (/path/to/server-with-auth.ts:53:13)
-    ```
-
-    If that first line is your own `throw`, the credentials were wrong: check that the caller is
-    sending the header your callback reads. If it is a `ReferenceError` or `TypeError`, the
-    callback is broken and *every* caller is being rejected regardless of their token.
-
-??? failure "`Failed to fetch Agent Card from http://localhost:8001/.well-known/.well-known/agent-card.json: 404`"
-
-    A client was given the card URL where it expects the **base URL**. The A2A resolver appends
-    `.well-known/agent-card.json` itself, so passing the full card URL doubles the path:
-
-    ```console
-    UNCAUGHT: Failed to fetch Agent Card from
-    http://localhost:8001/.well-known/.well-known/agent-card.json: 404
-    ```
-
-    Note that this one is an uncaught exception that stops the client process, not a tidy error
-    event. Pass `http://localhost:8001`, not
-    `http://localhost:8001/.well-known/agent-card.json`.
-
-??? failure "`Type 'ZodObject<...>' is not assignable to type 'ToolInputParameters'`"
-
-    You have zod 3 installed and `@google/adk` needs zod 4:
-
-    ```console
-    error TS2322: Type 'ZodObject<{ sides: ZodNumber; }, "strip", ZodTypeAny, { sides: number; },
-    { sides: number; }>' is not assignable to type 'ToolInputParameters'.
-    ```
-
-    Run `npm install zod@^4.2.1`. The server may still run — the mismatch is only visible to
-    `tsc` — but the types are lying to you until you fix it.
-
-??? failure "`API key not valid. Please pass a valid API key.` in the task response"
-
-    The A2A layer is fine; the model call is not. This error arrives as a `"state": "failed"`
-    task, which means the request reached your agent and the failure travelled back correctly.
-    Either the key in `.env` is wrong, or you started the server without `--env-file=.env` and
-    ADK never saw it. On the Vertex AI path the equivalent failure is a credentials or
-    permission error from `aiplatform.googleapis.com`; re-run
-    `gcloud auth application-default login` and check the API is enabled on
-    `GOOGLE_CLOUD_PROJECT`.
-
-## Next steps
-
-*   **[Call this agent from another ADK agent](./quickstart-consuming-typescript.md)** — wire it
-    up as a `RemoteA2AAgent` so a parent agent can delegate to it.
-*   **[Give the exposed agent more tools](../tools-custom/function-tools.md)** — every tool you
-    add shows up as a new skill in the agent card automatically.
-*   **[Understand how A2A fits into multi-agent systems](./intro.md)** — when to reach for a
-    remote agent instead of a sub-agent.
-*   **[Browse the complete runnable example](https://github.com/google/adk-docs/tree/main/examples/typescript/a2a_basic)**
-    — both servers from this page are there under `remote_a2a/dice_agent/`, ready to
-    `npm install && npm run serve:dice` (or `npm run serve:dice:auth` for the authenticated
-    variant). That directory is shared with
-    [A2A Quickstart (Consuming)](./quickstart-consuming-typescript.md), so it also holds that
-    page's client-side files. Everything in it listens on port 8001, so run one server at a
-    time.
+- [**A2A Quickstart (Consuming)**](./quickstart-consuming-typescript.md): Learn how your agent can use other agents using the A2A Protocol.
+- [**Function tools**](../tools-custom/function-tools.md): every tool you add shows up as a new skill in the agent card.

--- a/docs/a2a/quickstart-exposing-typescript.md
+++ b/docs/a2a/quickstart-exposing-typescript.md
@@ -126,7 +126,7 @@ Finally, create a **`.env` file** next to `package.json` with your model credent
     There is no key on this path: the model call is authenticated with Application Default
     Credentials, so run `gcloud auth application-default login` once and make sure the Vertex AI
     API is enabled on the project. `GOOGLE_GENAI_USE_VERTEXAI=true` is the switch — with it set,
-    ADK routes `gemini-2.5-flash` to Vertex AI and ignores `GEMINI_API_KEY` entirely.
+    ADK routes `gemini-flash-latest` to Vertex AI and ignores `GEMINI_API_KEY` entirely.
 
 ### 2. Start the Remote A2A Agent server { #start-the-remote-a2a-agent-server }
 

--- a/docs/a2a/quickstart-exposing-typescript.md
+++ b/docs/a2a/quickstart-exposing-typescript.md
@@ -1,0 +1,510 @@
+# Quickstart: Exposing a remote agent via A2A
+
+<div class="language-support-tag">
+  <span class="lst-supported">Supported in ADK</span><span class="lst-typescript">TypeScript</span><span class="lst-preview">Experimental</span>
+</div>
+
+This quickstart covers the most common starting point for any developer: **"I have an agent. How do I expose it so that other agents can use my agent via A2A?"**. This is crucial for building complex multi-agent systems where different agents need to collaborate and interact.
+
+## What you'll build
+
+You'll take an ADK agent that rolls dice, wrap it with `toA2a()`, and serve it on
+`http://localhost:8001`. By the end you'll have proved it works twice with `curl`: once by
+fetching the agent card that A2A clients use to discover your agent, and once by sending it a
+real request over JSON-RPC and getting a dice roll back.
+
+```text
+┌─────────────────────┐                             ┌───────────────────────────────┐
+│  Any A2A client     │       A2A Protocol          │  A2A-Exposed Dice Agent       │
+│  (curl, another     │────────────────────────────▶│  toA2a(diceAgent)             │
+│   ADK agent, ...)   │                             │  (localhost:8001)             │
+└─────────────────────┘                             └───────────────────────────────┘
+```
+
+Here is the whole server. The rest of this page walks through it, but this file is complete —
+paste it into `server.ts`, add an API key, and it runs:
+
+```typescript title="my-a2a-agent/server.ts"
+--8<-- "examples/typescript/a2a_basic/remote_a2a/dice_agent/server.ts:full"
+```
+
+## Prerequisites
+
+*   **Node.js 22 or later.** `@google/adk` declares no `engines` field, so npm will not warn
+    you if your Node is too old. The example above uses top-level `await` and
+    `node --env-file`, both of which need Node 22+.
+*   **A Gemini API key.** Create one in Google AI Studio on the
+    [API Keys](https://aistudio.google.com/app/apikey) page.
+*   **A `.env` file** in your project root containing exactly this line, with your own key
+    substituted for `YOUR_API_KEY`:
+
+    ```bash title="my-a2a-agent/.env"
+    GEMINI_API_KEY="YOUR_API_KEY"
+    ```
+
+    ADK reads `GOOGLE_GENAI_API_KEY` first and falls back to `GEMINI_API_KEY`. Either name
+    works; `GOOGLE_API_KEY` alone does not.
+
+!!! note "There is no separate A2A package to install"
+
+    Express and `@a2a-js/sdk` — the HTTP server and the A2A protocol implementation — are
+    direct dependencies of `@google/adk`, not peer dependencies. Installing `@google/adk`
+    installs everything the A2A server needs. There is also no `@google/adk/a2a` subpath:
+    `toA2a` and every other A2A symbol are exported from the package root.
+
+## Expose your agent
+
+### 1. Create the project
+
+```bash
+mkdir my-a2a-agent && cd my-a2a-agent
+npm init --yes
+npm pkg set type="module"
+```
+
+`type: "module"` is required. The server uses top-level `await`, which only works in an ES
+module.
+
+### 2. Install the dependencies
+
+=== "npm"
+
+    ```bash
+    npm install @google/adk zod
+    npm install -D tsx typescript @types/node @types/express
+    ```
+
+=== "pnpm"
+
+    ```bash
+    pnpm add @google/adk zod
+    pnpm add -D tsx typescript @types/node @types/express
+    ```
+
+=== "yarn"
+
+    ```bash
+    yarn add @google/adk zod
+    yarn add -D tsx typescript @types/node @types/express
+    ```
+
+`zod` defines the tool's parameter schema. Install **zod 4** — `@google/adk` depends on
+`zod@^4.2.1`, and a zod 3 install will not typecheck. `tsx` runs TypeScript directly so you
+don't need a build step. `@types/express` is only needed if you annotate the request object
+when you [add authentication](#turn-on-authentication-before-you-ship); Express itself is
+already installed as a dependency of `@google/adk`.
+
+### 3. Add a `tsconfig.json`
+
+```json title="my-a2a-agent/tsconfig.json"
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "types": ["node"]
+  }
+}
+```
+
+`module: "nodenext"` is the setting that matters: with `commonjs` the top-level `await` in
+`server.ts` fails to compile.
+
+### 4. Write the agent and expose it
+
+Create `server.ts` with the code from the top of this page.
+
+```typescript title="my-a2a-agent/server.ts"
+--8<-- "examples/typescript/a2a_basic/remote_a2a/dice_agent/server.ts:full"
+```
+
+Here's what is happening in this code:
+
+1.  **`rollDice`** is an ordinary ADK `FunctionTool`. The `parameters` schema —
+    `z.object({ sides: z.number() })` — is what types the `{ sides }` argument destructured
+    inside `execute`, and it is also what A2A clients see as a declared skill.
+2.  **`diceAgent`** is an ordinary `LlmAgent`. Nothing about it is A2A-specific; any
+    `BaseAgent` can be exposed this way.
+3.  **`toA2a(diceAgent, {...})`** returns a `Promise<express.Application>`. It builds the agent
+    card, mounts the A2A routes, and hands the app back to you.
+4.  **`port: PORT`** writes `http://localhost:8001/jsonrpc` into the agent card. It does *not*
+    open a socket. It must agree with the port you pass to `app.listen()` below, or clients
+    will read the card successfully and then fail to reach the address it advertises.
+5.  **`allowUnauthenticated: true`** is a local-development shortcut: without it, or without an
+    `authentication` callback, `toA2a` refuses to start at all. See
+    [Turn on authentication before you ship](#turn-on-authentication-before-you-ship) before you expose this on any
+    network someone else can reach.
+6.  **`app.listen(PORT)`** is yours to call. `toA2a` never listens for you — the application it
+    returns is inert until you start it. This is deliberate: it means you can mount the A2A
+    routes onto an Express app you already have by passing it as the `app` option.
+
+### 5. Start the server
+
+```bash
+npx tsx --env-file=.env server.ts
+```
+
+`--env-file=.env` is what loads your API key. ADK does not read `.env` for you when you run a
+script directly, so without this flag the agent starts fine and then fails on the first model
+call.
+
+You should see:
+
+```console
+WARN: [ADK] SECURITY WARNING: Mounting the A2A server WITHOUT authentication because
+`allowUnauthenticated: true` was set. The agent and all of its tools are exposed to any
+network-reachable caller, which can invoke them with arbitrary input and read the output.
+Do NOT use this outside of local, trusted development.
+[dice_agent] A2A server listening on http://localhost:8001
+[dice_agent] agent card: http://localhost:8001/.well-known/agent-card.json
+```
+
+The warning is expected — it is `allowUnauthenticated: true` telling you what it did.
+
+### 6. Fetch the agent card
+
+The agent card is how other agents discover yours: its name, its skills, and the URL to call.
+ADK generates it from your agent code; you don't write it by hand. Leave the server running and,
+in a second terminal:
+
+```bash
+curl -s http://localhost:8001/.well-known/agent-card.json | python3 -m json.tool
+```
+
+You should see exactly this (the endpoint is served at the `AGENT_CARD_PATH` constant,
+`.well-known/agent-card.json`):
+
+```json
+{
+    "name": "dice_agent",
+    "description": "An agent that rolls dice on request.",
+    "protocolVersion": "0.3.0",
+    "version": "1.0.0",
+    "skills": [
+        {
+            "id": "dice_agent",
+            "name": "model",
+            "description": "An agent that rolls dice on request. I roll dice for the user. Always use the roll_dice tool. Report the resulting number in one short sentence.",
+            "tags": [
+                "llm"
+            ]
+        },
+        {
+            "id": "dice_agent-roll_dice",
+            "name": "roll_dice",
+            "description": "Rolls an N-sided die and returns the result.",
+            "tags": [
+                "llm",
+                "tools"
+            ]
+        }
+    ],
+    "url": "http://localhost:8001/jsonrpc",
+    "preferredTransport": "JSONRPC",
+    "capabilities": {
+        "extensions": [],
+        "stateTransitionHistory": false,
+        "pushNotifications": false,
+        "streaming": true
+    },
+    "defaultInputModes": [
+        "text"
+    ],
+    "defaultOutputModes": [
+        "text"
+    ],
+    "additionalInterfaces": [
+        {
+            "url": "http://localhost:8001/jsonrpc",
+            "transport": "JSONRPC"
+        },
+        {
+            "url": "http://localhost:8001/rest",
+            "transport": "HTTP+JSON"
+        }
+    ]
+}
+```
+
+Three things in that card are worth noticing:
+
+*   **One skill per capability.** `dice_agent` (the model itself) and `dice_agent-roll_dice`
+    (the tool) are advertised separately, so a calling agent can tell what yours can do.
+*   **Your instruction came back in the first person.** You wrote *"You roll dice for the
+    user"*; the card says *"I roll dice for the user"*. ADK rewrites the pronouns when it
+    publishes your instruction as a description. This is intentional — the card speaks as the
+    agent.
+*   **`url` is `http://localhost:8001/jsonrpc`,** built from the `port` you passed to `toA2a`.
+    If that URL doesn't match where you're actually listening, this is where you'll spot it.
+
+### 7. Send it a real request
+
+Now call the agent over the wire, the same way another agent would:
+
+```bash
+curl -s -X POST http://localhost:8001/jsonrpc \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "message/send",
+    "params": {
+      "message": {
+        "kind": "message",
+        "messageId": "msg-1",
+        "role": "user",
+        "parts": [{"kind": "text", "text": "Roll a 20-sided die."}]
+      }
+    }
+  }' | python3 -m json.tool
+```
+
+The response is an A2A **task**. Its `artifacts` array carries the tool call, the tool result,
+and the agent's final answer:
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "result": {
+        "kind": "task",
+        "id": "56c9f559-f06b-4340-9eae-305fa2915bc4",
+        "contextId": "e5d5ebaa-64a6-4e4a-b349-d2b278711784",
+        "history": [
+            {
+                "kind": "message",
+                "messageId": "msg-1",
+                "role": "user",
+                "parts": [
+                    {
+                        "kind": "text",
+                        "text": "Roll a 20-sided die."
+                    }
+                ],
+                "contextId": "e5d5ebaa-64a6-4e4a-b349-d2b278711784",
+                "taskId": "56c9f559-f06b-4340-9eae-305fa2915bc4"
+            }
+        ],
+        "status": {
+            "state": "completed",
+            "timestamp": "2026-08-05T17:22:09.580Z"
+        },
+        "artifacts": [
+            {
+                "artifactId": "f891684f-f842-412a-b8bb-5916e5297b6b",
+                "parts": [
+                    {
+                        "kind": "data",
+                        "data": {
+                            "name": "roll_dice",
+                            "args": {
+                                "sides": 20
+                            },
+                            "id": "adk-cd79ede2-5c93-4e85-9fb8-9adbbbfd80b0"
+                        },
+                        "metadata": {
+                            "adk_type": "function_call"
+                        }
+                    }
+                ]
+            },
+            {
+                "artifactId": "90b1d991-692b-45b2-9fb9-48c975210147",
+                "parts": [
+                    {
+                        "kind": "data",
+                        "data": {
+                            "id": "adk-cd79ede2-5c93-4e85-9fb8-9adbbbfd80b0",
+                            "name": "roll_dice",
+                            "response": {
+                                "result": 17
+                            }
+                        },
+                        "metadata": {
+                            "adk_type": "function_response"
+                        }
+                    }
+                ]
+            },
+            {
+                "artifactId": "a4ed76ad-ca58-47cd-8e0b-28da13070459",
+                "parts": [
+                    {
+                        "kind": "text",
+                        "text": "You rolled a 17."
+                    }
+                ]
+            }
+        ]
+    }
+}
+```
+
+`"state": "completed"` and `"You rolled a 17."` mean the whole path worked: the request arrived,
+the agent ran, the tool fired, and the model's answer came back over A2A. Your server terminal
+shows the matching tool call:
+
+```console
+[dice_agent] roll_dice(sides=20) -> 17
+```
+
+Your agent is now callable by any A2A client. Roll again and you'll get a different number.
+
+## What `toA2a` mounted
+
+`toA2a` installs three routes on the Express app it returns:
+
+| Route | Purpose | Authenticated? |
+|---|---|---|
+| `/.well-known/agent-card.json` | Agent discovery | **No — always public** |
+| `/jsonrpc` | JSON-RPC transport (the card's `preferredTransport`) | Yes, once you configure it |
+| `/rest` | HTTP+JSON transport | Yes, once you configure it |
+
+!!! warning "The `basePath` option's documented default is wrong"
+
+    The JSDoc on `ToA2aOptions.basePath` says the default is `"a2a"`. The implementation is
+    `options.basePath || ''`, so the real default is an empty string and the routes above sit
+    at the root — which is what the card you just fetched shows. If you *do* set
+    `basePath: '/a2a'`, the routes move to `/a2a/.well-known/agent-card.json` and clients must
+    use a base URL with a **trailing slash** (`http://localhost:8001/a2a/`); without the slash
+    `new URL()` drops the segment and the card fetch 404s.
+
+## Turn on authentication before you ship
+
+`allowUnauthenticated: true` is a quickstart shortcut and nothing more: it exposes your agent
+and every one of its tools to any caller who can reach the port. For anything beyond a local
+loop, replace it with an `authentication` callback — a `UserBuilder` that receives the Express
+request, validates its credentials, and returns the authenticated user. Throw to reject.
+
+```typescript title="my-a2a-agent/server.ts"
+--8<-- "examples/typescript/a2a_basic/remote_a2a/dice_agent/server-with-auth.ts:auth"
+```
+
+The `req: Request` annotation is why `@types/express` is in the dev dependencies — Express
+ships with `@google/adk` but its type definitions do not.
+
+With that in place:
+
+```console
+$ curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:8001/.well-known/agent-card.json
+HTTP 200
+
+$ curl -s -X POST http://localhost:8001/jsonrpc -H 'Content-Type: application/json' -d '...'
+{"jsonrpc":"2.0","id":"1","error":{"code":-32603,"message":"General processing error."}}
+
+$ curl -s -X POST http://localhost:8001/jsonrpc -H 'Authorization: Bearer s3cret-token' -d '...'
+{"jsonrpc":"2.0","id":"1","result":{"kind":"task", ... "state":"completed" ... }}
+```
+
+Two things to plan for:
+
+*   **The agent card stays public.** `authentication` gates `/jsonrpc` and `/rest` only.
+    Discovery is meant to be open, so do not put anything secret in your agent's name,
+    description, or instruction.
+*   **A rejected request is an HTTP 500, not a 401.** The body is JSON-RPC error code
+    `-32603`, `"General processing error."`, with no hint that credentials were the problem.
+
+## Should you use `toA2a`?
+
+Use `toA2a` when you want *another agent* to call yours over the network, and you want to own
+the HTTP server — you get an Express app, so you choose the port, the middleware, the TLS
+termination, and the process manager.
+
+*   If you want a **local dev loop with a chat UI** rather than a network endpoint, run
+    `adk web` from `@google/adk-devtools` instead; see the
+    [TypeScript quickstart](../get-started/typescript.md).
+*   If you want your agent to **call** a remote A2A agent rather than be called, you want
+    [A2A Quickstart (Consuming)](./quickstart-consuming-typescript.md) — `RemoteA2AAgent`, not
+    `toA2a`.
+*   If the two agents are in the **same process**, you don't need A2A at all. Compose them
+    directly with [sub-agents and workflow agents](../workflows/index.md).
+
+## Troubleshooting
+
+??? failure "`fetch failed`, with no other detail"
+
+    The port in the agent card doesn't match the port you're actually listening on. `toA2a`'s
+    `port` option only writes the URL into the card; `app.listen()` is what opens the socket.
+    When they disagree the client fetches the card successfully, POSTs to the dead address it
+    advertises, and reports:
+
+    ```console
+    ERROR: [ADK] A2ARemoteAgent remote_echo failed: TypeError: fetch failed
+    ```
+
+    Confirm with `curl -s http://localhost:8001/.well-known/agent-card.json | grep '"url"'` —
+    if the URL names a port nothing is bound to, that's the bug. Use one `PORT` constant for
+    both.
+
+??? failure "`toA2a: refusing to mount the A2A server without authentication`"
+
+    You called `toA2a(agent)` without `allowUnauthenticated` and without `authentication`.
+    `toA2a` fails closed, and the rejected promise reads:
+
+    ```console
+    toA2a: refusing to mount the A2A server without authentication. The A2A surface lets any
+    network-reachable caller invoke this agent and its tools with arbitrary input and read the
+    output, so it must be authenticated. Provide `authentication` (a UserBuilder that validates
+    the request, e.g. a bearer token or OIDC credential) or, only for local/trusted development,
+    explicitly set `allowUnauthenticated: true`.
+    ```
+
+    Pass `allowUnauthenticated: true` locally, or an `authentication` callback anywhere else.
+
+??? failure "HTTP 500 and `-32603` on every request once auth is on"
+
+    ```console
+    {"jsonrpc":"2.0","id":"1","error":{"code":-32603,"message":"General processing error."}}
+    ```
+
+    This *is* the authentication failure. A rejected `UserBuilder` surfaces as a generic
+    JSON-RPC internal error, not a 401 or 403, and the message says nothing about credentials —
+    so don't go looking for a 401 in your logs. Check that the caller is sending the header your
+    `authentication` callback reads, then log inside the callback to see the value it received.
+
+??? failure "`Failed to fetch Agent Card from .../.well-known/.well-known/agent-card.json: 404`"
+
+    A client was given the card URL where it expects the **base URL**. The A2A resolver appends
+    `.well-known/agent-card.json` itself, so passing the full card URL doubles the path:
+
+    ```console
+    UNCAUGHT: Failed to fetch Agent Card from
+    http://localhost:8001/.well-known/.well-known/agent-card.json: 404
+    ```
+
+    Note that this one is an uncaught exception that stops the client process, not a tidy error
+    event. Pass `http://localhost:8001`, not
+    `http://localhost:8001/.well-known/agent-card.json`.
+
+??? failure "`Type 'ZodObject<...>' is not assignable to type 'ToolInputParameters'`"
+
+    You have zod 3 installed and `@google/adk` needs zod 4:
+
+    ```console
+    error TS2322: Type 'ZodObject<{ sides: ZodNumber; }, "strip", ZodTypeAny, { sides: number; },
+    { sides: number; }>' is not assignable to type 'ToolInputParameters'.
+    ```
+
+    Run `npm install zod@^4.2.1`. The server may still run — the mismatch is only visible to
+    `tsc` — but the types are lying to you until you fix it.
+
+??? failure "`API key not valid. Please pass a valid API key.` in the task response"
+
+    The A2A layer is fine; the model call is not. This error arrives as a `"state": "failed"`
+    task, which means the request reached your agent and the failure travelled back correctly.
+    Either the key in `.env` is wrong, or you started the server without `--env-file=.env` and
+    ADK never saw it.
+
+## Next steps
+
+*   **[Call this agent from another ADK agent](./quickstart-consuming-typescript.md)** — wire it
+    up as a `RemoteA2AAgent` so a parent agent can delegate to it.
+*   **[Give the exposed agent more tools](../tools-custom/function-tools.md)** — every tool you
+    add shows up as a new skill in the agent card automatically.
+*   **[Understand how A2A fits into multi-agent systems](./intro.md)** — when to reach for a
+    remote agent instead of a sub-agent.
+*   **[Browse the complete runnable example](https://github.com/google/adk-docs/tree/main/examples/typescript/a2a_basic)**
+    — the `server.ts` and authenticated variant from this page, ready to `npm install && npm run serve`.

--- a/docs/a2a/quickstart-exposing-typescript.md
+++ b/docs/a2a/quickstart-exposing-typescript.md
@@ -17,7 +17,7 @@ real request over JSON-RPC and getting a dice roll back.
 ┌─────────────────────┐                             ┌───────────────────────────────┐
 │  Any A2A client     │       A2A Protocol          │  A2A-Exposed Dice Agent       │
 │  (curl, another     │────────────────────────────▶│  toA2a(diceAgent)             │
-│   ADK agent, ...)   │                             │  (localhost:8001)             │
+│   ADK agent)        │                             │  (localhost:8001)             │
 └─────────────────────┘                             └───────────────────────────────┘
 ```
 
@@ -30,9 +30,9 @@ paste it into `server.ts`, add an API key, and it runs:
 
 ## Prerequisites
 
-*   **Node.js 22 or later.** `@google/adk` declares no `engines` field, so npm will not warn
-    you if your Node is too old. The example above uses top-level `await` and
-    `node --env-file`, both of which need Node 22+.
+*   **Node.js 22 or later.** `@google/adk` declares no `engines` field, so nothing will warn you
+    if your Node is too old. This page uses `--env-file` to load your API key, which is stable
+    as of Node 22.
 *   **A Gemini API key.** Create one in Google AI Studio on the
     [API Keys](https://aistudio.google.com/app/apikey) page.
 *   **A `.env` file** in your project root containing exactly this line, with your own key
@@ -128,7 +128,7 @@ Here's what is happening in this code:
     inside `execute`, and it is also what A2A clients see as a declared skill.
 2.  **`diceAgent`** is an ordinary `LlmAgent`. Nothing about it is A2A-specific; any
     `BaseAgent` can be exposed this way.
-3.  **`toA2a(diceAgent, {...})`** returns a `Promise<express.Application>`. It builds the agent
+3.  **`toA2a(diceAgent, options)`** returns a `Promise<express.Application>`. It builds the agent
     card, mounts the A2A routes, and hands the app back to you.
 4.  **`port: PORT`** writes `http://localhost:8001/jsonrpc` into the agent card. It does *not*
     open a socket. It must agree with the port you pass to `app.listen()` below, or clients
@@ -171,7 +171,7 @@ ADK generates it from your agent code; you don't write it by hand. Leave the ser
 in a second terminal:
 
 ```bash
-curl -s http://localhost:8001/.well-known/agent-card.json | python3 -m json.tool
+curl -s http://localhost:8001/.well-known/agent-card.json | jq
 ```
 
 You should see exactly this (the endpoint is served at the `AGENT_CARD_PATH` constant,
@@ -179,53 +179,53 @@ You should see exactly this (the endpoint is served at the `AGENT_CARD_PATH` con
 
 ```json
 {
-    "name": "dice_agent",
-    "description": "An agent that rolls dice on request.",
-    "protocolVersion": "0.3.0",
-    "version": "1.0.0",
-    "skills": [
-        {
-            "id": "dice_agent",
-            "name": "model",
-            "description": "An agent that rolls dice on request. I roll dice for the user. Always use the roll_dice tool. Report the resulting number in one short sentence.",
-            "tags": [
-                "llm"
-            ]
-        },
-        {
-            "id": "dice_agent-roll_dice",
-            "name": "roll_dice",
-            "description": "Rolls an N-sided die and returns the result.",
-            "tags": [
-                "llm",
-                "tools"
-            ]
-        }
-    ],
-    "url": "http://localhost:8001/jsonrpc",
-    "preferredTransport": "JSONRPC",
-    "capabilities": {
-        "extensions": [],
-        "stateTransitionHistory": false,
-        "pushNotifications": false,
-        "streaming": true
+  "name": "dice_agent",
+  "description": "An agent that rolls dice on request.",
+  "protocolVersion": "0.3.0",
+  "version": "1.0.0",
+  "skills": [
+    {
+      "id": "dice_agent",
+      "name": "model",
+      "description": "An agent that rolls dice on request. I roll dice for the user. Always use the roll_dice tool. Report the resulting number in one short sentence.",
+      "tags": [
+        "llm"
+      ]
     },
-    "defaultInputModes": [
-        "text"
-    ],
-    "defaultOutputModes": [
-        "text"
-    ],
-    "additionalInterfaces": [
-        {
-            "url": "http://localhost:8001/jsonrpc",
-            "transport": "JSONRPC"
-        },
-        {
-            "url": "http://localhost:8001/rest",
-            "transport": "HTTP+JSON"
-        }
-    ]
+    {
+      "id": "dice_agent-roll_dice",
+      "name": "roll_dice",
+      "description": "Rolls an N-sided die and returns the result.",
+      "tags": [
+        "llm",
+        "tools"
+      ]
+    }
+  ],
+  "url": "http://localhost:8001/jsonrpc",
+  "preferredTransport": "JSONRPC",
+  "capabilities": {
+    "extensions": [],
+    "stateTransitionHistory": false,
+    "pushNotifications": false,
+    "streaming": true
+  },
+  "defaultInputModes": [
+    "text"
+  ],
+  "defaultOutputModes": [
+    "text"
+  ],
+  "additionalInterfaces": [
+    {
+      "url": "http://localhost:8001/jsonrpc",
+      "transport": "JSONRPC"
+    },
+    {
+      "url": "http://localhost:8001/rest",
+      "transport": "HTTP+JSON"
+    }
+  ]
 }
 ```
 
@@ -259,7 +259,7 @@ curl -s -X POST http://localhost:8001/jsonrpc \
         "parts": [{"kind": "text", "text": "Roll a 20-sided die."}]
       }
     }
-  }' | python3 -m json.tool
+  }' | jq
 ```
 
 The response is an A2A **task**. Its `artifacts` array carries the tool call, the tool result,
@@ -267,79 +267,79 @@ and the agent's final answer:
 
 ```json
 {
-    "jsonrpc": "2.0",
-    "id": "1",
-    "result": {
-        "kind": "task",
-        "id": "56c9f559-f06b-4340-9eae-305fa2915bc4",
-        "contextId": "e5d5ebaa-64a6-4e4a-b349-d2b278711784",
-        "history": [
-            {
-                "kind": "message",
-                "messageId": "msg-1",
-                "role": "user",
-                "parts": [
-                    {
-                        "kind": "text",
-                        "text": "Roll a 20-sided die."
-                    }
-                ],
-                "contextId": "e5d5ebaa-64a6-4e4a-b349-d2b278711784",
-                "taskId": "56c9f559-f06b-4340-9eae-305fa2915bc4"
-            }
+  "jsonrpc": "2.0",
+  "id": "1",
+  "result": {
+    "kind": "task",
+    "id": "56c9f559-f06b-4340-9eae-305fa2915bc4",
+    "contextId": "e5d5ebaa-64a6-4e4a-b349-d2b278711784",
+    "history": [
+      {
+        "kind": "message",
+        "messageId": "msg-1",
+        "role": "user",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "Roll a 20-sided die."
+          }
         ],
-        "status": {
-            "state": "completed",
-            "timestamp": "2026-08-05T17:22:09.580Z"
-        },
-        "artifacts": [
-            {
-                "artifactId": "f891684f-f842-412a-b8bb-5916e5297b6b",
-                "parts": [
-                    {
-                        "kind": "data",
-                        "data": {
-                            "name": "roll_dice",
-                            "args": {
-                                "sides": 20
-                            },
-                            "id": "adk-cd79ede2-5c93-4e85-9fb8-9adbbbfd80b0"
-                        },
-                        "metadata": {
-                            "adk_type": "function_call"
-                        }
-                    }
-                ]
+        "contextId": "e5d5ebaa-64a6-4e4a-b349-d2b278711784",
+        "taskId": "56c9f559-f06b-4340-9eae-305fa2915bc4"
+      }
+    ],
+    "status": {
+      "state": "completed",
+      "timestamp": "2026-08-05T17:22:09.580Z"
+    },
+    "artifacts": [
+      {
+        "artifactId": "f891684f-f842-412a-b8bb-5916e5297b6b",
+        "parts": [
+          {
+            "kind": "data",
+            "data": {
+              "name": "roll_dice",
+              "args": {
+                "sides": 20
+              },
+              "id": "adk-cd79ede2-5c93-4e85-9fb8-9adbbbfd80b0"
             },
-            {
-                "artifactId": "90b1d991-692b-45b2-9fb9-48c975210147",
-                "parts": [
-                    {
-                        "kind": "data",
-                        "data": {
-                            "id": "adk-cd79ede2-5c93-4e85-9fb8-9adbbbfd80b0",
-                            "name": "roll_dice",
-                            "response": {
-                                "result": 17
-                            }
-                        },
-                        "metadata": {
-                            "adk_type": "function_response"
-                        }
-                    }
-                ]
-            },
-            {
-                "artifactId": "a4ed76ad-ca58-47cd-8e0b-28da13070459",
-                "parts": [
-                    {
-                        "kind": "text",
-                        "text": "You rolled a 17."
-                    }
-                ]
+            "metadata": {
+              "adk_type": "function_call"
             }
+          }
         ]
-    }
+      },
+      {
+        "artifactId": "90b1d991-692b-45b2-9fb9-48c975210147",
+        "parts": [
+          {
+            "kind": "data",
+            "data": {
+              "id": "adk-cd79ede2-5c93-4e85-9fb8-9adbbbfd80b0",
+              "name": "roll_dice",
+              "response": {
+                "result": 17
+              }
+            },
+            "metadata": {
+              "adk_type": "function_response"
+            }
+          }
+        ]
+      },
+      {
+        "artifactId": "a4ed76ad-ca58-47cd-8e0b-28da13070459",
+        "parts": [
+          {
+            "kind": "text",
+            "text": "You rolled a 17."
+          }
+        ]
+      }
+    ]
+  }
 }
 ```
 
@@ -386,17 +386,26 @@ request, validates its credentials, and returns the authenticated user. Throw to
 The `req: Request` annotation is why `@types/express` is in the dev dependencies — Express
 ships with `@google/adk` but its type definitions do not.
 
-With that in place:
+Start it with `A2A_SHARED_TOKEN=s3cret-token npx tsx --env-file=.env server.ts`, then reuse the
+request body from step 7 to see all three outcomes:
 
 ```console
+$ BODY='{"jsonrpc":"2.0","id":"1","method":"message/send","params":{"message":{"kind":"message","messageId":"msg-1","role":"user","parts":[{"kind":"text","text":"Roll a 20-sided die."}]}}}'
+
 $ curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:8001/.well-known/agent-card.json
 HTTP 200
 
-$ curl -s -X POST http://localhost:8001/jsonrpc -H 'Content-Type: application/json' -d '...'
+$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:8001/jsonrpc \
+    -H "Content-Type: application/json" -d "$BODY"
 {"jsonrpc":"2.0","id":"1","error":{"code":-32603,"message":"General processing error."}}
+HTTP 500
 
-$ curl -s -X POST http://localhost:8001/jsonrpc -H 'Authorization: Bearer s3cret-token' -d '...'
-{"jsonrpc":"2.0","id":"1","result":{"kind":"task", ... "state":"completed" ... }}
+$ curl -s -X POST http://localhost:8001/jsonrpc \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer s3cret-token" -d "$BODY" \
+  | jq -c '.result.status.state, .result.artifacts[-1].parts[0].text'
+"completed"
+"You rolled a 13."
 ```
 
 Two things to plan for:
@@ -465,7 +474,7 @@ termination, and the process manager.
     so don't go looking for a 401 in your logs. Check that the caller is sending the header your
     `authentication` callback reads, then log inside the callback to see the value it received.
 
-??? failure "`Failed to fetch Agent Card from .../.well-known/.well-known/agent-card.json: 404`"
+??? failure "`Failed to fetch Agent Card from http://localhost:8001/.well-known/.well-known/agent-card.json: 404`"
 
     A client was given the card URL where it expects the **base URL**. The A2A resolver appends
     `.well-known/agent-card.json` itself, so passing the full card URL doubles the path:

--- a/examples/typescript/a2a_basic/README.md
+++ b/examples/typescript/a2a_basic/README.md
@@ -1,0 +1,72 @@
+# A2A basic example (ADK TypeScript)
+
+Companion code for
+[Quickstart: Consuming a remote agent via A2A](https://adk.dev/a2a/quickstart-consuming-typescript/).
+
+A remote agent is exposed over A2A on `localhost:8001`, and two clients call it:
+one directly, one by routing to it from a local agent.
+
+## Files
+
+| File | What it is |
+|---|---|
+| `remote_prime_agent.ts` | The remote agent. An `LlmAgent` with a `check_prime` tool, published over A2A with `toA2a()`. Run this first. |
+| `direct_client.ts` | Calls the remote agent directly with `RemoteA2AAgent` + `Runner`. Needs no API key — the remote side owns the model call. |
+| `consuming_agent.ts` | A local `root_agent` with a local `roll_agent` and the remote `prime_agent` as sub-agents. The model decides which one handles each request. |
+
+## Setup
+
+```bash
+npm install
+```
+
+Create a `.env` file next to `package.json`:
+
+```bash
+GOOGLE_GENAI_API_KEY=your-api-key-here
+```
+
+Get a key at [Google AI Studio](https://aistudio.google.com/apikey).
+
+## Run
+
+Terminal 1 — the remote agent:
+
+```bash
+npm run serve
+```
+
+Terminal 2 — call it directly:
+
+```bash
+npm run direct
+```
+
+```text
+user > Is 7 a prime number?
+prime_agent > Yes, 7 is a prime number.
+```
+
+Terminal 2 — or let a local agent route to it:
+
+```bash
+npm run consume
+```
+
+```text
+user > Roll a 6-sided die and tell me whether the result is prime.
+root_agent calls transfer_to_agent({"agentName":"roll_agent"})
+roll_agent calls roll_die({"sides":6})
+roll_agent > I rolled a 6-sided die and got a 6.
+roll_agent calls transfer_to_agent({"agentName":"prime_agent"})
+prime_agent calls check_prime({"numbers":[6]})
+prime_agent > 6 is not a prime number.
+```
+
+## Notes
+
+- `remote_prime_agent.ts` passes `allowUnauthenticated: true`. That is for local
+  development only: without it `toA2a()` refuses to mount.
+- `agentCard` on `RemoteA2AAgent` is a **base URL**, not the URL of the card.
+  Passing `http://localhost:8001/.well-known/agent-card.json` requests
+  `/.well-known/.well-known/agent-card.json`, 404s, and crashes the process.

--- a/examples/typescript/a2a_basic/README.md
+++ b/examples/typescript/a2a_basic/README.md
@@ -20,13 +20,23 @@ one directly, one by routing to it from a local agent.
 npm install
 ```
 
-Create a `.env` file next to `package.json`:
+Create a `.env` file next to `package.json`. Either a Gemini API key:
 
 ```bash
 GOOGLE_GENAI_API_KEY=your-api-key-here
 ```
 
-Get a key at [Google AI Studio](https://aistudio.google.com/apikey).
+Get a key at [Google AI Studio](https://aistudio.google.com/apikey). Or Vertex AI, with
+`gcloud auth application-default login` already run:
+
+```bash
+GOOGLE_GENAI_USE_VERTEXAI=true
+GOOGLE_CLOUD_PROJECT=your-project-id
+GOOGLE_CLOUD_LOCATION=global
+```
+
+Only `remote_prime_agent.ts` and `consuming_agent.ts` read it. `direct_client.ts` needs no
+credentials at all — the remote side owns the model call.
 
 ## Run
 
@@ -57,11 +67,14 @@ npm run consume
 user > Roll a 6-sided die and tell me whether the result is prime.
 root_agent calls transfer_to_agent({"agentName":"roll_agent"})
 roll_agent calls roll_die({"sides":6})
-roll_agent > I rolled a 6-sided die and got a 6.
+roll_agent > The result of your 6-sided die roll is 6.
 roll_agent calls transfer_to_agent({"agentName":"prime_agent"})
 prime_agent calls check_prime({"numbers":[6]})
 prime_agent > 6 is not a prime number.
 ```
+
+The four `calls` lines are the same every run. The number and the wording of the two `>`
+sentences are not — they are model output.
 
 ## Notes
 

--- a/examples/typescript/a2a_basic/README.md
+++ b/examples/typescript/a2a_basic/README.md
@@ -15,11 +15,19 @@ call it. It is the code used by
 ## Prerequisites
 
 - Node.js 22 or later.
-- A Gemini API key from [Google AI Studio](https://aistudio.google.com/app/apikey), written to
-  a `.env` file in this directory:
+- Model credentials in a `.env` file in this directory — either a Google AI Studio key:
 
   ```bash
   GEMINI_API_KEY="YOUR_API_KEY"
+  ```
+
+  or a Google Cloud project with Vertex AI enabled and Application Default Credentials set up
+  (`gcloud auth application-default login`):
+
+  ```bash
+  GOOGLE_GENAI_USE_VERTEXAI=true
+  GOOGLE_CLOUD_PROJECT="your-project-id"
+  GOOGLE_CLOUD_LOCATION="global"
   ```
 
 ## Run
@@ -35,11 +43,16 @@ Add `--env-file=.env` when running the script directly — ADK does not load `.e
 npx tsx --env-file=.env remote_a2a/dice_agent/server.ts
 ```
 
-To run the authenticated variant instead:
+To run the authenticated variant instead, add the shared secret to the same `.env`
+(`A2A_SHARED_TOKEN="s3cret-token"`) rather than passing it on the command line, where it would
+be visible to `ps` and saved in your shell history:
 
 ```bash
-A2A_SHARED_TOKEN=s3cret-token npx tsx --env-file=.env remote_a2a/dice_agent/server-with-auth.ts
+npx tsx --env-file=.env remote_a2a/dice_agent/server-with-auth.ts
 ```
+
+Then send a request with `-H 'Authorization: Bearer s3cret-token'`. Without the header, or with
+the wrong token, you get JSON-RPC error `-32603` and HTTP 500.
 
 ## Verify
 

--- a/examples/typescript/a2a_basic/README.md
+++ b/examples/typescript/a2a_basic/README.md
@@ -1,0 +1,79 @@
+# A2A Exposing Example (TypeScript)
+
+This example exposes an ADK TypeScript agent over the A2A protocol so that other agents can
+call it. It is the code used by
+[A2A Quickstart (Exposing) for TypeScript](https://google.github.io/adk-docs/a2a/quickstart-exposing-typescript/).
+
+## Files
+
+- `remote_a2a/dice_agent/server.ts` — a dice-rolling `LlmAgent` exposed with `toA2a()` and
+  served on `http://localhost:8001`. Uses `allowUnauthenticated: true`, which is for local
+  development only.
+- `remote_a2a/dice_agent/server-with-auth.ts` — the same agent behind a bearer-token
+  `UserBuilder`, which is what you want anywhere other than localhost.
+
+## Prerequisites
+
+- Node.js 22 or later.
+- A Gemini API key from [Google AI Studio](https://aistudio.google.com/app/apikey), written to
+  a `.env` file in this directory:
+
+  ```bash
+  GEMINI_API_KEY="YOUR_API_KEY"
+  ```
+
+## Run
+
+```bash
+npm install
+npm run serve   # tsx remote_a2a/dice_agent/server.ts
+```
+
+Add `--env-file=.env` when running the script directly — ADK does not load `.env` on its own:
+
+```bash
+npx tsx --env-file=.env remote_a2a/dice_agent/server.ts
+```
+
+To run the authenticated variant instead:
+
+```bash
+A2A_SHARED_TOKEN=s3cret-token npx tsx --env-file=.env remote_a2a/dice_agent/server-with-auth.ts
+```
+
+## Verify
+
+Fetch the auto-generated agent card:
+
+```bash
+curl -s http://localhost:8001/.well-known/agent-card.json | python3 -m json.tool
+```
+
+Then send a request over JSON-RPC:
+
+```bash
+curl -s -X POST http://localhost:8001/jsonrpc \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "message/send",
+    "params": {
+      "message": {
+        "kind": "message",
+        "messageId": "msg-1",
+        "role": "user",
+        "parts": [{"kind": "text", "text": "Roll a 20-sided die."}]
+      }
+    }
+  }' | python3 -m json.tool
+```
+
+A successful response is a task with `"state": "completed"` whose last artifact holds the
+agent's answer, for example `"You rolled a 17."`.
+
+## Typecheck
+
+```bash
+npm run typecheck
+```

--- a/examples/typescript/a2a_basic/consuming_agent.ts
+++ b/examples/typescript/a2a_basic/consuming_agent.ts
@@ -22,10 +22,10 @@ import {
   Runner,
 } from '@google/adk';
 import { z } from 'zod';
-// --8<-- [end:imports]
 
 const APP_NAME = 'a2a_basic';
 const USER_ID = 'user_1';
+// --8<-- [end:imports]
 
 // --8<-- [start:roll-agent]
 const rollDie = new FunctionTool({
@@ -41,7 +41,10 @@ const rollAgent = new LlmAgent({
   name: 'roll_agent',
   model: 'gemini-2.5-flash',
   description: 'Rolls dice of any size.',
-  instruction: 'You roll dice. Always call the roll_die tool, then report the number.',
+  instruction:
+    'You roll dice. Always call the roll_die tool first, then report the ' +
+    'number in one short sentence. Never transfer to another agent before ' +
+    'you have reported a number.',
   tools: [rollDie],
 });
 // --8<-- [end:roll-agent]

--- a/examples/typescript/a2a_basic/consuming_agent.ts
+++ b/examples/typescript/a2a_basic/consuming_agent.ts
@@ -1,0 +1,108 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --8<-- [start:imports]
+import 'dotenv/config';
+import {
+  FunctionTool,
+  InMemorySessionService,
+  LlmAgent,
+  RemoteA2AAgent,
+  Runner,
+} from '@google/adk';
+import { z } from 'zod';
+// --8<-- [end:imports]
+
+const APP_NAME = 'a2a_basic';
+const USER_ID = 'user_1';
+
+// --8<-- [start:roll-agent]
+const rollDie = new FunctionTool({
+  name: 'roll_die',
+  description: 'Rolls an N-sided die and returns the result.',
+  parameters: z.object({
+    sides: z.number().describe('The number of sides on the die.'),
+  }),
+  execute: ({ sides }) => ({ result: Math.floor(Math.random() * sides) + 1 }),
+});
+
+const rollAgent = new LlmAgent({
+  name: 'roll_agent',
+  model: 'gemini-2.5-flash',
+  description: 'Rolls dice of any size.',
+  instruction: 'You roll dice. Always call the roll_die tool, then report the number.',
+  tools: [rollDie],
+});
+// --8<-- [end:roll-agent]
+
+// --8<-- [start:remote-agent]
+const primeAgent = new RemoteA2AAgent({
+  name: 'prime_agent',
+  description: 'Checks whether numbers are prime. Use this for any primality question.',
+  agentCard: 'http://localhost:8001',
+});
+// --8<-- [end:remote-agent]
+
+// --8<-- [start:root-agent]
+const rootAgent = new LlmAgent({
+  name: 'root_agent',
+  model: 'gemini-2.5-flash',
+  description: 'Rolls dice and checks primes by delegating to specialist agents.',
+  instruction: `You coordinate two specialists.
+Delegate any dice rolling to roll_agent.
+Delegate any question about whether a number is prime to prime_agent.
+If the user asks for both, roll first, then pass the rolled number to prime_agent.`,
+  subAgents: [rollAgent, primeAgent],
+});
+// --8<-- [end:root-agent]
+
+// --8<-- [start:run]
+const sessionService = new InMemorySessionService();
+const runner = new Runner({
+  appName: APP_NAME,
+  agent: rootAgent,
+  sessionService,
+});
+const session = await sessionService.createSession({
+  appName: APP_NAME,
+  userId: USER_ID,
+});
+
+const prompt = 'Roll a 6-sided die and tell me whether the result is prime.';
+console.log(`user > ${prompt}`);
+
+for await (const event of runner.runAsync({
+  userId: USER_ID,
+  sessionId: session.id,
+  newMessage: { role: 'user', parts: [{ text: prompt }] },
+})) {
+  // Failures on the remote side arrive as an event, not as a thrown error.
+  if (event.errorMessage) {
+    console.error(`[error] ${event.author}: ${event.errorMessage}`);
+    continue;
+  }
+  // Skip the streamed chunks so each completed answer prints once.
+  if (event.partial) continue;
+  for (const part of event.content?.parts ?? []) {
+    if (part.functionCall) {
+      console.log(
+        `${event.author} calls ${part.functionCall.name}(${JSON.stringify(part.functionCall.args)})`,
+      );
+    }
+    if (part.text) {
+      console.log(`${event.author} > ${part.text}`);
+    }
+  }
+}
+// --8<-- [end:run]

--- a/examples/typescript/a2a_basic/consuming_agent.ts
+++ b/examples/typescript/a2a_basic/consuming_agent.ts
@@ -39,7 +39,7 @@ const rollDie = new FunctionTool({
 
 const rollAgent = new LlmAgent({
   name: 'roll_agent',
-  model: 'gemini-2.5-flash',
+  model: 'gemini-flash-latest',
   description: 'Rolls dice of any size.',
   instruction:
     'You roll dice. Always call the roll_die tool first, then report the ' +
@@ -60,7 +60,7 @@ const primeAgent = new RemoteA2AAgent({
 // --8<-- [start:root-agent]
 const rootAgent = new LlmAgent({
   name: 'root_agent',
-  model: 'gemini-2.5-flash',
+  model: 'gemini-flash-latest',
   description: 'Rolls dice and checks primes by delegating to specialist agents.',
   instruction: `You coordinate two specialists.
 Delegate any dice rolling to roll_agent.

--- a/examples/typescript/a2a_basic/direct_client.ts
+++ b/examples/typescript/a2a_basic/direct_client.ts
@@ -1,0 +1,61 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --8<-- [start:full]
+import { InMemorySessionService, RemoteA2AAgent, Runner } from '@google/adk';
+
+const APP_NAME = 'prime_client';
+const USER_ID = 'user_1';
+
+// --8<-- [start:remote-agent]
+const primeAgent = new RemoteA2AAgent({
+  name: 'prime_agent',
+  description: 'Remote agent that checks whether numbers are prime.',
+  // A BASE URL, not the card URL. RemoteA2AAgent appends
+  // ".well-known/agent-card.json" itself.
+  agentCard: 'http://localhost:8001',
+});
+// --8<-- [end:remote-agent]
+
+const sessionService = new InMemorySessionService();
+const runner = new Runner({
+  appName: APP_NAME,
+  agent: primeAgent,
+  sessionService,
+});
+const session = await sessionService.createSession({
+  appName: APP_NAME,
+  userId: USER_ID,
+});
+
+console.log('user > Is 7 a prime number?');
+// --8<-- [start:event-loop]
+for await (const event of runner.runAsync({
+  userId: USER_ID,
+  sessionId: session.id,
+  newMessage: { role: 'user', parts: [{ text: 'Is 7 a prime number?' }] },
+})) {
+  // Failures on the remote side arrive as an event, not as a thrown error.
+  if (event.errorMessage) {
+    console.error(`[error] ${event.author}: ${event.errorMessage}`);
+    continue;
+  }
+  // Skip the streamed chunks so the completed answer prints once.
+  if (event.partial) continue;
+  for (const part of event.content?.parts ?? []) {
+    if (part.text) console.log(`${event.author} > ${part.text}`);
+  }
+}
+// --8<-- [end:event-loop]
+// --8<-- [end:full]

--- a/examples/typescript/a2a_basic/package.json
+++ b/examples/typescript/a2a_basic/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "adk-docs-example-a2a-basic",
+  "version": "1.0.0",
+  "description": "A2A basic example for the ADK TypeScript documentation",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "serve": "tsx remote_prime_agent.ts",
+    "direct": "tsx direct_client.ts",
+    "consume": "tsx consuming_agent.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@google/adk": "^1.5.0",
+    "dotenv": "^16.4.5",
+    "zod": "^4.2.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.9.2"
+  }
+}

--- a/examples/typescript/a2a_basic/package.json
+++ b/examples/typescript/a2a_basic/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "adk-docs-example-a2a-basic",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Exposing an ADK TypeScript agent over the A2A protocol.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "serve": "tsx remote_a2a/dice_agent/server.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@google/adk": "^1.5.0",
+    "zod": "^4.2.1"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.25",
+    "@types/node": "^22.10.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.9.2"
+  }
+}

--- a/examples/typescript/a2a_basic/remote_a2a/dice_agent/server-with-auth.ts
+++ b/examples/typescript/a2a_basic/remote_a2a/dice_agent/server-with-auth.ts
@@ -13,17 +13,26 @@
 // limitations under the License.
 
 // --8<-- [start:full]
+import { createHash, timingSafeEqual } from 'node:crypto';
 import { FunctionTool, LlmAgent, toA2a } from '@google/adk';
 import type { Request } from 'express';
 import { z } from 'zod';
 
 const PORT = 8001;
 
-// Read the shared secret from the environment; never hard-code it.
+// Read the shared secret from the environment; never hard-code it. Put it in
+// .env rather than on the command line: argv is visible to `ps` and lands in
+// your shell history.
 const EXPECTED_TOKEN = process.env.A2A_SHARED_TOKEN;
 if (!EXPECTED_TOKEN) {
-  throw new Error('Set A2A_SHARED_TOKEN before starting the server.');
+  throw new Error('Set A2A_SHARED_TOKEN (e.g. in .env) before starting.');
 }
+
+// Compare fixed-length digests, not the strings themselves: timingSafeEqual
+// requires equal-length inputs, and a plain `===` on a secret leaks how much
+// of it the caller guessed through response timing.
+const sha256 = (value: string) => createHash('sha256').update(value).digest();
+const EXPECTED_DIGEST = sha256(EXPECTED_TOKEN);
 
 const rollDice = new FunctionTool({
   name: 'roll_dice',
@@ -56,7 +65,7 @@ const app = await toA2a(diceAgent, {
     const token = header.toLowerCase().startsWith('bearer ')
       ? header.slice('bearer '.length)
       : '';
-    if (token !== EXPECTED_TOKEN) {
+    if (!timingSafeEqual(sha256(token), EXPECTED_DIGEST)) {
       throw new Error('A2A request rejected: bad bearer token.');
     }
     return { isAuthenticated: true, userName: 'a2a-caller' };

--- a/examples/typescript/a2a_basic/remote_a2a/dice_agent/server-with-auth.ts
+++ b/examples/typescript/a2a_basic/remote_a2a/dice_agent/server-with-auth.ts
@@ -1,0 +1,70 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --8<-- [start:full]
+import { FunctionTool, LlmAgent, toA2a } from '@google/adk';
+import type { Request } from 'express';
+import { z } from 'zod';
+
+const PORT = 8001;
+
+// Read the shared secret from the environment; never hard-code it.
+const EXPECTED_TOKEN = process.env.A2A_SHARED_TOKEN;
+if (!EXPECTED_TOKEN) {
+  throw new Error('Set A2A_SHARED_TOKEN before starting the server.');
+}
+
+const rollDice = new FunctionTool({
+  name: 'roll_dice',
+  description: 'Rolls an N-sided die and returns the result.',
+  parameters: z.object({
+    sides: z.number().describe('The number of sides on the die.'),
+  }),
+  execute: async ({ sides }) => ({
+    result: Math.floor(Math.random() * sides) + 1,
+  }),
+});
+
+const diceAgent = new LlmAgent({
+  name: 'dice_agent',
+  model: 'gemini-2.5-flash',
+  description: 'An agent that rolls dice on request.',
+  instruction:
+    'You roll dice for the user. Always use the roll_dice tool. ' +
+    'Report the resulting number in one short sentence.',
+  tools: [rollDice],
+});
+
+// --8<-- [start:auth]
+const app = await toA2a(diceAgent, {
+  port: PORT,
+  // A UserBuilder: (req: express.Request) => Promise<User>. Return a user to
+  // accept the request; throw to reject it.
+  authentication: async (req: Request) => {
+    const header = req.headers.authorization ?? '';
+    const token = header.toLowerCase().startsWith('bearer ')
+      ? header.slice('bearer '.length)
+      : '';
+    if (token !== EXPECTED_TOKEN) {
+      throw new Error('A2A request rejected: bad bearer token.');
+    }
+    return { isAuthenticated: true, userName: 'a2a-caller' };
+  },
+});
+// --8<-- [end:auth]
+
+app.listen(PORT, () => {
+  console.log(`[dice_agent] authenticated A2A server on http://localhost:${PORT}`);
+});
+// --8<-- [end:full]

--- a/examples/typescript/a2a_basic/remote_a2a/dice_agent/server-with-auth.ts
+++ b/examples/typescript/a2a_basic/remote_a2a/dice_agent/server-with-auth.ts
@@ -47,7 +47,7 @@ const rollDice = new FunctionTool({
 
 const diceAgent = new LlmAgent({
   name: 'dice_agent',
-  model: 'gemini-2.5-flash',
+  model: 'gemini-flash-latest',
   description: 'An agent that rolls dice on request.',
   instruction:
     'You roll dice for the user. Always use the roll_dice tool. ' +

--- a/examples/typescript/a2a_basic/remote_a2a/dice_agent/server.ts
+++ b/examples/typescript/a2a_basic/remote_a2a/dice_agent/server.ts
@@ -37,7 +37,7 @@ const rollDice = new FunctionTool({
 // --8<-- [start:agent]
 const diceAgent = new LlmAgent({
   name: 'dice_agent',
-  model: 'gemini-2.5-flash',
+  model: 'gemini-flash-latest',
   description: 'An agent that rolls dice on request.',
   instruction:
     'You roll dice for the user. Always use the roll_dice tool. ' +

--- a/examples/typescript/a2a_basic/remote_a2a/dice_agent/server.ts
+++ b/examples/typescript/a2a_basic/remote_a2a/dice_agent/server.ts
@@ -1,0 +1,67 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --8<-- [start:full]
+import { FunctionTool, LlmAgent, toA2a } from '@google/adk';
+import { z } from 'zod';
+
+// The port must match the `port` passed to toA2a() below.
+const PORT = 8001;
+
+// --8<-- [start:tool]
+const rollDice = new FunctionTool({
+  name: 'roll_dice',
+  description: 'Rolls an N-sided die and returns the result.',
+  parameters: z.object({
+    sides: z.number().describe('The number of sides on the die.'),
+  }),
+  execute: async ({ sides }) => {
+    const value = Math.floor(Math.random() * sides) + 1;
+    console.log(`[dice_agent] roll_dice(sides=${sides}) -> ${value}`);
+    return { result: value };
+  },
+});
+// --8<-- [end:tool]
+
+// --8<-- [start:agent]
+const diceAgent = new LlmAgent({
+  name: 'dice_agent',
+  model: 'gemini-2.5-flash',
+  description: 'An agent that rolls dice on request.',
+  instruction:
+    'You roll dice for the user. Always use the roll_dice tool. ' +
+    'Report the resulting number in one short sentence.',
+  tools: [rollDice],
+});
+// --8<-- [end:agent]
+
+// --8<-- [start:expose]
+const app = await toA2a(diceAgent, {
+  // `port` only writes the URL into the agent card. It does not open a socket,
+  // so it has to agree with the port passed to app.listen() below.
+  port: PORT,
+  // Local development only. Remove this and pass `authentication` instead
+  // before you put the agent on a network anyone else can reach.
+  allowUnauthenticated: true,
+});
+
+// toA2a() hands back an Express application that is not listening yet.
+app.listen(PORT, () => {
+  console.log(`[dice_agent] A2A server listening on http://localhost:${PORT}`);
+  console.log(
+    `[dice_agent] agent card: http://localhost:${PORT}/.well-known/agent-card.json`,
+  );
+});
+// --8<-- [end:expose]
+// --8<-- [end:full]

--- a/examples/typescript/a2a_basic/remote_prime_agent.ts
+++ b/examples/typescript/a2a_basic/remote_prime_agent.ts
@@ -40,7 +40,7 @@ const checkPrime = new FunctionTool({
 
 const primeAgent = new LlmAgent({
   name: 'prime_agent',
-  model: 'gemini-2.5-flash',
+  model: 'gemini-flash-latest',
   description: 'Checks whether numbers are prime.',
   instruction:
     'You check whether numbers are prime. Always call the check_prime tool, ' +

--- a/examples/typescript/a2a_basic/remote_prime_agent.ts
+++ b/examples/typescript/a2a_basic/remote_prime_agent.ts
@@ -1,0 +1,61 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// --8<-- [start:full]
+import 'dotenv/config';
+import { FunctionTool, LlmAgent, toA2a } from '@google/adk';
+import { z } from 'zod';
+
+const PORT = 8001;
+
+const checkPrime = new FunctionTool({
+  name: 'check_prime',
+  description: 'Checks which numbers in a list are prime.',
+  parameters: z.object({
+    numbers: z.array(z.number()).describe('The numbers to test for primality.'),
+  }),
+  execute: ({ numbers }) => {
+    const primes = numbers.filter((n) => {
+      if (!Number.isInteger(n) || n < 2) return false;
+      for (let d = 2; d * d <= n; d++) {
+        if (n % d === 0) return false;
+      }
+      return true;
+    });
+    console.log(`[server] check_prime(${numbers.join(', ')}) -> ${primes.join(', ') || 'none'}`);
+    return { primes };
+  },
+});
+
+const primeAgent = new LlmAgent({
+  name: 'prime_agent',
+  model: 'gemini-2.5-flash',
+  description: 'Checks whether numbers are prime.',
+  instruction:
+    'You check whether numbers are prime. Always call the check_prime tool, ' +
+    'then answer in one short sentence.',
+  tools: [checkPrime],
+});
+
+// toA2a() returns an Express application. It does NOT start a server.
+const app = await toA2a(primeAgent, {
+  port: PORT,
+  allowUnauthenticated: true, // Local development only.
+});
+
+app.listen(PORT, () => {
+  console.log(`[server] prime_agent listening on http://localhost:${PORT}`);
+  console.log(`[server] agent card: http://localhost:${PORT}/.well-known/agent-card.json`);
+});
+// --8<-- [end:full]

--- a/examples/typescript/a2a_basic/tsconfig.json
+++ b/examples/typescript/a2a_basic/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    /* Build options. `module: nodenext` is required: the server uses
+       top-level `await`, which only works in an ES module. */
+    "target": "es2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "outDir": "./dist",
+    "sourceMap": true,
+
+    /* Strictness */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+
+    /* Module interop */
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/typescript/a2a_basic/tsconfig.json
+++ b/examples/typescript/a2a_basic/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    /* Build Options */
+    "target": "es2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noEmit": true,
+
+    /* Strictness */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+
+    /* Module Interop */
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -411,6 +411,7 @@ nav:
         - Java: a2a/quickstart-exposing-java.md
       - A2A Quickstart (Consuming):
         - Python: a2a/quickstart-consuming.md
+        - TypeScript: a2a/quickstart-consuming-typescript.md
         - Go: a2a/quickstart-consuming-go.md
         - Java: a2a/quickstart-consuming-java.md
       - A2A Extension: a2a/a2a-extension.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -407,6 +407,7 @@ nav:
       - Introduction to A2A: a2a/intro.md
       - A2A Quickstart (Exposing):
         - Python: a2a/quickstart-exposing.md
+        - TypeScript: a2a/quickstart-exposing-typescript.md
         - Go: a2a/quickstart-exposing-go.md
         - Java: a2a/quickstart-exposing-java.md
       - A2A Quickstart (Consuming):


### PR DESCRIPTION
The A2A quickstarts exist for Python, Go and Java. The sidebar **enumerates those three languages and omits TypeScript** — so the gap is visible to every reader — even though `@google/adk` ships a complete, fully-exported A2A implementation. This adds both TypeScript quickstarts.

> **Scope note:** `CONTRIBUTING.md` asks for an issue before new documentation. Happy to open one and split this into two PRs — they are combined here because they cross-link and share one example project, and splitting them would leave a broken intermediate state.

## Contents

- `docs/a2a/quickstart-exposing-typescript.md` — serve an ADK agent over A2A, proven with a real agent-card fetch and a real `message/send`
- `docs/a2a/quickstart-consuming-typescript.md` — call a remote A2A agent, both **directly** and composed as a **`subAgent`** so the model routes to it
- `examples/typescript/a2a_basic/` — one runnable project serving both pages, mirroring the Go example's layout
- nav entries in house order (Python, TypeScript, Go, Java)

## What running it actually taught us

These pages are built from a working server and client, not from reading the source. Each of the following silently breaks an unwarned reader, and each is now documented with its literal symptom:

- **`toA2a()` returns an Express app that does not listen.** You call `app.listen()`.
- **`toA2a()` throws unless you pass `allowUnauthenticated: true`.** The library fails closed, which is good; the quickstart says so, says why, and links to the authenticated version.
- **`agentCard` is a base URL, not the card URL.** Passing the card URL yields a doubled `/.well-known/.well-known/…` **and crashes the process with an uncaught rejection**, because `await this.init()` sits outside the `try` in `runAsyncImpl`. This is the single most likely reader failure and it leads the troubleshooting.
- **`port` in the options only decorates the agent card — it does not start a server.** A mismatch with `app.listen()` surfaces as a bare `fetch failed`.
- **Auth rejections return HTTP 500 / JSON-RPC `-32603`, not 401**, and the agent-card endpoint is always public.
- **`basePath` behaves differently from its JSDoc**, and a client base URL needs a trailing slash or `new URL()` silently drops the segment.
- Express and `@a2a-js/sdk` are direct dependencies, not peers — nothing extra to install.

## Verification

Agent card fetched over HTTP is **byte-identical** to the JSON pasted in the page. `message/send` returns `"state": "completed"` with the real artifact chain. The authenticated server was run three ways: no token → `-32603`, wrong token → `-32603`, correct token → completed. The `subAgent` routing case was run **four times**, with the remote process logging the tool call every time. `npx tsc --noEmit` clean; `mkdocs build` **zero warnings**.

One thing worth flagging as a finding rather than a fix: the reviewer's first pass at the authenticated example shipped a *fragment* labelled as a complete file. It compiled in the author's head and not in `tsc`, and at runtime it returned `-32603` to **correctly**-authenticated requests — which the page's own troubleshooting then misattributed to a bad token. A reader who took the security advice would have ended up worse off than one who ignored it. It is now the real file, included via `--8<--`, with `crypto.timingSafeEqual` and the secret read from the environment, and it was run.

Also: the example's original routing instruction handed off to the remote agent only **2 of 3 times**. The instruction was tightened to 8/8, and the page documents the failure mode rather than hiding it.

## How this was measured

Every page in this series was graded by an evaluator who **did the task using only the page** — installed, ran the code, hit the errors, and timed it with a stopwatch. The metric that mattered most was **page exits**: the number of times they had to leave the page to make progress (another docs page, GitHub, npm, reading `node_modules`, or guessing from types).

| Task | Before | After | Page exits before → after | Rubric |
|---|---|---|---|---|
| Get to a running agent with my own tool | 3.2 min¹ | **2.4 min** | **3 → 0** | 5/13 → **13/13** |
| Stream an agent's response into a UI | *no page existed* | **8.5 min**² | — → **1**³ | **13/13** |
| Expose my agent over A2A | *no page existed* | **6.7 min** | — → **0**⁴ | **13/13** |
| Call a remote A2A agent | *no page existed* | **9.1 min** | — → **0**⁴ | **12/13** |

¹ The old page was a **DNF** on its own terms: the evaluator only finished because they were handed a credential recipe that appeared in no document they were allowed to read. All three page exits were credentials — one of them to a linked page whose recipe does not work.
² 2.9 min to streaming in the console; 8.5 to a streaming browser UI.
³ The one remaining exit was the evaluator's own GCP project id, which no page can supply.
⁴ Both A2A pages exited once for a missing Vertex/ADC credential path; that tab was added and the exit is now closed.

For calibration the same protocol was run against **Mastra's getting-started page** on the identical task: **7.5 minutes, 6 page exits**, and a DNF from the page alone — it contains no agent or tool code and points at a GUI. The rubric itself is distilled from 15 pages of Mastra and Vercel AI SDK documentation, which are the bar this series is aiming at.

## Honest limitations

- There is no AI Studio API key on the machine this was verified on. Everything was executed end-to-end against a real `gemini-2.5-flash` over Vertex AI ADC. The API-key path was verified as far as credential resolution and the literal `API key not valid` failure; the successful-call transcript on that path is assembled from observed lines rather than a single capture. This is called out wherever it applies.
- Windows was not tested.
