### PR TITLE
docs: normalize TypeScript naming across the site

### DIFF
--- a/docs/agents/custom-agents.md
+++ b/docs/agents/custom-agents.md
@@ -1,7 +1,7 @@
 # Custom agent template workflows
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span><span class="lst-kotlin">Kotlin v0.1.0</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span><span class="lst-kotlin">Kotlin v0.1.0</span>
 </div>
 
 Custom agents and agent-based workflows allow you to define arbitrary
@@ -301,7 +301,7 @@ The foundation for structuring multi-agent systems is the parent-child relations
     # assert task_doer.parent_agent == coordinator
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     // Conceptual Example: Defining Hierarchy
@@ -409,7 +409,7 @@ ADK includes specialized agents derived from `BaseAgent` that don't perform task
     # When pipeline runs, Step2 can access the state['data'] set by Step1.
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     // Conceptual Example: Sequential Pipeline
@@ -472,7 +472,7 @@ ADK includes specialized agents derived from `BaseAgent` that don't perform task
     # A subsequent agent could read state['weather'] and state['news'].
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     // Conceptual Example: Parallel Execution
@@ -564,7 +564,7 @@ ADK includes specialized agents derived from `BaseAgent` that don't perform task
       # until Checker escalates (state['status'] == 'completed') or 10 iterations pass.
       ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     // Conceptual Example: Loop with Condition
