### PR TITLE
feat(search): replace the lunr search index with Pagefind

### DIFF
--- a/docs/stylesheets/pagefind.css
+++ b/docs/stylesheets/pagefind.css
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Themes the Pagefind search components to match Material for MkDocs.
+ *
+ * Pagefind applies `all: initial` to its host elements, so no site styles
+ * cascade in. Custom properties are the documented theming hook, and they are
+ * exempt from `all`, so mapping Material's palette onto the `--pf-*` variables
+ * is enough to theme the whole search UI - including dark mode - without any
+ * JavaScript.
+ *
+ * These are declared on `body` rather than `:root` on purpose. Material only
+ * declares its default palette at `:root`; the dark palette is declared on
+ * `[data-md-color-scheme="slate"]`, which the theme sets on `<body>`. Mapping
+ * at `:root` would resolve against the light palette and stay light after the
+ * palette toggle.
+ */
+body {
+  --pf-font: var(--md-text-font-family, system-ui, sans-serif);
+
+  --pf-text: var(--md-default-fg-color);
+  --pf-text-secondary: var(--md-default-fg-color--light);
+  --pf-text-muted: var(--md-default-fg-color--light);
+  --pf-background: var(--md-default-bg-color);
+
+  --pf-border: var(--md-default-fg-color--lightest);
+  --pf-border-focus: var(--md-default-fg-color--lighter);
+  --pf-hover: var(--md-code-bg-color);
+
+  --pf-skeleton: var(--md-code-bg-color);
+  --pf-skeleton-shine: var(--md-default-fg-color--lightest);
+
+  /* Matched terms render as transparent-background, weight-500 text. */
+  --pf-mark: var(--md-default-fg-color);
+
+  --pf-outline-focus: var(--md-typeset-a-color);
+  --pf-shadow-lg: var(--md-shadow-z3);
+
+  /* Roomier than the 560px default; ADK page titles and paths run long. */
+  --pf-modal-max-width: 42rem;
+}
+
+/*
+ * Material renders headings and code inside search excerpts using its own
+ * type scale, which is larger than Pagefind's. Nudge the result text up
+ * slightly so excerpts stay legible against the site's body copy.
+ */
+body {
+  --pf-result-title-font-size: 15px;
+  --pf-result-excerpt-font-size: 14px;
+}
+
+/* Header integration -------------------------------------------------- */
+
+/*
+ * Sits between the SDK repository links and the palette toggle. `flex-shrink`
+ * keeps the trigger from collapsing when the page title is long.
+ */
+.adk-search__trigger {
+  flex-shrink: 0;
+  margin-right: 0.4rem;
+}
+
+/*
+ * The header is crowded once the SDK links, palette toggle and navigation
+ * tabs are all present. Below Material's `medium` breakpoint, collapse the
+ * trigger to just its magnifying-glass icon - the same thing the component's
+ * own `compact` attribute does, but responsive rather than fixed at render
+ * time.
+ */
+@media screen and (max-width: 76.1875em) {
+  .adk-search__trigger .pf-trigger-text,
+  .adk-search__trigger .pf-trigger-shortcut {
+    display: none;
+  }
+
+  .adk-search__trigger .pf-trigger-btn {
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+  }
+}

