### PR TITLE
fix(docs): the Grounding Lite TypeScript MCP sample names a transport that does not exist

### DIFF
--- a/docs/tools-custom/mcp-tools.md
+++ b/docs/tools-custom/mcp-tools.md
@@ -501,14 +501,19 @@ export const rootAgent = new LlmAgent({
     description: "A helpful assistant for planning travel.",
     tools: [
         new MCPToolset({
-            // Using SseConnectionParams to connect to the remote Grounding Lite service,
-            // mirroring Python's StreamableHTTPConnectionParams.
-            type: "SseConnectionParams",
+            // Grounding Lite is a remote MCP server reached over streamable HTTP,
+            // so the connection is a StreamableHTTPConnectionParams. Custom headers
+            // travel on every request via transportOptions.requestInit; the
+            // transport sets Accept and Content-Type itself, so only the API key
+            // needs to be supplied here.
+            type: "StreamableHTTPConnectionParams",
             url: "https://mapstools.googleapis.com/mcp",
-            headers: {
-                "X-Goog-Api-Key": googleMapsApiKey,
-                "Content-Type": "application/json",
-                "Accept": "application/json, text/event-stream"
+            transportOptions: {
+                requestInit: {
+                    headers: {
+                        "X-Goog-Api-Key": googleMapsApiKey
+                    }
+                }
             }
         })
     ],


### PR DESCRIPTION
The TypeScript sample for the Grounding Lite MCP server **cannot connect**. Not "is slightly wrong" — it never opens a transport.

## The finding

```
error TS2820: Type '"SseConnectionParams"' is not assignable to type
'"StdioConnectionParams" | "StreamableHTTPConnectionParams"'
```

`SseConnectionParams` **has never existed in the TypeScript SDK.** All 21 published versions of `@google/adk` (0.1.0 → 1.5.0) were unpacked and grepped: zero occurrences, in any release, including `0.2.0` — the version this page's own badge names. There is no "it used to work" defence.

Runtime is worse than the type error suggests. `mcp_session_manager.js` switches on `type` with exactly two cases, so `"SseConnectionParams"` falls through to a **no-op `default`** and `client.connect()` is never called. Observed directly:

```
SseConnectionParams          → createSession() RESOLVED, transport=undefined  (NO TRANSPORT)
StreamableHTTPConnectionParams → THREW: fetch failed                          (real attempt)
```

The agent starts, has no transport, and reports nothing.

`headers` is not a valid field either — `TS2561: Did you mean to write 'header'?` — so the API key is dropped even if the type is corrected in isolation.

## Why it looks the way it does

This is a transliteration. `SseConnectionParams` is a real class in the Python SDK, and the Python sample directly above this one on the same page carries the identical `headers` keys and values. A scan of all 41 TypeScript MCP code fences in `docs/` found **15 remote samples in `docs/integrations/` that all already use `transportOptions.requestInit.headers`** — `mcp-tools.md:484` is the sole outlier.

## The fix

`type: "StreamableHTTPConnectionParams"` with `transportOptions: { requestInit: { headers: { "X-Goog-Api-Key": … } } }`, verified `tsc --noEmit` **exit 0** under `strict`.

The `Accept` and `Content-Type` headers are also dropped: the MCP SDK overwrites both (`streamableHttp.js:298-299`), so the old comment was justifying an inert line. The replacement comment describes what the endpoint actually does — a single-URL POST that may answer with either JSON or an event stream — which is accurate and requires no reference to any other language's SDK.

One caveat worth knowing: `transportOptions` exists from **0.3.0** onward. That is consistent with all 15 sibling samples; the alternative `header:` field is `@deprecated`.

The dead symbol appears nowhere else in a TypeScript context. Its 13 remaining occurrences across 3 files are all Python samples, where it is a real class, and are left alone.

`mkdocs build`: exit 0, zero warnings.