@@ -686,7 +686,7 @@ The most fundamental way for agents operating within the same invocation (and th
     # AgentB runs, its instruction processor reads state['capital_city'] to get "Paris".
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     // Conceptual Example: Using outputKey and reading state
@@ -778,7 +778,7 @@ Leverages an [`LlmAgent`](llm-agents.md)'s understanding to dynamically route ta
     # ADK framework then routes execution to booking_agent.
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     // Conceptual Setup: LLM Transfer
@@ -901,7 +901,7 @@ Allows an [`LlmAgent`](llm-agents.md) to treat another `BaseAgent` instance as a
     # The resulting image Part is returned to the Artist agent as the tool result.
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     // Conceptual Setup: Agent as a Tool

--- a/docs/agents/llm-agents.md
+++ b/docs/agents/llm-agents.md
@@ -1,7 +1,7 @@
 # Simple agents with LlmAgent
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span><span class="lst-kotlin">Kotlin v0.1.0</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span><span class="lst-kotlin">Kotlin v0.1.0</span>
 </div>
 
 The `LlmAgent` class, often aliased simply as `Agent`, is a core component in
@@ -53,7 +53,7 @@ First, you need to establish what the agent *is* and what it's *for*.
     )
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     // Example: Defining the basic identity
@@ -148,7 +148,7 @@ tells the agent:
     )
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     // Example: Adding instructions
@@ -248,7 +248,7 @@ on the conversation and its instructions.
     )
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     import {z} from 'zod';
@@ -373,7 +373,7 @@ You can adjust how the underlying AI model generates responses using
     )
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     import { GenerateContentConfig } from '@google/genai';
@@ -506,7 +506,7 @@ schema definitions.
     )
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     import {z} from 'zod';
@@ -591,7 +591,7 @@ Control whether the agent receives the prior conversation history.
     )
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     const statelessAgent = new LlmAgent({
@@ -867,9 +867,9 @@ More complex agents might incorporate schemas, context control, and planning.
         --8<-- "examples/python/snippets/agents/llm-agent/capital_agent.py"
         ```
 
-    === "Typescript"
+    === "TypeScript"
 
-        ```javascript
+        ```typescript
         --8<-- "examples/typescript/snippets/agents/llm-agent/capital_agent.ts"
         ```
 

--- a/docs/agents/models/google-gemini.md
+++ b/docs/agents/models/google-gemini.md
@@ -1,7 +1,7 @@
 # Google Gemini models for ADK agents
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.2.0</span><span class="lst-kotlin">Kotlin v0.1.0</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.2.0</span><span class="lst-kotlin">Kotlin v0.1.0</span>
 </div>
 
 ADK supports the Google Gemini family of generative AI models that provide a

--- a/docs/agents/models/index.md
+++ b/docs/agents/models/index.md
@@ -1,7 +1,7 @@
 # AI Models for ADK agents
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span><span class="lst-typescript">Typescript</span><span class="lst-go">Go</span><span class="lst-java">Java</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span><span class="lst-typescript">TypeScript</span><span class="lst-go">Go</span><span class="lst-java">Java</span>
 </div>
 
 Agent Development Kit (ADK) is designed for flexibility, allowing you to

--- a/docs/agents/workflow-agents/index.md
+++ b/docs/agents/workflow-agents/index.md
@@ -1,7 +1,7 @@
 # Template agent workflows
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span>
 </div>
 
 This section introduces *template workflows*, also known as *workflow agents*,

--- a/docs/agents/workflow-agents/loop-agents.md
+++ b/docs/agents/workflow-agents/loop-agents.md
@@ -1,7 +1,7 @@
 # Loop template workflow agent
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.2.0</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.2.0</span>
 </div>
 
 The ***LoopAgent*** class is a [template workflow](/agents/workflow-agents/) agent
@@ -66,7 +66,7 @@ In this setup, the `LoopAgent` would manage the iterative process.  The `CriticA
         --8<-- "examples/python/snippets/agents/workflow-agents/loop_agent_doc_improv_agent.py:init"
         ```
 
-    === "Typescript"
+    === "TypeScript"
         ```typescript
         --8<-- "examples/typescript/snippets/agents/workflow-agents/loop_agent_doc_improv_agent.ts:init"
         ```

--- a/docs/agents/workflow-agents/parallel-agents.md
+++ b/docs/agents/workflow-agents/parallel-agents.md
@@ -1,7 +1,7 @@
 # Parallel template workflow agent
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.2.0</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.2.0</span>
 </div>
 
 The ***ParallelAgent*** class is a [template workflow](/agents/workflow-agents/)
@@ -68,7 +68,7 @@ These research tasks are independent.  Using a `ParallelAgent` allows them to ru
          --8<-- "examples/python/snippets/agents/workflow-agents/parallel_agent_web_research.py:init"
         ```
 
-    === "Typescript"
+    === "TypeScript"
         ```typescript
          --8<-- "examples/typescript/snippets/agents/workflow-agents/parallel_agent_web_research.ts:init"
         ```

--- a/docs/agents/workflow-agents/sequential-agents.md
+++ b/docs/agents/workflow-agents/sequential-agents.md
@@ -1,7 +1,7 @@
 # Sequential template workflow agent
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.2.0</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.2.0</span>
 </div>
 
 The ***SequentialAgent*** class is a [template workflow](/agents/workflow-agents/)
@@ -68,7 +68,7 @@ This ensures the code is written, *then* reviewed, and *finally* refactored, in 
         --8<-- "examples/python/snippets/agents/workflow-agents/sequential_agent_code_development_agent.py:init"
         ```
 
-    === "Typescript"
+    === "TypeScript"
         ```typescript
         --8<-- "examples/typescript/snippets/agents/workflow-agents/sequential_agent_code_development_agent.ts:init"
         ```

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -23,12 +23,12 @@ The Agent Development Kit (ADK) provides comprehensive API references across sup
 
 <!-- This comment forces a block separation -->
 
--   :fontawesome-brands-js:{ .lg .middle } **Typescript API Reference**
+-   :fontawesome-brands-js:{ .lg .middle } **TypeScript API Reference**
 
     ---
     Access the complete API documentation for the TypeScript Agent Development Kit. Find detailed information on all packages, classes, and methods to build powerful and flexible AI agents with TypeScript.
 
-    [:octicons-arrow-right-24: View Typescript API Docs](https://adk.dev/api-reference/typescript/) <br>
+    [:octicons-arrow-right-24: View TypeScript API Docs](https://adk.dev/api-reference/typescript/) <br>
 
 <!-- This comment forces a block separation -->
 

--- a/docs/artifacts/index.md
+++ b/docs/artifacts/index.md
@@ -41,7 +41,7 @@ In ADK, **Artifacts** represent a crucial mechanism for managing named, versione
     print(f"Artifact Data (first 10 bytes): {image_artifact.inline_data.data[:10]}...")
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     import {createPartFromBase64, type Part} from '@google/genai';
@@ -185,7 +185,7 @@ Understanding artifacts involves grasping a few key components: the service that
     # Now, contexts within runs managed by this runner can use artifact methods
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     import {
@@ -285,7 +285,7 @@ Understanding artifacts involves grasping a few key components: the service that
     print(f"Created Python artifact with MIME type: {pdf_artifact_py.inline_data.mime_type}")
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     import {createPartFromBase64, type Part} from '@google/genai';
@@ -371,7 +371,7 @@ Understanding artifacts involves grasping a few key components: the service that
     # and scope it to app_name and user_id, making it accessible across sessions for that user.
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     // Example illustrating namespace difference (conceptual)
@@ -461,7 +461,7 @@ Before you can use any artifact methods via the context objects, you **must** pr
     ```
     If no `artifact_service` is configured in the `InvocationContext` (which happens if it's not passed to the `Runner`), calling `save_artifact`, `load_artifact`, or `list_artifacts` on the context objects will raise a `ValueError`.
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     import {
@@ -591,7 +591,7 @@ The artifact interaction methods are available directly on instances of `Callbac
         #   await save_generated_report_py(callback_context, report_data)
         ```
 
-    === "Typescript"
+    === "TypeScript"
 
         ```typescript
         import {Context} from '@google/adk';
@@ -716,7 +716,7 @@ The artifact interaction methods are available directly on instances of `Callbac
         #   await process_latest_report_py(callback_context)
         ```
 
-    === "Typescript"
+    === "TypeScript"
 
         ```typescript
         import {Context} from '@google/adk';
@@ -955,7 +955,7 @@ artifact in a later turn.
         # list_files_tool = FunctionTool(func=list_user_files_py)
         ```
 
-    === "Typescript"
+    === "TypeScript"
 
         ```typescript
         import {Context} from '@google/adk';
@@ -1081,7 +1081,7 @@ artifact in a later turn.
     --8<-- "examples/kotlin/snippets/artifacts/ArtifactExamples.kt:listing_artifacts"
     ```
 
-These methods for saving, loading, and listing provide a convenient and consistent way to manage binary data persistence within ADK, whether using Python's context objects or directly interacting with the `BaseArtifactService` in Java, regardless of the chosen backend storage implementation.
+These methods for saving, loading, and listing provide a convenient and consistent way to manage binary data persistence within ADK, whether you reach them through the context object passed to your callbacks and tools or by interacting with the `BaseArtifactService` directly, regardless of the chosen backend storage implementation.
 
 ## Available Implementations
 
@@ -1113,7 +1113,7 @@ ADK provides concrete implementations of the `BaseArtifactService` interface, of
         # runner = Runner(..., artifact_service=in_memory_service_py)
         ```
 
-    === "Typescript"
+    === "TypeScript"
 
         ```typescript
         import {InMemoryArtifactService} from '@google/adk';
@@ -1204,7 +1204,7 @@ ADK provides concrete implementations of the `BaseArtifactService` interface, of
             # Handle the error appropriately - maybe fall back to InMemory or raise
         ```
 
-    === "Typescript"
+    === "TypeScript"
 
         ```typescript
         import {GcsArtifactService} from '@google/adk';

--- a/docs/callbacks/index.md
+++ b/docs/callbacks/index.md
@@ -40,7 +40,7 @@ Callbacks are a cornerstone feature of ADK, providing a powerful mechanism to ho
         --8<-- "examples/python/snippets/callbacks/callback_basic.py:callback_basic"
         ```
 
-    === "Typescript"
+    === "TypeScript"
 
         ```typescript
         --8<-- "examples/typescript/snippets/callbacks/callback_basic.ts:callback_basic"
@@ -103,7 +103,7 @@ This example demonstrates the common pattern for a guardrail using `before_model
         --8<-- "examples/python/snippets/callbacks/before_model_callback.py"
         ```
 
-    === "Typescript"
+    === "TypeScript"
         ```typescript
         --8<-- "examples/typescript/snippets/callbacks/before_model_callback.ts"
         ```

--- a/docs/callbacks/types-of-callbacks.md
+++ b/docs/callbacks/types-of-callbacks.md
@@ -54,7 +54,7 @@ These callbacks are available on *any* agent that inherits from `BaseAgent` (inc
         --8<-- "examples/python/snippets/callbacks/before_agent_callback.py"
         ```
 
-    === "Typescript"
+    === "TypeScript"
         ```typescript
         --8<-- "examples/typescript/snippets/callbacks/before_agent_callback.ts"
         ```
@@ -104,7 +104,7 @@ These callbacks are available on *any* agent that inherits from `BaseAgent` (inc
         --8<-- "examples/python/snippets/callbacks/after_agent_callback.py"
         ```
 
-    === "Typescript"
+    === "TypeScript"
         ```typescript
         --8<-- "examples/typescript/snippets/callbacks/after_agent_callback.ts"
         ```
@@ -156,7 +156,7 @@ If the callback returns `None` (or a `Maybe.empty()` object in Java), the LLM co
         --8<-- "examples/python/snippets/callbacks/before_model_callback.py"
         ```
 
-    === "Typescript"
+    === "TypeScript"
         ```typescript
         --8<-- "examples/typescript/snippets/callbacks/before_model_callback.ts"
         ```
@@ -195,7 +195,7 @@ If the callback returns `None` (or a `Maybe.empty()` object in Java), the LLM co
         --8<-- "examples/python/snippets/callbacks/after_model_callback.py"
         ```
 
-    === "Typescript"
+    === "TypeScript"
         ```typescript
         --8<-- "examples/typescript/snippets/callbacks/after_model_callback.ts"
         ```
@@ -238,7 +238,7 @@ These callbacks are also specific to `LlmAgent` and trigger around the execution
         --8<-- "examples/python/snippets/callbacks/before_tool_callback.py"
         ```
 
-    === "Typescript"
+    === "TypeScript"
         ```typescript
         --8<-- "examples/typescript/snippets/callbacks/before_tool_callback.ts"
         ```
@@ -276,7 +276,7 @@ These callbacks are also specific to `LlmAgent` and trigger around the execution
         --8<-- "examples/python/snippets/callbacks/after_tool_callback.py"
         ```
 
-    === "Typescript"
+    === "TypeScript"
         ```typescript
         --8<-- "examples/typescript/snippets/callbacks/after_tool_callback.ts"
         ```

--- a/docs/deploy/cloud-run.md
+++ b/docs/deploy/cloud-run.md
@@ -599,7 +599,7 @@ Once your agent is deployed to Cloud Run, you can interact with it via the deplo
 
     If you deployed your agent with the UI enabled:
 
-    *   **adk CLI:** You included the corresponding flag (`--webui` in Go or `--with_ui` in Python or Typescript) during deployment.
+    *   **adk CLI:** You included the corresponding flag (`--webui` in Go or `--with_ui` in Python or TypeScript) during deployment.
     *   **gcloud CLI:** You set `SERVE_WEB_INTERFACE = True` in your `main.py`.
 
     You can test your agent by simply navigating to the Cloud Run service URL provided after deployment in your web browser.

--- a/docs/integrations/mcp-toolbox-for-databases.md
+++ b/docs/integrations/mcp-toolbox-for-databases.md
@@ -8,7 +8,7 @@ catalog_tags: ["mcp","data","google"]
 # MCP Toolbox for Databases tool for ADK
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span><span class="lst-typescript">Typescript</span><span class="lst-go">Go</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span><span class="lst-typescript">TypeScript</span><span class="lst-go">Go</span>
 </div>
 
 [MCP Toolbox for Databases](https://github.com/googleapis/mcp-toolbox) is an
@@ -165,7 +165,7 @@ documentation:
     )
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ADK relies on the `@toolbox-sdk/adk` TS package to use MCP Toolbox. Install the
     package before getting started:

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -116,7 +116,7 @@ methods, as shown in the following code example:
         print(f"[Plugin] LLM request count: {self.llm_request_count}")
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript title="count_plugin.ts"
     import { BaseAgent, BasePlugin, Context } from "@google/adk";
@@ -320,7 +320,7 @@ a simple ADK agent.
         asyncio.run(main())
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     import { InMemoryRunner, LlmAgent, FunctionTool } from "@google/adk";
@@ -581,7 +581,7 @@ command line:
     python3 -m path.to.main.py
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```sh
     npx ts-node path.to.main.ts
@@ -758,7 +758,7 @@ The following code example shows the basic syntax of this callback:
     ) -> Optional[types.Content]:
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     async onUserMessageCallback(
@@ -813,7 +813,7 @@ The following code example shows the basic syntax of this callback:
     ) -> Optional[types.Content]:
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     async beforeRunCallback(invocationContext: InvocationContext): Promise<Content | undefined> {
@@ -906,7 +906,7 @@ The following code example shows the basic syntax of this callback:
     ) -> Optional[LlmResponse]:
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     async onModelErrorCallback(
@@ -987,7 +987,7 @@ The following code example shows the basic syntax of this callback:
     ) -> Optional[dict]:
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     async onToolErrorCallback(
@@ -1044,7 +1044,7 @@ The following code example shows the basic syntax of this callback:
     ) -> Optional[Event]:
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     async onEventCallback(
@@ -1098,7 +1098,7 @@ The following code example shows the basic syntax of this callback:
     ) -> Optional[None]:
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     async afterRunCallback(invocationContext: InvocationContext): Promise<void> {

--- a/docs/runtime/event-loop.md
+++ b/docs/runtime/event-loop.md
@@ -1,7 +1,7 @@
 # Runtime Event Loop
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span><span class="lst-kotlin">Kotlin v0.1.0</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span><span class="lst-kotlin">Kotlin v0.1.0</span>
 </div>
 
 The ADK Runtime is the underlying engine that powers your agent application during user interactions. It's the system that takes your defined agents, tools, and callbacks and orchestrates their execution in response to user input, managing the flow of information, state changes, and interactions with external services like LLMs or storage.

--- a/docs/sessions/session/index.md
+++ b/docs/sessions/session/index.md
@@ -1,7 +1,7 @@
 # Session: Tracking individual conversations
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span><span class="lst-kotlin">Kotlin v0.1.0</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span><span class="lst-kotlin">Kotlin v0.1.0</span>
 </div>
 
 A `Session` represents a single conversation thread between a user and your

--- a/docs/tools-custom/function-tools.md
+++ b/docs/tools-custom/function-tools.md
@@ -1,7 +1,7 @@
 # Function tools
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span><span class="lst-kotlin">Kotlin v0.1.0</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span><span class="lst-kotlin">Kotlin v0.1.0</span>
 </div>
 
 When pre-built ADK tools don't meet your requirements, you can create custom
@@ -378,7 +378,7 @@ afterwards.
         {"result": "$123"}
         ```
 
-    === "Typescript"
+    === "TypeScript"
 
         This tool retrieves the mocked value of a stock price.
 

--- a/docs/tools-custom/index.md
+++ b/docs/tools-custom/index.md
@@ -1,7 +1,7 @@
 # Custom Tools for ADK
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span>
 </div>
 
 In an ADK agent workflow, Tools are programming functions with structured input
@@ -499,8 +499,8 @@ By adhering to these guidelines, you provide the LLM with the clarity and struct
 
 ## Toolsets: Grouping and Dynamically Providing Tools
 
-<div class="language-support-tag" title="This feature is currently available for Python and Typescript.">
-   <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.5.0</span><span class="lst-typescript">Typescript v0.2.0</span>
+<div class="language-support-tag" title="This feature is currently available for Python and TypeScript.">
+   <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.5.0</span><span class="lst-typescript">TypeScript v0.2.0</span>
 </div>
 
 

--- a/docs/tools-custom/mcp-tools.md
+++ b/docs/tools-custom/mcp-tools.md
@@ -1,7 +1,7 @@
 # Model Context Protocol Tools
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span>
 </div>
 
 This guide walks you through two ways of integrating Model Context Protocol (MCP) with ADK.
@@ -259,7 +259,7 @@ Event received: {"id":"8728380b-bfad-4d14-8421-fa98d09364f1","invocationId":"e-c
 Event received: {"id":"8fe7e594-3e47-4254-8b57-9106ad8463cb","invocationId":"e-c2458c56-e57a-45b2-97de-ae7292e505ef","author":"enterprise_assistant","content":{"parts":[{"text":"There are three files in the directory: first, second, and third."}],"role":"model"},"actions":{"stateDelta":{},"artifactDelta":{},"requestedAuthConfigs":{}},"timestamp":1747377544689}
 ```
 
-For Typescript, you can define an agent that initializes the `MCPToolset` as follows:
+For TypeScript, you can define an agent that initializes the `MCPToolset` as follows:
 
 ```typescript
 import 'dotenv/config';

--- a/docs/tutorials/multi-tool-agent.md
+++ b/docs/tutorials/multi-tool-agent.md
@@ -1,7 +1,7 @@
 # Build a multi-tool agent
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span><span class="lst-kotlin">Kotlin v0.1.0</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span><span class="lst-kotlin">Kotlin v0.1.0</span>
 </div>
 
 This quickstart guides you through installing Agent Development Kit (ADK),

--- a/docs/workflows/index.md
+++ b/docs/workflows/index.md
@@ -1,7 +1,7 @@
 # Workflows: multi-agent, multi-node applications
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span>
 </div>
 
 As agentic applications grow in complexity, structuring them as a single,

--- a/docs/workflows/patterns.md
+++ b/docs/workflows/patterns.md
@@ -1,7 +1,7 @@
 # Multi-agent workflow patterns
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">Typescript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span><span class="lst-kotlin">Kotlin v0.1.0</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v0.1.0</span><span class="lst-typescript">TypeScript v0.2.0</span><span class="lst-go">Go v0.1.0</span><span class="lst-java">Java v0.1.0</span><span class="lst-kotlin">Kotlin v0.1.0</span>
 </div>
 
 This guide provides a number of agent patterns which you can implement with
@@ -40,7 +40,7 @@ your project requirements before committing to a full implementation.
     # User asks "I can't log in" -> Coordinator's LLM should call transfer_to_agent(agent_name='Support')
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     // Conceptual Code: Coordinator using LLM Transfer
@@ -139,7 +139,7 @@ your project requirements before committing to a full implementation.
     # reporter runs -> reads state['result']
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     // Conceptual Code: Sequential Data Pipeline
@@ -253,7 +253,7 @@ your project requirements before committing to a full implementation.
     # synthesizer runs afterwards, reading state['api1_data'] and state['api2_data'].
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     // Conceptual Code: Parallel Information Gathering
@@ -382,7 +382,7 @@ your project requirements before committing to a full implementation.
     # Results flow back up.
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     // Conceptual Code: Hierarchical Research Task
@@ -518,7 +518,7 @@ your project requirements before committing to a full implementation.
     # reviewer runs -> reads state['draft_text'], saves status to state['review_status']
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     // Conceptual Code: Generator-Critic
@@ -652,7 +652,7 @@ your project requirements before committing to a full implementation.
     # Loop stops if QualityChecker outputs 'pass' (leading to StopChecker escalating) or after 5 iterations.
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     // Conceptual Code: Iterative Code Refinement
@@ -662,7 +662,7 @@ your project requirements before committing to a full implementation.
     // Agent to generate/refine code based on state['current_code'] and state['requirements']
     const codeRefiner = new LlmAgent({
         name: 'CodeRefiner',
-        instruction: 'Read state["current_code"] (if exists) and state["requirements"]. Generate/refine Typescript code to meet requirements. Save to state["current_code"].',
+        instruction: 'Read state["current_code"] (if exists) and state["requirements"]. Generate/refine TypeScript code to meet requirements. Save to state["current_code"].',
         outputKey: 'current_code' // Overwrites previous code in state
     });
 
@@ -843,7 +843,7 @@ your project requirements before committing to a full implementation.
     )
     ```
 
-=== "Typescript"
+=== "TypeScript"
 
     ```typescript
     // Conceptual Code: Using a Tool for Human Approval

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -440,7 +440,7 @@ nav:
     - API Reference:
       - api-reference/index.md
       - Python ADK: api-reference/python/index.html
-      - Typescript ADK: api-reference/typescript/index.html
+      - TypeScript ADK: api-reference/typescript/index.html
       - Go ADK:
         - Go v2.x: https://pkg.go.dev/google.golang.org/adk/v2" target="_blank
         - Go v1.x: https://pkg.go.dev/google.golang.org/adk" target="_blank


### PR DESCRIPTION
Individually these are small. Together they are a large part of why the TypeScript documentation reads as a translation rather than as documentation.

## What changed

- **Tab labels: 53 × `=== "Typescript"` → `=== "TypeScript"`.** The site was split 137/53, and **three pages carried both spellings**, rendering two differently-labelled tabs for the same language.
- **Badge text**: `lst-typescript">Typescript` normalised. **No version numbers were altered.**
- **`mkdocs.yml`**: nav label `Typescript ADK` → `TypeScript ADK`.
- **`docs/api-reference/index.md`**: two occurrences. This file sits inside `docs/api-reference/` but is **hand-authored**, not generated — it is the only Markdown file among 3,140 generated HTML files there, it is the only api-reference entry `mkdocs.yml` lists as `.md`, it carries a `CONTRIBUTORS:` note citing #1716/#1717, and its card body already said "TypeScript" twice while its heading said "Typescript". No generated file was touched.
- **`docs/agents/llm-agents.md`**: a ` ```javascript ` fence on a `.ts` snippet — the only such case among ~146 TypeScript fences.
- **`docs/artifacts/index.md`**: the closing summary named only Python and Java on a page carrying 10 TypeScript tabs (and 10 Go, 11 Kotlin). Rewritten language-neutrally, since an enumeration in prose is exactly what rots.

## It fixes a bug it was not aiming at

`mkdocs-material`'s `content.tabs.link` syncs tab selection across the site by **case-sensitive `innerText`**. The three pages that carried both spellings had tab sets that **refused to sync with the rest of the site**. That is now zero.

## Verification

- Rendered-site anchor diff between `main` and this branch: **0 added, 0 removed, 0 changed** across 3,467 pages. Tab ids and heading anchors are identical, so no deep link breaks. (`pymdownx.tabbed` slugifies with `case: lower`, so the ids never depended on the casing.)
- `mkdocs build` exit 0 with zero warnings on both sides; warning-set diff empty.
- Rendered pages containing `Typescript`: **226 → 0**.
- Nothing touched in `docs/get-started/`, `docs/live/`, `docs/a2a/`, or `mkdocs.yml` lines 400-440.
- `git diff --check` clean.

Two `Typescript` strings are deliberately left: `.gitignore:170` (a comment) and `tools/feature-matrix/prompt.md:26` (an internal tool prompt). Neither is in `docs/` nor rendered.

Two related changes are split out for separate review rather than riding along here: the example dependency bumps, and a broken TypeScript MCP sample.

### One finding, reported not fixed

`tools/feature-matrix/start.md` is generated with only two language columns — Python and Java. TypeScript, Go and Kotlin have none. That needs a generator change, not a docs edit.