--- a/hooks/pagefind_index.py
+++ b/hooks/pagefind_index.py
@@ -1,0 +1,128 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Builds the Pagefind search index as a MkDocs post-build step.
+
+Pagefind is a static search engine: it crawls the *rendered* HTML in
+``site_dir`` and emits a sharded index plus a WASM query engine into
+``site/pagefind/``. The browser downloads only the shards a query touches,
+instead of the single multi-megabyte JSON index that MkDocs' built-in
+lunr-based ``search`` plugin produces.
+
+Which pages get indexed is controlled by the ``data-pagefind-body`` attribute
+set on the ``<article>`` element in ``overrides/main.html``. Once that
+attribute exists anywhere on the site, Pagefind indexes *only* pages that
+carry it, which keeps the generated API reference output (Dokka, Javadoc and
+TypeDoc write thousands of HTML files into ``docs/api-reference/``) out of the
+index. Those files were never in the lunr index either, so this preserves the
+existing search scope.
+
+Set ``PAGEFIND_SKIP=1`` to skip indexing, e.g. for link-checking builds that
+never serve the search UI.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+import time
+
+from mkdocs.exceptions import PluginError
+
+log = logging.getLogger("mkdocs.hooks.pagefind")
+
+# Characters that Pagefind should treat as part of a word rather than as
+# punctuation to strip. The ADK docs are full of identifiers that are
+# meaningless once split ("adk.run", "google.adk.agents", "@Tool", "--reload"),
+# and the default configuration would index those as separate bare words.
+INCLUDE_CHARACTERS = ".-@#+"
+
+# Interface chrome that sits inside the indexed article but is not prose.
+#
+# Pagefind concatenates the text of adjacent inline elements without inserting
+# a separator, so sibling elements written without whitespace between them are
+# indexed as a single fused token. Three constructs in this site hit that:
+#
+#   .headerlink          the "¶" permalink anchor appended to every heading by
+#                        the `toc` extension - pure navigation, and it fused
+#                        into headings on 230 of 232 pages
+#   .tabbed-labels       the tab strip emitted by `pymdownx.tabbed`, written as
+#                        `<label>Python</label><label>Java</label>`, which is
+#                        indexed as "PythonJava". The tab *contents* are still
+#                        indexed, so per-language content remains searchable.
+#   .language-support-tag  the hand-authored "Supported in ADK" version badge,
+#                        a run of adjacent <span>s that produced tokens such as
+#                        "ADKPythonTypeScriptGoJava".
+#
+# Excluding these took pages carrying fused language tokens from 109/232 to
+# 5/232, and every remaining hit is a genuine identifier ("RxJava",
+# "pdfArtifactJava") rather than a defect.
+EXCLUDE_SELECTORS = ".headerlink, .tabbed-labels, .language-support-tag"
+
+
+def on_post_build(config, **kwargs) -> None:
+    """Runs the Pagefind CLI over the freshly built site."""
+    if os.environ.get("PAGEFIND_SKIP") == "1":
+        log.info("PAGEFIND_SKIP=1 set, skipping search index build.")
+        return
+
+    site_dir = config["site_dir"]
+    command = [
+        sys.executable,
+        "-m",
+        "pagefind",
+        "--site",
+        site_dir,
+        "--include-characters",
+        INCLUDE_CHARACTERS,
+        "--exclude-selectors",
+        EXCLUDE_SELECTORS,
+        # Errors only. The sole warning this suppresses is that eight generated
+        # files (seven Dokka `navigation.html` fragments and the Google site
+        # verification file) have no <html> element. None of them are indexable
+        # or intended to be, so the warning is noise on every build. Genuine
+        # failures still set a non-zero exit code and are raised below.
+        "--silent",
+    ]
+
+    started = time.monotonic()
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as error:  # pragma: no cover - defensive
+        raise PluginError(
+            f"Could not run the Pagefind indexer ({error}). Install the pinned "
+            "version with: pip install -r requirements.txt"
+        ) from error
+
+    if "No module named pagefind" in result.stderr:
+        raise PluginError(
+            "Pagefind is not installed, so the site would be built without a "
+            "search index. Install it with: pip install -r requirements.txt"
+        )
+
+    if result.returncode != 0:
+        raise PluginError(
+            "Pagefind failed to build the search index "
+            f"(exit code {result.returncode}).\n{result.stdout}\n{result.stderr}"
+        )
+
+    elapsed = time.monotonic() - started
+    log.info("Built Pagefind search index in %.2f seconds", elapsed)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ validation:
 extra_css:
   - stylesheets/custom.css
   - stylesheets/language-tags.css
+  - stylesheets/pagefind.css
 
 # Custom JavaScript
 extra_javascript:
@@ -114,9 +115,15 @@ markdown_extensions:
       permalink: true
 
 
+# Hooks
+hooks:
+  # Builds the Pagefind search index from the rendered HTML after each build.
+  - hooks/pagefind_index.py
+
 # Plugins
 plugins:
-  - search
+  # NOTE: the built-in `search` plugin (lunr.js) is intentionally not enabled.
+  # Search is served by Pagefind instead - see hooks/pagefind_index.py.
   - macros:
       module_name: scripts/integrations
       # Set custom delimiters for J2 templates to avoid conflicts with Markdown

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -35,6 +35,35 @@
   <meta name="twitter:title" content="Agent Development Kit (ADK)">
   <meta name="twitter:description" content="Build powerful multi-agent systems with Agent Development Kit (ADK)">
   <meta name="twitter:image" content="https://adk.dev/assets/adk-social-card.png">
+
+  <!--
+    Pagefind search. These assets are generated into the site directory after
+    the build by hooks/pagefind_index.py, so they do not exist under docs/.
+    The module script is deferred by default, and Pagefind derives the bundle
+    path from this script's own URL, which keeps subpath deploys working.
+  -->
+  <link rel="stylesheet" href="{{ 'pagefind/pagefind-component-ui.css' | url }}">
+  <script type="module" src="{{ 'pagefind/pagefind-component-ui.js' | url }}"></script>
+{% endblock %}
+
+<!--
+  Mirrors the `container` block from the theme's base.html, adding
+  `data-pagefind-body` to the article. Pagefind indexes only pages carrying
+  that attribute, which scopes the index to real documentation pages, and
+  within them to the main content - excluding the header, navigation, sidebar
+  and footer, and excluding the generated API reference output entirely.
+-->
+{% block container %}
+  <div class="md-content" data-md-component="content">
+    {% if "navigation.path" in features %}
+      {% include "partials/path.html" %}
+    {% endif %}
+    <article class="md-content__inner md-typeset" data-pagefind-body>
+      {% block content %}
+        {% include "partials/content.html" %}
+      {% endblock %}
+    </article>
+  </div>
 {% endblock %}
 
 <!-- top of page announcement banner here: -->

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -96,21 +96,17 @@
       {% include "partials/alternate.html" %}
     {% endif %}
 
-    <!-- Button to open search modal -->
-    {% if "material/search" in config.plugins %}
-      {% set search = config.plugins["material/search"] | attr("config") %}
+    <!--
+      Pagefind search, replacing the theme's lunr-backed modal. The built-in
+      `search` plugin is disabled in mkdocs.yml, so partials/search.html is
+      deliberately not included here.
 
-      <!-- Check if search is actually enabled - see https://t.ly/DT_0V -->
-      {% if search.enabled %}
-        <label class="md-header__button md-icon" for="__search">
-          {% set icon = config.theme.icon.search or "material/magnify" %}
-          {% include ".icons/" ~ icon ~ ".svg" %}
-        </label>
-
-        <!-- Search interface -->
-        {% include "partials/search.html" %}
-      {% endif %}
-    {% endif %}
+      These elements live in the header, outside every region that instant
+      navigation swaps (announce, container, header-topic, outdated, logo,
+      skip), so the components stay mounted across client-side navigation.
+    -->
+    <pagefind-modal-trigger class="adk-search__trigger"></pagefind-modal-trigger>
+    <pagefind-modal reset-on-close></pagefind-modal>
   </nav>
 
   <!-- Navigation tabs (sticky) -->

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ mkdocs-linkcheck==1.0.6
 mkdocs-llmstxt==0.5.0
 mkdocs-macros-plugin==1.4.1
 click==8.2.1
+# Static search index, built by hooks/pagefind_index.py after each site build.
+pagefind[bin]==1.5.2


### PR DESCRIPTION
## Summary

Replaces MkDocs' built-in lunr.js search with [Pagefind](https://pagefind.app/).

The built-in `search` plugin builds one lunr index and the browser downloads all of it before the first query. On this site that's **3.5 MB (843 KB gzipped)**, fetched on every page load whether or not the reader opens search. Pagefind shards the index at build time and ships a WASM query engine, so the browser fetches only the shards a query touches.

## Measured impact

Built the previous commit as a baseline, served both locally, and read the **server access log** — Pagefind fetches its index from a Web Worker, and those requests don't appear in page-level devtools events.

| | before (lunr) | after (Pagefind) |
|---|---|---|
| on page load | **855 KB gzip** | **46 KB gzip** |
| on first search | 0 | 378 KB gzip |
| total, if the reader searches | 855 KB | 425 KB |

Readers who never search pay **95% less**. Readers who do pay about half.

One honest caveat: unlike lunr, Pagefind's cost isn't one-time — it fetches more fragments as you scroll results, so a session with many queries eventually crosses over.

## How it works

- `hooks/pagefind_index.py` runs the indexer in `on_post_build`: **+2.2s** on a ~31s build.
- Pagefind ships as a **PyPI wheel with a prebuilt binary**, so it installs from `requirements.txt` with **no Node toolchain** in CI. A `manylinux` wheel exists for `ubuntu-latest`.
- Index scope is set by `data-pagefind-body` on the article, via a `container` block override mirroring the theme's own. Once that attribute exists anywhere, Pagefind indexes only pages carrying it — which keeps the **3,130 generated Dokka/Javadoc/TypeDoc files** out. Those were never in the lunr index either, so **search scope is unchanged**: 232 pages in, 232 indexed.
- UI is Pagefind's **Component UI** (`<pagefind-modal>`), which supersedes the older Default UI as of Pagefind 1.5.0. Keeps `Cmd/Ctrl+K` and adds WAI-ARIA compliance.
- Theming maps `--pf-*` onto Material's `--md-*` **on `body`, not `:root`** — Material declares its light palette at `:root` but its dark palette on `[data-md-color-scheme]` on `<body>`, so mapping at `:root` would stay light after the palette toggle. Custom properties are exempt from Pagefind's `all: initial` host reset, so **dark mode needs no JavaScript**.
- The components live in the header, outside every region Material's instant navigation swaps, so they stay mounted across client-side navigation.

`PAGEFIND_SKIP=1` skips indexing, e.g. for link-checking builds.

## Index quality fixes

Pagefind concatenates adjacent inline elements without a separator, so siblings authored without whitespace fuse into one token. It does **not** fix this for free — three constructs here hit it, removed via `--exclude-selectors`:

| selector | produced |
|---|---|
| `.headerlink` | `¶` permalink anchors fused into headings on **230 of 232** pages |
| `.tabbed-labels` | `<label>Python</label><label>Java</label>` → `PythonJava` |
| `.language-support-tag` | `ADKPythonTypeScriptGoJava` |

Pages with fused language tokens: **109/232 → 5/232**, and all five remaining are genuine identifiers (`RxJava`, `pdfArtifactJava` is a real variable in a Java sample). Tab *contents* stay indexed, so per-language content remains searchable — verified `Kotlin agent` → 25 results, `Java streaming` → 34.

`--include-characters ".-@#+"` keeps dotted identifiers intact; without it `google.adk.agents` degrades to three bare words (133 results with it).

## Verification

Driven in headless Chrome against the built site:

- trigger renders, `Ctrl+K` opens, queries return results, and `¶` permalink anchors no longer appear in indexed headings
- **zero** requests for `search_index.json` or the lunr worker
- no JS errors, no same-origin HTTP failures
- dark mode: `dialogBg` resolves to `rgb(30, 33, 41)` with light text after the palette toggle
- **instant navigation**: same component node persists, no duplicates, search still works. This needed care — instant nav is inert on `localhost` because Material gates interception on `sitemap.xml`, whose URLs are absolute to `adk.dev`. I rebuilt with a local `site_url` to reproduce production conditions, and confirmed production `adk.dev` does use it.
- `mkdocs build --strict` passes; `mkdocs serve` works (search functions in dev too)
- both failure paths tested: `PAGEFIND_SKIP=1`, and a clear error if the dependency is missing

## Note for reviewers

Screenshots of the modal in light and dark mode can be attached if useful. Licensing is unchanged: Pagefind is MIT, same as mkdocs-material and lunr.
