### PR TITLE
feat(search): replace lunr with Pagefind and a grouped-results search modal

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -39,3 +39,4 @@ jobs:
             mkdocs-material-
       - run: pip install -r requirements.txt
       - run: mkdocs build --strict
+      - run: python scripts/verify_search_index.py site

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -42,4 +42,6 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: pip install -r requirements.txt
+      - run: mkdocs build --strict
+      - run: python scripts/verify_search_index.py site
       - run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,10 @@ cython_debug/
 # mkdocs documentation
 docs/site
 
+# Local design/plan scratch space. Never committed; see the LOCAL_ONLY_PREFIX
+# exemption in scripts/verify_search_index.py.
+docs/superpowers/
+
 # Utilities for local development
 .gemini/
 .scripts/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,10 @@ when using compatible AI coding tools in this repo.
     This command starts a local docs server, typically at
     `http://127.0.0.1:8000/`.
 
+    Set `PAGEFIND_SKIP=1` to skip building the search index on each rebuild
+    while authoring; site search will not work in that build, and because
+    skipping logs a warning, `mkdocs build --strict` fails while it is set.
+
 ## Create Your Contribution
 
 | Type | Description |

--- a/docs/javascript/search.js
+++ b/docs/javascript/search.js
@@ -365,11 +365,27 @@
    * Windows sends AltGr as Ctrl+Alt: on layouts where AltGr+K is a printable
    * character, matching on Ctrl alone would swallow it.
    */
+  /*
+   * `/`, `s` and `f` were bound by Material's own search, which this replaces.
+   * Rebinding them keeps existing muscle memory working instead of silently
+   * dropping three shortcuts. They are bare keys, so they must not fire while
+   * the reader is typing into a field or editing content.
+   */
+  const TYPING_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT"]);
+  const isTyping = (target) =>
+    TYPING_TAGS.has(target.tagName) || target.isContentEditable;
+
   document.addEventListener("keydown", (event) => {
     if ((event.ctrlKey || event.metaKey) && !event.altKey && event.code === "KeyK") {
       event.preventDefault();
       if (dialog.open) dialog.close();
       else openDialog();
+      return;
+    }
+    if (dialog.open || event.ctrlKey || event.metaKey || event.altKey) return;
+    if (["/", "s", "f"].includes(event.key) && !isTyping(event.target)) {
+      event.preventDefault();
+      openDialog();
     }
   });
 

--- a/docs/javascript/search.js
+++ b/docs/javascript/search.js
@@ -1,0 +1,426 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Search modal backed by Pagefind.
+ *
+ * Nothing search-related is fetched on page load. `pagefind.js` (12.8 KB
+ * gzipped) is dynamically imported when the modal is first opened, and
+ * `pagefind-highlight.js` (9.6 KB gzipped) only when the current URL carries
+ * highlight terms, which happens only when arriving from a search result.
+ */
+(() => {
+  "use strict";
+
+  /*
+   * Belt and braces, not a live guard.
+   *
+   * Material's instant navigation re-evaluates only the scripts it finds
+   * inside the container it swaps -- roughly `Ke(M("script", Ce("container")))`
+   * in the bundled runtime. extra_javascript is emitted outside that
+   * container, so this file is never re-evaluated and the flag can never
+   * actually be observed as true. It stays because it is free and because
+   * the failure it prevents is silent.
+   *
+   * If the trigger or dialog is ever moved into a replaced region, this
+   * guard becomes the bug rather than the fix: the script would keep the
+   * references it captured below, they would point at detached nodes after
+   * the first client-side navigation, and search would stop working with no
+   * error. Re-check this if either element moves.
+   */
+  if (window.__adkSearchInitialised) return;
+
+  const dialog = document.querySelector("[data-adk-search-dialog]");
+  const trigger = document.querySelector("[data-adk-search-trigger]");
+  if (!dialog || !trigger) return;
+
+  window.__adkSearchInitialised = true;
+
+  const input = dialog.querySelector("[data-adk-search-input]");
+  const results = dialog.querySelector("[data-adk-search-results]");
+  const status = dialog.querySelector("[data-adk-search-status]");
+  const closeButton = dialog.querySelector("[data-adk-search-close]");
+
+  const MAX_PAGES = 5;
+  const MAX_SECTIONS = 3;
+  const DEBOUNCE_MS = 300;
+  const HIGHLIGHT_PARAM = "pagefind-highlight";
+  const ACTIVE_CLASS = "adk-search__link--active";
+  const OPTION_ID_PREFIX = "adk-search-option-";
+
+  /*
+   * Resolved now, at initial page load. The header survives instant
+   * navigation, so the rendered relative path would resolve against the
+   * wrong document if this were deferred until the modal opens.
+   */
+  const BUNDLE = new URL(dialog.dataset.pagefindBundle, document.baseURI).href;
+
+  let cursor = -1;
+
+  /*
+   * Memoised so the warm-up fired by openDialog() and the first keystroke
+   * share one load instead of racing. Pagefind's own init_pagefind() happens
+   * to be idempotent, but that is an undocumented internal detail and not
+   * something to depend on.
+   *
+   * The module is only published to callers once options() and init() have
+   * both succeeded. Resolving to the raw module earlier would mean a failed
+   * init still handed back a truthy, unusable engine -- the likeliest
+   * failure mode in production (CSP blocking wasm, a partial deploy, a
+   * corrupt entry file) is exactly the one that must reach the error UI.
+   */
+  let pagefindPromise = null;
+
+  function loadPagefind() {
+    pagefindPromise ??= (async () => {
+      const mod = await import(`${BUNDLE}pagefind.js`);
+      await mod.options({
+        excerptLength: 20,
+        // Makes Pagefind append the term to every result URL itself.
+        highlightParam: HIGHLIGHT_PARAM,
+      });
+      await mod.init();
+      return mod;
+    })().catch((error) => {
+      console.error("Pagefind failed to load", error);
+      return null;
+    });
+    return pagefindPromise;
+  }
+
+  function setStatus(message) {
+    status.textContent = message;
+  }
+
+  function renderExcerpt(html) {
+    const paragraph = document.createElement("p");
+    paragraph.className = "adk-search__excerpt";
+    /*
+     * Safe against injection: pagefind.js escapes `<` and `>` in
+     * `fragment.raw_content` before building excerpts (`loadFragment`,
+     * pagefind 1.5.2), so the only markup reaching innerHTML is Pagefind's
+     * own <mark>. calculate_sub_results reads the same escaped
+     * raw_content, so section excerpts are covered by the same guarantee.
+     * Re-verify on any Pagefind bump.
+     *
+     * Note this does not rest on trusting page content. Raw fragments really
+     * do contain unescaped `<a href=...>` and things like `Optional<Content>`
+     * from the API docs; it is that escape step, not the provenance of the
+     * text, that makes this safe.
+     */
+    paragraph.innerHTML = html || "";
+    return paragraph;
+  }
+
+  /*
+   * Result links opt out of Material's instant navigation via target="_self".
+   *
+   * Material intercepts internal links by stripping the query and hash and
+   * testing the bare URL against its sitemap, so `/page/?pagefind-highlight=x`
+   * would be intercepted and handled client-side. That would leave the
+   * dialog open over the new page and, because the document is never
+   * replaced, the arrival highlighting at the bottom of this file would
+   * never run. Material's handler bails out early on a truthy `target`, so
+   * setting it forces a full navigation, which both tears down the dialog
+   * and re-runs this script.
+   *
+   * The links are also the listbox options: role, aria-selected and id are
+   * what make the arrow-key cursor perceivable to assistive tech. The ids
+   * are assigned in runSearch once the full list exists.
+   */
+  function renderPage(page) {
+    const item = document.createElement("li");
+    item.className = "adk-search__page";
+    // Options are the <a>s; the list plumbing carries no semantics.
+    item.setAttribute("role", "presentation");
+
+    const link = document.createElement("a");
+    link.className = "adk-search__page-link";
+    link.href = page.url;
+    link.target = "_self";
+    link.setAttribute("role", "option");
+    link.setAttribute("aria-selected", "false");
+    link.textContent = (page.meta && page.meta.title) || page.url;
+    item.appendChild(link);
+
+    const sections = (page.sub_results || [])
+      .filter((section) => section.url !== page.url)
+      .slice(0, MAX_SECTIONS);
+
+    if (sections.length === 0) {
+      item.appendChild(renderExcerpt(page.excerpt));
+      return item;
+    }
+
+    const list = document.createElement("ul");
+    list.className = "adk-search__sections";
+    list.setAttribute("role", "presentation");
+    for (const section of sections) {
+      const sectionItem = document.createElement("li");
+      sectionItem.setAttribute("role", "presentation");
+      const sectionLink = document.createElement("a");
+      sectionLink.className = "adk-search__section-link";
+      sectionLink.href = section.url;
+      sectionLink.target = "_self";
+      sectionLink.setAttribute("role", "option");
+      sectionLink.setAttribute("aria-selected", "false");
+
+      const title = document.createElement("span");
+      title.className = "adk-search__section-title";
+      title.textContent = section.title;
+
+      sectionLink.append(title, renderExcerpt(section.excerpt));
+      sectionItem.appendChild(sectionLink);
+      list.appendChild(sectionItem);
+    }
+    item.appendChild(list);
+    return item;
+  }
+
+  // Clears the rendered list and every piece of state that describes it.
+  function clearResults() {
+    setCursor(-1);
+    results.replaceChildren();
+    setExpanded(false);
+  }
+
+  async function runSearch(rawQuery) {
+    const query = rawQuery.trim();
+    /*
+     * Reset the cursor against the list that is on screen right now, not the
+     * one that will replace it. The rendering below is at least DEBOUNCE_MS
+     * away, and until then the previously active row is still displayed;
+     * resetting the index alone would leave it looking selected while Enter
+     * did nothing.
+     */
+    setCursor(-1);
+
+    if (!query) {
+      clearResults();
+      setStatus("");
+      return;
+    }
+
+    const engine = await loadPagefind();
+    if (!engine) {
+      clearResults();
+      setStatus("Search is unavailable. Try reloading the page.");
+      return;
+    }
+
+    try {
+      const search = await engine.debouncedSearch(query, {}, DEBOUNCE_MS);
+      // Resolves to null when a later keystroke superseded this call.
+      if (search === null) return;
+      // Ignore a response that arrived after the box was cleared or changed.
+      if (input.value.trim() !== query) return;
+
+      if (search.results.length === 0) {
+        clearResults();
+        setStatus(`No results for "${query}"`);
+        return;
+      }
+
+      const pages = await Promise.all(
+        search.results.slice(0, MAX_PAGES).map((result) => result.data())
+      );
+      if (input.value.trim() !== query) return;
+
+      setCursor(-1);
+      results.replaceChildren(...pages.map(renderPage));
+      resultLinks().forEach((link, index) => {
+        link.id = `${OPTION_ID_PREFIX}${index}`;
+      });
+      setExpanded(true);
+      /*
+       * Announced by the role="status" region. Reporting both numbers is the
+       * only signal that MAX_PAGES has truncated the list.
+       */
+      const total = search.results.length;
+      setStatus(
+        total === pages.length
+          ? `${total} result${total === 1 ? "" : "s"}`
+          : `${total} results, showing top ${pages.length}`
+      );
+    } catch (error) {
+      /*
+       * debouncedSearch() and result.data() both fetch over the network --
+       * index chunks and fragment files are pulled per query. Without this
+       * the rejection escapes into the input listener, which ignores it: an
+       * unhandled rejection, stale results left on screen, and no signal.
+       */
+      console.error("Pagefind search failed", error);
+      clearResults();
+      setStatus("Search failed. Check your connection and try again.");
+    }
+  }
+
+  function resultLinks() {
+    return Array.from(results.querySelectorAll("a"));
+  }
+
+  function setExpanded(expanded) {
+    input.setAttribute("aria-expanded", expanded ? "true" : "false");
+  }
+
+  /*
+   * The single place the selection is written. It keeps three things in
+   * step that used to drift apart: the index, the visual highlight, and the
+   * accessible selection. Passing -1 means "nothing selected" and clears the
+   * highlight from every link currently rendered, which is what makes a
+   * reset safe to do while an older list is still on screen.
+   */
+  function setCursor(next) {
+    const links = resultLinks();
+    cursor = next >= 0 && next < links.length ? next : -1;
+    links.forEach((link, index) => {
+      const active = index === cursor;
+      link.classList.toggle(ACTIVE_CLASS, active);
+      link.setAttribute("aria-selected", active ? "true" : "false");
+    });
+    if (cursor >= 0) {
+      input.setAttribute("aria-activedescendant", links[cursor].id);
+      links[cursor].scrollIntoView({ block: "nearest" });
+    } else {
+      input.removeAttribute("aria-activedescendant");
+    }
+  }
+
+  function moveCursor(delta) {
+    const links = resultLinks();
+    if (links.length === 0) return;
+    /*
+     * From "nothing selected", down goes to the first item and up to the
+     * last. Folding -1 into the modulo instead would send ArrowUp to
+     * links.length - 2, the second-to-last item.
+     */
+    const next =
+      cursor < 0
+        ? delta > 0
+          ? 0
+          : links.length - 1
+        : (cursor + delta + links.length) % links.length;
+    setCursor(next);
+  }
+
+  function openDialog() {
+    if (dialog.open) return;
+    input.value = "";
+    clearResults();
+    setStatus("");
+    dialog.showModal();
+    input.focus();
+    // Warm the engine while the reader is still typing their first character.
+    loadPagefind();
+  }
+
+  trigger.addEventListener("click", openDialog);
+  closeButton.addEventListener("click", () => dialog.close());
+  input.addEventListener("input", (event) => runSearch(event.target.value));
+
+  /*
+   * Closing here is not redundant with the full navigation that target="_self"
+   * forces. A result pointing at the page the reader is already on differs
+   * from the current URL only by hash, so the browser scrolls instead of
+   * loading a document: nothing is torn down and the dialog would otherwise
+   * stay open over the anchor it just jumped to.
+   */
+  results.addEventListener("click", (event) => {
+    if (event.target.closest("a")) dialog.close();
+  });
+
+  /*
+   * Clicking the backdrop closes; clicking inside the panel does not.
+   *
+   * Both ends of the gesture have to be on the backdrop. A click event is
+   * dispatched against the nearest common ancestor of mousedown and mouseup,
+   * so selecting text in the input and releasing outside the panel targets
+   * the dialog itself and would otherwise close it mid drag-select.
+   */
+  let backdropPressed = false;
+  dialog.addEventListener("mousedown", (event) => {
+    backdropPressed = event.target === dialog;
+  });
+  dialog.addEventListener("click", (event) => {
+    if (backdropPressed && event.target === dialog) dialog.close();
+    backdropPressed = false;
+  });
+
+  /*
+   * `code` rather than `key` so the shortcut is the physical K position and
+   * does not move around on Dvorak or AZERTY. altKey is excluded because
+   * Windows sends AltGr as Ctrl+Alt: on layouts where AltGr+K is a printable
+   * character, matching on Ctrl alone would swallow it.
+   */
+  document.addEventListener("keydown", (event) => {
+    if ((event.ctrlKey || event.metaKey) && !event.altKey && event.code === "KeyK") {
+      event.preventDefault();
+      if (dialog.open) dialog.close();
+      else openDialog();
+    }
+  });
+
+  dialog.addEventListener("keydown", (event) => {
+    /*
+     * All three keys are scoped to the combobox. aria-activedescendant only
+     * has meaning while the input holds focus, so moving the cursor from the
+     * close button would shift a pointer nothing is listening to.
+     */
+    if (event.target !== input) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      moveCursor(1);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      moveCursor(-1);
+    } else if (event.key === "Enter") {
+      const links = resultLinks();
+      if (cursor >= 0 && links[cursor]) {
+        event.preventDefault();
+        links[cursor].click();
+      }
+    }
+  });
+
+  /*
+   * Arrival highlighting. Loaded only when the URL carries highlight terms,
+   * so a normal page view never pays for it.
+   */
+  if (new URLSearchParams(window.location.search).has(HIGHLIGHT_PARAM)) {
+    import(`${BUNDLE}pagefind-highlight.js`)
+      .then(({ default: PagefindHighlight }) => {
+        // Constructing it performs the highlighting.
+        new PagefindHighlight({
+          highlightParam: HIGHLIGHT_PARAM,
+          markContext: document.querySelector("article.md-content__inner"),
+          /*
+           * Not what prevents the yellow: Pagefind's injected rule is
+           * `:where(.pagefind-highlight){...}` at specificity 0-0-0, and
+           * Material's own `.md-typeset mark` already outranks it, so the
+           * marks would be palette-coloured either way.
+           *
+           * It is set for two narrower reasons: it keeps a stray <style>
+           * element out of <head>, and it removes the injected
+           * `color: black`, which is the one declaration that would matter
+           * if a mark ever landed outside .md-typeset and so escaped
+           * Material's rule.
+           */
+          addStyles: false,
+        });
+      })
+      .catch((error) => console.error("Pagefind highlight failed to load", error));
+  }
+})();

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -169,13 +169,10 @@ button.md-content__button:hover svg {
   overflow: hidden !important;
 }
 
-/* Constrain header right edge and search bar width on desktop */
+/* Constrain header right edge on desktop */
 @media screen and (min-width: 60em) {
   .md-header__inner {
     padding-right: 5rem;
-  }
-  .md-search__form {
-    max-width: 12rem;
   }
 }
 
@@ -456,21 +453,6 @@ nav.md-nav--primary .md-nav__item--section>.md-nav__link {
 
 [data-md-color-scheme="slate"] .md-header svg,
 [data-md-color-scheme="slate"] .md-header path {
-  fill: var(--md-default-fg-color);
-}
-
-[data-md-color-scheme="slate"] .md-search__input {
-  color: var(--md-default-fg-color);
-  background-color: var(--md-default-bg-color);
-  border-color: var(--md-default-fg-color--light);
-}
-
-[data-md-color-scheme="slate"] .md-search__input::placeholder {
-  color: var(--md-default-fg-color--light);
-}
-
-[data-md-color-scheme="slate"] .md-search__icon svg,
-[data-md-color-scheme="slate"] .md-search__icon path {
   fill: var(--md-default-fg-color);
 }
 

--- a/docs/stylesheets/search.css
+++ b/docs/stylesheets/search.css
@@ -1,0 +1,285 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Search modal.
+ *
+ * Everything here reads Material's own custom properties, so the palette
+ * toggle is handled by ordinary cascade. Material declares its light palette
+ * at :root and its dark palette on [data-md-color-scheme] on <body>, and
+ * these elements live in the normal document, so both resolve correctly with
+ * no JavaScript and no variable bridging.
+ */
+
+/* Trigger ---------------------------------------------------------------- */
+
+/*
+ * Qualified with .md-header__button for specificity, not for scoping.
+ *
+ * Material declares `.md-header__button:not([hidden]) { display: inline-block }`.
+ * :not() takes the specificity of its argument, so that is 0-2-0 and a bare
+ * `.adk-search__trigger` at 0-1-0 loses to it no matter what the source
+ * order is. The button then blockifies and align-items, gap and the
+ * `margin-left: auto` on the key hint all go inert, stacking the icon, label
+ * and shortcut into three rows that overflow the header. This selector is
+ * also 0-2-0 and wins on source order, since search.css is loaded after
+ * Material's stylesheet.
+ *
+ * padding is here for the same reason -- Material sets `padding: .4rem` on
+ * .md-header__button -- and the rest ride along so the whole trigger is
+ * declared at one specificity rather than several.
+ */
+.md-header__button.adk-search__trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  width: auto;
+  padding: 0 0.5rem;
+  border-radius: 0.2rem;
+  cursor: pointer;
+}
+
+.adk-search__trigger svg {
+  width: 1.2rem;
+  height: 1.2rem;
+  fill: currentcolor;
+  flex-shrink: 0;
+}
+
+.adk-search__trigger-label,
+.adk-search__trigger-keys {
+  display: none;
+}
+
+/*
+ * 60em is where Material's own search control changes shape, not 76.25em,
+ * which is where the sidebar appears. This trigger replaces Material's
+ * search outright, so tracking the search breakpoint is the coherent choice.
+ */
+@media screen and (min-width: 60em) {
+  .md-header__button.adk-search__trigger {
+    background-color: var(--md-default-bg-color);
+    border: 1px solid var(--md-default-fg-color--lightest);
+    min-width: 11rem;
+    height: 1.8rem;
+  }
+
+  .adk-search__trigger-label {
+    display: block;
+    font-size: 0.7rem;
+    color: var(--md-default-fg-color--light);
+  }
+
+  .adk-search__trigger-keys {
+    display: flex;
+    gap: 0.15rem;
+    margin-left: auto;
+  }
+
+  .adk-search__trigger-keys kbd {
+    background-color: var(--md-default-fg-color--lightest);
+    border-radius: 0.15rem;
+    color: var(--md-default-fg-color--light);
+    font-size: 0.6rem;
+    padding: 0.05rem 0.25rem;
+  }
+}
+
+/* Dialog ----------------------------------------------------------------- */
+
+.adk-search {
+  border: none;
+  background: transparent;
+  padding: 0;
+  width: min(46rem, 92vw);
+  margin-top: 4rem;
+  color: var(--md-typeset-color);
+}
+
+.adk-search::backdrop {
+  background-color: rgb(0 0 0 / 55%);
+}
+
+/*
+ * The panel owns the height cap; the dialog shrink-wraps it. Capping both
+ * was redundant, and capping only the dialog would let the panel overflow
+ * it, since the dialog does not establish a scroll container.
+ */
+.adk-search__panel {
+  display: flex;
+  flex-direction: column;
+  max-height: 80vh;
+  background-color: var(--md-default-bg-color);
+  border-radius: 0.3rem;
+  box-shadow: 0 0.2rem 1rem rgb(0 0 0 / 25%);
+  overflow: hidden;
+}
+
+/* Input ------------------------------------------------------------------ */
+
+.adk-search__field {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+}
+
+/*
+ * The input suppresses its own outline so the borderless field does not get
+ * a ring floating inside it, so the focus indicator has to live on the
+ * wrapper instead. Without this the modal's primary control has no visible
+ * focus state at all.
+ */
+.adk-search__field:focus-within {
+  border-bottom-color: var(--md-accent-fg-color);
+  box-shadow: inset 0 -1px 0 var(--md-accent-fg-color);
+}
+
+.adk-search__field svg {
+  width: 1.1rem;
+  height: 1.1rem;
+  fill: var(--md-default-fg-color--light);
+  flex-shrink: 0;
+}
+
+.adk-search__input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--md-typeset-color);
+  font-size: 0.85rem;
+  font-family: inherit;
+}
+
+.adk-search__input::-webkit-search-cancel-button {
+  display: none;
+}
+
+.adk-search__close {
+  background-color: var(--md-default-fg-color--lightest);
+  border: none;
+  border-radius: 0.15rem;
+  color: var(--md-default-fg-color--light);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.6rem;
+  padding: 0.15rem 0.35rem;
+}
+
+/* Results ---------------------------------------------------------------- */
+
+.adk-search__status {
+  color: var(--md-default-fg-color--light);
+  font-size: 0.75rem;
+  padding: 0 0.8rem;
+}
+
+.adk-search__status:not(:empty) {
+  padding: 0.8rem;
+}
+
+.adk-search__results {
+  list-style: none;
+  margin: 0;
+  overflow-y: auto;
+  padding: 0.4rem;
+}
+
+.adk-search__page + .adk-search__page {
+  margin-top: 0.3rem;
+}
+
+.adk-search__page-link {
+  display: block;
+  border-radius: 0.2rem;
+  color: var(--md-typeset-color);
+  font-size: 0.78rem;
+  font-weight: 700;
+  padding: 0.4rem 0.5rem;
+  text-decoration: none;
+}
+
+.adk-search__sections {
+  list-style: none;
+  margin: 0 0 0 0.5rem;
+  padding: 0 0 0 0.5rem;
+  border-left: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.adk-search__section-link {
+  display: block;
+  border-radius: 0.2rem;
+  color: var(--md-typeset-color);
+  padding: 0.35rem 0.5rem;
+  text-decoration: none;
+}
+
+.adk-search__section-title {
+  display: block;
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.adk-search__excerpt {
+  color: var(--md-default-fg-color--light);
+  font-size: 0.68rem;
+  line-height: 1.5;
+  margin: 0.1rem 0 0;
+}
+
+.adk-search__excerpt mark {
+  background: transparent;
+  color: var(--md-accent-fg-color);
+  font-weight: 700;
+}
+
+.adk-search__page-link:hover,
+.adk-search__section-link:hover,
+.adk-search__link--active {
+  background-color: var(--md-default-fg-color--lightest);
+}
+
+.adk-search__link--active {
+  outline: 2px solid var(--md-accent-fg-color);
+  outline-offset: -2px;
+}
+
+/* Arrival highlighting --------------------------------------------------- */
+
+/*
+ * Terms marked in the page after arriving from a search result.
+ *
+ * This rule is deliberately a no-op today, kept as documentation rather than
+ * as the thing doing the work. Be honest about why:
+ *
+ * mark.js wraps matches in a bare <mark>, and markContext points at
+ * article.md-content__inner, which is .md-typeset. Material's own
+ * `.md-typeset mark` therefore already applies and already resolves to this
+ * exact token, so deleting this rule would change nothing on screen. The
+ * yellow is not prevented by us either -- Pagefind's injected
+ * `:where(.pagefind-highlight)` is specificity 0-0-0 and was losing anyway.
+ *
+ * It stays for two reasons. It states the intended colour at the point
+ * someone will look for it, so a future change to markOptions.element or to
+ * markContext does not silently drop palette awareness. And at 0-2-0 it
+ * outranks `.md-typeset mark`, so if the wrapper element ever stops being
+ * <mark> this keeps working rather than needing to be discovered.
+ */
+.md-typeset .pagefind-highlight {
+  background-color: var(--md-typeset-mark-color);
+}

--- a/hooks/pagefind_index.py
+++ b/hooks/pagefind_index.py
@@ -18,9 +18,8 @@ Pagefind is a static search engine: it crawls the *rendered* HTML in
 ``site_dir`` and emits a sharded index plus a WASM query engine into
 ``site/pagefind/``. The browser fetches only the shards a query touches,
 instead of the single multi-megabyte JSON index the built-in lunr-based
-``search`` plugin produces. That plugin is still enabled at this commit, so
-the site currently ships both indexes; ``search`` is removed later in this
-series, once the Pagefind-backed UI is in place.
+``search`` plugin produced. That plugin is disabled in ``mkdocs.yml``; Pagefind
+is the only search index the site ships.
 
 Which pages get indexed is controlled by the ``data-pagefind-body`` attribute
 on the ``<article>`` element, set in ``overrides/main.html``. Once that

--- a/hooks/pagefind_index.py
+++ b/hooks/pagefind_index.py
@@ -1,0 +1,246 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Builds the Pagefind search index as a MkDocs post-build step.
+
+Pagefind is a static search engine: it crawls the *rendered* HTML in
+``site_dir`` and emits a sharded index plus a WASM query engine into
+``site/pagefind/``. The browser fetches only the shards a query touches,
+instead of the single multi-megabyte JSON index the built-in lunr-based
+``search`` plugin produces. That plugin is still enabled at this commit, so
+the site currently ships both indexes; ``search`` is removed later in this
+series, once the Pagefind-backed UI is in place.
+
+Which pages get indexed is controlled by the ``data-pagefind-body`` attribute
+on the ``<article>`` element, set in ``overrides/main.html``. Once that
+attribute exists anywhere on the site, Pagefind indexes *only* pages carrying
+it, which keeps the generated API reference output out of the index.
+
+Set ``PAGEFIND_SKIP`` to any value other than ``0``, ``false``, ``no`` or
+``off`` to skip indexing. This is for ``mkdocs serve`` authoring loops; search
+is non-functional while it is set, so skipping logs a warning and therefore
+fails a ``--strict`` build.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.exceptions import PluginError
+from mkdocs.plugins import event_priority
+from mkdocs.plugins import get_plugin_logger
+
+log = get_plugin_logger(__name__)
+
+BODY_ATTRIBUTE = b"data-pagefind-body"
+
+# Pagefind concatenates adjacent inline elements without a separator, so
+# sibling elements authored without whitespace fuse into a single token.
+# Three constructs on this site hit that:
+#   .headerlink           the "&para;" permalink anchor, fusing into headings
+#   .tabbed-labels        <label>Python</label><label>Java</label> from
+#                         pymdownx.tabbed, indexed as "PythonJava"
+#   .language-support-tag the "Supported in ADK" badge, which produced
+#                         "ADKPythonTypeScriptGoJava"
+# Measured on the 2026-08-07 content set, over a 226-page control build with
+# no exclude selectors: removing them drops fused tokens from 219 across 193
+# of the 226 indexed pages to zero. Tab *contents* stay indexed, so
+# per-language content remains searchable.
+#
+# Each selector is paired with the substring that proves it is still rendered
+# somewhere on the site. A selector that matches nothing is valid CSS and
+# fails silently -- the build stays green while the fused tokens come back --
+# so the marker counts are asserted on every build. Pairing them here means a
+# selector cannot be added without a liveness check.
+#
+# Those counts are taken over indexed pages ONLY (see _count_markers), and that
+# scoping is load-bearing, not an optimisation. site/api-reference/python/ is
+# Sphinx/Furo output from a pipeline decoupled from mkdocs-material, and Furo
+# also emits class="headerlink" -- google-adk.html alone has 1372 occurrences.
+# Counting site-wide would pin that marker above zero forever, so the tripwire
+# could never fire for the exact case it exists for: mkdocs-material renaming
+# the class. Verified: with site-wide counting, a simulated rename across all
+# theme-rendered pages still left headerlink at 3 and the check stayed silent.
+#
+# One caveat on .tabbed-labels: 234 pages match the substring but only 119
+# contain a real element, because material's inlined JS bundle mentions
+# ".tabbed-labels" on every page. It still detects a material rename (the
+# bundle changes too), but it is really measuring "the bundle is present" and
+# would not notice pymdownx.tabbed being dropped from mkdocs.yml.
+SELECTOR_MARKERS: dict[str, bytes] = {
+    ".headerlink": b"headerlink",
+    ".tabbed-labels": b"tabbed-labels",
+    ".language-support-tag": b"language-support-tag",
+}
+
+# Two selectors sharing a marker would collapse into one count, and both would
+# then be checked by whichever is live -- the one way to add a selector that
+# skips its own liveness check. A hard raise rather than an `assert`, because
+# `assert` is stripped under `python -O` and a guard that vanishes under an
+# interpreter flag is worse than no guard at all.
+if len(set(SELECTOR_MARKERS.values())) != len(SELECTOR_MARKERS):
+    raise ValueError(
+        "each selector needs its own marker; a shared one is not an "
+        "independent check"
+    )
+
+# ".headerlink, .tabbed-labels, .language-support-tag"
+EXCLUDE_SELECTORS = ", ".join(SELECTOR_MARKERS)
+
+# Keep dotted and prefixed identifiers intact. Without this,
+# "google.adk.agents" degrades into three unrelated words.
+INCLUDE_CHARACTERS = ".-@#+"
+
+# Indexing this site takes ~4s. The ceiling only exists so that a wedged
+# Pagefind fails the build instead of burning the CI job's 6-hour limit.
+TIMEOUT_SECONDS = 600
+
+# Values of PAGEFIND_SKIP that mean "do not skip". Presence alone is not
+# enough: PAGEFIND_SKIP=0 in a CI matrix must not silently ship dead search.
+_SKIP_DISABLED = {"", "0", "false", "no", "off"}
+
+
+def _count_markers(site_dir: Path) -> dict[bytes, int]:
+    """Count how many built HTML files contain each marker, in one pass.
+
+    Returns a mapping from each marker to the number of files containing it.
+    Everything is counted in a single traversal because the traversal, not the
+    substring search, is what costs anything.
+
+    ``BODY_ATTRIBUTE`` is counted across every built page; the selector markers
+    are counted only on the pages carrying it. A page Pagefind does not index
+    cannot contribute a fused token to the index, so its markup says nothing
+    about whether a selector is still doing its job -- and the generated API
+    reference is large enough to hold a marker above zero on its own.
+    """
+    selector_markers = tuple(SELECTOR_MARKERS.values())
+    counts = dict.fromkeys((BODY_ATTRIBUTE, *selector_markers), 0)
+    for path in site_dir.rglob("*.html"):
+        try:
+            html = path.read_bytes()
+        except OSError as exc:  # pragma: no cover - unreadable file
+            log.warning("Could not read %s: %s", path, exc)
+            continue
+        if BODY_ATTRIBUTE not in html:
+            continue
+        counts[BODY_ATTRIBUTE] += 1
+        for marker in selector_markers:
+            if marker in html:
+                counts[marker] += 1
+    return counts
+
+
+def _reported_page_count(site_dir: Path) -> int:
+    """Return the page count Pagefind recorded in its entry file."""
+    entry = site_dir / "pagefind" / "pagefind-entry.json"
+    if not entry.is_file():
+        raise PluginError(f"Pagefind wrote no entry file at {entry}.")
+    data = json.loads(entry.read_text(encoding="utf-8"))
+    return sum(lang["page_count"] for lang in data["languages"].values())
+
+
+def _check_selectors_still_match(marker_counts: dict[bytes, int]) -> None:
+    """Fail if any exclude selector no longer matches any indexed page."""
+    for selector, marker in SELECTOR_MARKERS.items():
+        if marker_counts[marker] == 0:
+            raise PluginError(
+                f"The exclude selector {selector!r} matches no indexed page, so "
+                "it is no longer suppressing anything and adjacent inline "
+                "elements will fuse into single tokens in the search index. "
+                "Either the theme renamed the class, in which case update "
+                "EXCLUDE_SELECTORS in this hook to the new name, or the "
+                "construct has genuinely been removed from the site, in which "
+                "case drop it from EXCLUDE_SELECTORS. Do not leave it as a "
+                "selector that matches nothing: that is silently ineffective."
+            )
+
+
+@event_priority(-100)
+def on_post_build(config: MkDocsConfig, **kwargs: Any) -> None:
+    """Run Pagefind over the built site and verify the index scope.
+
+    Runs at the lowest priority so that it sees the final contents of
+    ``site_dir``. Anything emitting indexable HTML from its own
+    ``on_post_build`` must run before this, or its pages are both unindexed
+    and uncounted, which would leave the assertions below green.
+    """
+    if os.environ.get("PAGEFIND_SKIP", "").strip().lower() not in _SKIP_DISABLED:
+        log.warning(
+            "PAGEFIND_SKIP is set - skipping the Pagefind index build. "
+            "Site search will not work in this build."
+        )
+        return
+
+    site_dir = Path(config.site_dir)
+    marker_counts = _count_markers(site_dir)
+
+    expected = marker_counts[BODY_ATTRIBUTE]
+    if expected == 0:
+        raise PluginError(
+            f"No file in {site_dir} carries {BODY_ATTRIBUTE.decode()}. The "
+            "container block in overrides/main.html has probably stopped "
+            "matching the theme, and search would be built empty."
+        )
+    _check_selectors_still_match(marker_counts)
+
+    command = [
+        sys.executable,
+        "-m",
+        "pagefind",
+        "--site",
+        str(site_dir),
+        "--exclude-selectors",
+        EXCLUDE_SELECTORS,
+        "--include-characters",
+        INCLUDE_CHARACTERS,
+        "--quiet",
+    ]
+    try:
+        result = subprocess.run(
+            command, capture_output=True, text=True, timeout=TIMEOUT_SECONDS
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise PluginError(
+            f"Pagefind did not finish within {TIMEOUT_SECONDS}s and was "
+            "killed. The index in site/pagefind/ is incomplete."
+        ) from exc
+    if result.returncode != 0:
+        raise PluginError(
+            "Pagefind indexing failed with exit code "
+            f"{result.returncode}:\n{result.stdout}\n{result.stderr}"
+        )
+
+    # Pagefind writes non-fatal diagnostics to stderr while still exiting 0,
+    # even under --quiet. Keep this at info, NOT warning: the site's standing
+    # notices ("N pages found without an <html> element") come from generated
+    # API-reference files we do not control, and CI builds with --strict,
+    # which turns any warning into a hard failure.
+    if result.stderr.strip():
+        log.info("Pagefind reported:\n%s", result.stderr.strip())
+
+    reported = _reported_page_count(site_dir)
+    if reported != expected:
+        raise PluginError(
+            f"Pagefind indexed {reported} pages but {expected} files carry "
+            f"{BODY_ATTRIBUTE.decode()}. The index scope is not what the "
+            "templates describe."
+        )
+
+    log.info("Pagefind indexed %d pages.", reported)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -273,6 +273,13 @@ plugins:
         Community:
         - community/*.md
 
+# Hooks
+# Registered after every plugin above, and runs last in `on_post_build`.
+hooks:
+  # Builds the Pagefind search index from the rendered HTML after each build.
+  # Set PAGEFIND_SKIP=1 to skip it while authoring; search is then dead.
+  - hooks/pagefind_index.py
+
 # Navigation
 nav:
   - Home: index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ validation:
 extra_css:
   - stylesheets/custom.css
   - stylesheets/language-tags.css
+  - stylesheets/search.css
 
 # Custom JavaScript
 extra_javascript:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,7 +118,8 @@ markdown_extensions:
 
 # Plugins
 plugins:
-  - search
+  # NOTE: the built-in `search` plugin (lunr.js) is intentionally not enabled.
+  # Search is served by Pagefind - see hooks/pagefind_index.py.
   - macros:
       module_name: scripts/integrations
       # Set custom delimiters for J2 templates to avoid conflicts with Markdown

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ extra_css:
 # Custom JavaScript
 extra_javascript:
   - javascript/copy-page.js
+  - javascript/search.js
 
 # Additional config
 extra:

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -37,6 +37,41 @@
   <meta name="twitter:image" content="https://adk.dev/assets/adk-social-card.png">
 {% endblock %}
 
+<!--
+  Mirrors the `container` block from mkdocs-material 9.7.0's base.html,
+  adding `data-pagefind-body` to the article. Nothing else here departs from
+  upstream on purpose: when bumping mkdocs-material, diff this block against
+  site-packages/material/templates/base.html and expect exactly one
+  substantive difference; ignore indentation (`diff -b`), because this copy
+  sits at a different nesting depth than upstream's. Nothing in the build
+  detects drift.
+
+  Pagefind indexes only pages carrying that attribute, and within them only
+  the subtree it is attached to, so the header, navigation, table of contents
+  and footer stay out of the index.
+  The pre-generated API reference under docs/api-reference/ (python/,
+  typescript/, java/, ...) is copied verbatim by MkDocs rather than rendered
+  through this template, so it never receives the attribute and is not
+  indexed. The hand-written api-reference/index.md is a normal page and is
+  indexed, as it was under the previous lunr-based search.
+
+  The attribute is conditional on `page`. MkDocs renders theme templates such
+  as 404.html without a page in the context, and an unconditional attribute
+  would index the 404 page as a search result.
+-->
+{% block container %}
+  <div class="md-content" data-md-component="content">
+    {% if "navigation.path" in features %}
+      {% include "partials/path.html" %}
+    {% endif %}
+    <article class="md-content__inner md-typeset"{% if page %} data-pagefind-body{% endif %}>
+      {% block content %}
+        {% include "partials/content.html" %}
+      {% endblock %}
+    </article>
+  </div>
+{% endblock %}
+
 <!-- top of page announcement banner here: -->
 <!--
 <span class="announce-item">

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -120,8 +120,48 @@
     >
       {% include ".icons/material/magnify.svg" %}
       <span class="adk-search__trigger-label">{{ lang.t('search') }}</span>
-      <kbd class="adk-search__trigger-keys"><kbd>Ctrl</kbd><kbd>K</kbd></kbd>
+      {#-
+        Nested <kbd> is the spec's markup for a key combination: the outer
+        element is the chord, the inner ones are the individual keys. The
+        script below relies on that nesting to find the modifier, so keep
+        `Ctrl` as the first inner <kbd>.
+
+        Rendered hidden on purpose - see the script.
+      -#}
+      <kbd class="adk-search__trigger-keys" style="display: none"><kbd>Ctrl</kbd><kbd>K</kbd></kbd>
     </button>
+    {#-
+      Relabel the shortcut on Apple platforms, where the handler in
+      search.js already accepts Meta as well as Control.
+
+      Inline and immediately after the button on purpose. The hint is
+      server-rendered as `Ctrl` so the HTML stays identical for every
+      visitor and fully cacheable, then corrected here during parse. Doing
+      it from search.js instead would be too late: that file is a plain
+      <script src> at the end of <body>, and it was measured finishing 6ms
+      *after* first paint on a throttled connection, so Mac readers would
+      see `Ctrl` repaint to `Cmd`. Clearing the inline `display` rather
+      than toggling a class hands responsive control back to the
+      stylesheet, which keeps the hint hidden below 60em.
+
+      With JavaScript off the hint stays hidden, which is correct: the
+      shortcut it advertises would not work either.
+    -#}
+    <script>
+      (() => {
+        const button = document.querySelector("[data-adk-search-trigger]");
+        const chord = button?.querySelector("kbd");
+        if (!chord) return;
+        const modifier = chord.querySelector("kbd");
+        // navigator.platform is deprecated and frozen, but it is the only
+        // option that works in Safari and Firefox - i.e. on most actual Macs.
+        if (modifier && /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform)) {
+          modifier.textContent = "\u2318";
+          button.setAttribute("aria-keyshortcuts", "Meta+K");
+        }
+        chord.style.display = "";
+      })();
+    </script>
   </nav>
 
   <!-- Navigation tabs (sticky) -->

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -122,22 +122,6 @@
       <span class="adk-search__trigger-label">{{ lang.t('search') }}</span>
       <kbd class="adk-search__trigger-keys"><kbd>Ctrl</kbd><kbd>K</kbd></kbd>
     </button>
-
-    <!-- Button to open search modal -->
-    {% if "material/search" in config.plugins %}
-      {% set search = config.plugins["material/search"] | attr("config") %}
-
-      <!-- Check if search is actually enabled - see https://t.ly/DT_0V -->
-      {% if search.enabled %}
-        <label class="md-header__button md-icon" for="__search">
-          {% set icon = config.theme.icon.search or "material/magnify" %}
-          {% include ".icons/" ~ icon ~ ".svg" %}
-        </label>
-
-        <!-- Search interface -->
-        {% include "partials/search.html" %}
-      {% endif %}
-    {% endif %}
   </nav>
 
   <!-- Navigation tabs (sticky) -->

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -96,6 +96,33 @@
       {% include "partials/alternate.html" %}
     {% endif %}
 
+    {#-
+      Pagefind search trigger.
+
+      The dialog this opens is deliberately not here. It is included after
+      the closing </header> below, because custom.css repaints every
+      descendant of .md-header in dark mode via a blanket
+      `[data-md-color-scheme="slate"] .md-header *` rule, which flattened the
+      dialog's colours. See partials/search-modal.html for the full
+      reasoning before moving either piece.
+
+      This button is a header control and is meant to follow header colours,
+      so it stays inside the header and is inlined here, mirroring how
+      Material pairs its own .md-header__button with a separate
+      partials/search.html include.
+    -#}
+    <button
+      type="button"
+      class="md-header__button md-icon adk-search__trigger"
+      data-adk-search-trigger
+      aria-label="{{ lang.t('search') }}"
+      aria-keyshortcuts="Control+K"
+    >
+      {% include ".icons/material/magnify.svg" %}
+      <span class="adk-search__trigger-label">{{ lang.t('search') }}</span>
+      <kbd class="adk-search__trigger-keys"><kbd>Ctrl</kbd><kbd>K</kbd></kbd>
+    </button>
+
     <!-- Button to open search modal -->
     {% if "material/search" in config.plugins %}
       {% set search = config.plugins["material/search"] | attr("config") %}
@@ -120,3 +147,17 @@
     {% endif %}
   {% endif %}
 </header>
+
+{#-
+  Pagefind search dialog, outside <header> on purpose.
+
+  base.html renders this block immediately before
+  <div class="md-container" data-md-component="container">, so the dialog
+  lands as a sibling of both .md-header and .md-container. That puts it out
+  of reach of custom.css's `[data-md-color-scheme="slate"] .md-header *`
+  colour override while keeping it outside every element instant navigation
+  replaces, so it stays mounted with its listeners intact.
+
+  See partials/search-modal.html before relocating this.
+-#}
+{% include "partials/search-modal.html" %}

--- a/overrides/partials/search-modal.html
+++ b/overrides/partials/search-modal.html
@@ -1,0 +1,105 @@
+{#-
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-#}
+{#-
+  The search dialog, backed by Pagefind.
+
+  The trigger button that opens this dialog is NOT here. It is inlined in
+  partials/header.html, which includes this partial separately, after the
+  closing </header>. Two constraints pull in opposite directions and only
+  that split satisfies both.
+
+  1. The dialog must not be a descendant of .md-header.
+
+     docs/stylesheets/custom.css declares, for the slate scheme:
+
+         [data-md-color-scheme="slate"] .md-header,
+         [data-md-color-scheme="slate"] .md-header * { color: ...; }
+
+     That blanket descendant selector is specificity 0-2-0 and repaints
+     every element inside the header in dark mode. With the dialog inside
+     the header it beat our own 0-1-1 rules and flattened the excerpt text,
+     the section links and the <mark> accent on matched terms. The rule is
+     load-bearing for the real header, so the dialog moves out from under it
+     rather than being fought with higher-specificity overrides.
+
+  2. The dialog must stay outside the seven elements Material's instant
+     navigation replaces: announce, container, header-topic, outdated, logo,
+     skip and tabs. Anything inside those is destroyed on client-side
+     navigation, taking its event listeners with it.
+
+  base.html renders the header block immediately before
+  <div class="md-container" data-md-component="container">, so including
+  this partial after the closing </header> makes the dialog a sibling of
+  both: outside .md-header, and outside every replaced element.
+
+  Do not move this back inside the header. It satisfies constraint 2 there
+  but reintroduces the dark-mode bug from constraint 1.
+
+  data-pagefind-bundle is resolved to an absolute URL by search.js at initial
+  page load, before any instant navigation can change the document location.
+-#}
+<dialog
+  class="adk-search"
+  data-adk-search-dialog
+  data-pagefind-bundle="{{ 'pagefind/' | url }}"
+  aria-label="{{ lang.t('search') }}"
+>
+  <div class="adk-search__panel">
+    <div class="adk-search__field">
+      {% include ".icons/material/magnify.svg" %}
+      {#-
+        The combobox half of an ARIA combobox/listbox pair. Focus stays in
+        this input for the whole interaction; arrow keys move a virtual
+        cursor expressed as aria-activedescendant rather than moving real
+        focus, so typing keeps working without the input having to forward
+        printable keys back to itself.
+
+        search.js keeps aria-expanded and aria-activedescendant in sync, and
+        owns the role="option" / aria-selected / id attributes on the result
+        links inside the listbox below.
+      -#}
+      <input
+        type="search"
+        class="adk-search__input"
+        data-adk-search-input
+        placeholder="{{ lang.t('search.placeholder') }}"
+        aria-label="{{ lang.t('search.placeholder') }}"
+        role="combobox"
+        aria-expanded="false"
+        aria-controls="adk-search-listbox"
+        aria-autocomplete="list"
+        autocomplete="off"
+        autocorrect="off"
+        autocapitalize="off"
+        spellcheck="false"
+      >
+      <button
+        type="button"
+        class="adk-search__close"
+        data-adk-search-close
+        aria-label="Close search"
+      >Esc</button>
+    </div>
+    <div class="adk-search__status" data-adk-search-status role="status" aria-live="polite"></div>
+    <ul
+      class="adk-search__results"
+      data-adk-search-results
+      id="adk-search-listbox"
+      role="listbox"
+      aria-label="{{ lang.t('search') }}"
+    ></ul>
+  </div>
+</dialog>

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ mkdocs-linkcheck==1.0.6
 mkdocs-llmstxt==0.5.0
 mkdocs-macros-plugin==1.4.1
 click==8.2.1
+pagefind[bin]==1.5.2
+# The binary, not the wrapper, produces the index format, pagefind.js and the
+# CLI surface. `pagefind[bin]` only constrains it to <2, so pin it directly.
+pagefind-bin==1.5.2

--- a/scripts/verify_search_index.py
+++ b/scripts/verify_search_index.py
@@ -1,0 +1,329 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verifies the quality and scope of the built Pagefind index.
+
+Run against a built site:
+
+    python scripts/verify_search_index.py site
+
+Three invariants are checked.
+
+1. Scope, under-broad: the page count Pagefind recorded matches the number of
+   built HTML files carrying ``data-pagefind-body``. This catches Pagefind
+   silently dropping pages it was told to index -- an unparseable page, a
+   crawler that stopped following part of the tree after an upgrade.
+
+2. Scope, over-broad: no page that must never be searchable appears in the
+   index. ``data-pagefind-body`` is applied in ``overrides/main.html`` inside
+   an ``{% if page %}`` guard precisely so that ``404.html`` is excluded, and
+   check 1 cannot see that guard fail (see ``check_scope``).
+
+3. Tokenization: no fused language token survives. Pagefind concatenates
+   adjacent inline elements without a separator, so the language badge and
+   the tab label strip previously produced tokens such as ``ADKPython`` and
+   ``PythonTypeScriptGoJava`` -- 219 of them across 193 of the 226 indexed
+   pages, measured on the 2026-08-07 content set. Genuine identifiers that
+   contain a language name, such as ``RxJava``, must not be flagged, so the
+   pattern matches only runs of two or more language names spliced together.
+
+``hooks/pagefind_index.py`` asserts invariant 1 at build time and additionally
+guards the exclude selectors against a silent theme rename. This script is
+deliberately standalone and re-derives everything from the built output, so it
+can be pointed at a site directory that some other machine built -- a CI
+artefact, a release tarball, a colleague's `site/` -- where the hook's
+build-time assertions are no longer observable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import re
+import sys
+from pathlib import Path
+
+# Two or more of these spliced directly together is always a fusion artefact,
+# never a real identifier. "RxJava" and "pdfArtifactJava" contain a single
+# language name and are correctly ignored.
+#
+# CONTRACT: any language that can appear in a language-support badge or a
+# pymdownx.tabbed label strip must be listed in this alternation. A language
+# added to the site but not added here is invisible to this check, and nothing
+# else will notice -- there is no liveness tripwire for the alternation itself
+# the way SELECTOR_MARKERS in hooks/pagefind_index.py has one for the
+# selectors.
+#
+# The leading \b is deliberate: fusion into a preceding word character, as in
+# "SetupPythonJava", is knowingly out of scope. Requiring the run to start at
+# a word boundary is what keeps "RxJava" and "pdfArtifactJava" unflagged, and
+# the two cannot both be had from one pattern. Measured on the 2026-08-07
+# content set: across all 226 control fragments, zero fused runs began
+# mid-word, so the exemption costs nothing today.
+FUSED_TOKEN = re.compile(r"\b(?:ADK|Python|TypeScript|Go|Java|Kotlin){2,}[A-Za-z.0-9]*")
+
+# Local-only pages. `docs/superpowers/` is listed in .gitignore, so these
+# exist in a developer build and never in CI. The design document itself
+# quotes fused tokens as literal prose describing the defect.
+#
+# The exemption is unconditional and path-based, not content-based: anything
+# that ever lands under this prefix is silently exempt from the tokenization
+# check. That is only safe while the prefix stays git-ignored scratch space.
+# If real documentation is ever published there, narrow this to the specific
+# design documents or drop it.
+LOCAL_ONLY_PREFIX = "/superpowers/"
+
+# URL prefixes that must never appear in the index, whatever the templates do.
+#
+# /404.html is the case the {% if page %} guard in overrides/main.html exists
+# for. The rest is generated API-reference output -- Sphinx/Furo for Python,
+# Dokka for Kotlin, and so on -- from pipelines decoupled from mkdocs-material;
+# it is enormous, differently themed, and would swamp real results.
+#
+# These are language-specific on purpose. The bare prefix "/api-reference/"
+# would match "/api-reference/", the hand-written landing page, which IS
+# legitimately indexed. Verified against the 2026-08-07 build: "/api-reference/"
+# is the only indexed URL under that tree.
+#
+# All seven generated subtrees are listed, not just the four large ones.
+# agentconfig/, cli/ and rest/ are one to three files each and are equally
+# not indexed today; barring them costs nothing and means a future template
+# change cannot quietly pull them in.
+NEVER_INDEXED = (
+    "/404.html",
+    "/api-reference/agentconfig/",
+    "/api-reference/cli/",
+    "/api-reference/java/",
+    "/api-reference/kotlin/",
+    "/api-reference/python/",
+    "/api-reference/rest/",
+    "/api-reference/typescript/",
+)
+
+# Pagefind prefixes each gzip-compressed fragment payload with this marker.
+# The compression is applied over the marker too, so the file has to be
+# decompressed before the marker can be found.
+FRAGMENT_MARKER = b"pagefind_dcd"
+
+# Fragment keys this script reads. Absence means the fragment schema changed
+# under a Pagefind upgrade, which must be a loud failure: every check below
+# reads these keys, and a checker that silently reads nothing reports green on
+# a broken index.
+REQUIRED_FRAGMENT_KEYS = ("url", "content")
+
+
+def _load_fragments(site: Path) -> list[dict]:
+    """Return the decoded JSON of every Pagefind fragment.
+
+    Raises ``ValueError`` if a fragment is not in the expected format, rather
+    than skipping it. ``requirements.txt`` pins ``pagefind-bin==1.5.2`` -- the
+    binary, which is what produces the fragment format, and which the
+    ``pagefind[bin]`` extra alone would only constrain to <2 -- so the format
+    is fixed until someone bumps it, and the bump is exactly when this needs
+    to fail loudly instead of quietly scanning nothing.
+    """
+    fragments = []
+    for path in sorted((site / "pagefind" / "fragment").glob("*.pf_fragment")):
+        raw = gzip.decompress(path.read_bytes())
+        marker = raw.find(FRAGMENT_MARKER)
+        if marker == -1:
+            raise ValueError(
+                f"{path.name} is not a Pagefind fragment: no "
+                f"{FRAGMENT_MARKER.decode()} marker in the decompressed bytes"
+            )
+        fragment = json.loads(raw[raw.index(b"{", marker) :].decode("utf-8"))
+        missing = [key for key in REQUIRED_FRAGMENT_KEYS if key not in fragment]
+        if missing:
+            raise ValueError(
+                f"{path.name} has no {missing} key; the fragment schema has "
+                f"changed and it now carries {sorted(fragment)}. Update "
+                "REQUIRED_FRAGMENT_KEYS and the checks that read them"
+            )
+        fragments.append(fragment)
+    return fragments
+
+
+def _reported_page_count(site: Path) -> int:
+    """Return the page count Pagefind recorded in its entry file.
+
+    Raises ``ValueError`` if the entry file is malformed or its schema has
+    changed, so that a Pagefind upgrade surfaces as a finding rather than a
+    bare traceback -- the same contract as ``_load_fragments``.
+    """
+    path = site / "pagefind" / "pagefind-entry.json"
+    try:
+        entry = json.loads(path.read_text(encoding="utf-8"))
+        return sum(lang["page_count"] for lang in entry["languages"].values())
+    except (json.JSONDecodeError, KeyError, TypeError, AttributeError) as exc:
+        raise ValueError(
+            f"{path} is not the schema this script expects "
+            f"({type(exc).__name__}: {exc}); Pagefind's entry file format has "
+            "probably changed"
+        ) from exc
+
+
+def check_scope(site: Path, indexed: int) -> list[str]:
+    """Fail if Pagefind indexed fewer pages than were marked for indexing.
+
+    This mirrors the scope assertion in ``hooks/pagefind_index.py``; the two
+    must be kept in sync. The duplication is deliberate -- importing the hook
+    would drag ``mkdocs.*`` into a script that otherwise needs only the
+    standard library, and the point of this script is to run against a built
+    site without the toolchain that built it.
+
+    Note what this can and cannot catch. Pagefind indexes *exactly* the pages
+    carrying ``data-pagefind-body``, so ``indexed`` and ``attribute_count`` are
+    two measurements of the same cause and normally move together. The
+    equality therefore only fires in one direction: Pagefind dropping a page
+    it was told to index. It does NOT catch the attribute leaking onto a page
+    that should never be searchable -- both numbers rise together and the
+    check stays green. ``check_never_indexed`` owns that direction.
+    """
+    attribute_count = sum(
+        1 for p in site.rglob("*.html") if b"data-pagefind-body" in p.read_bytes()
+    )
+    if indexed != attribute_count:
+        return [
+            f"index scope: Pagefind indexed {indexed} pages but "
+            f"{attribute_count} HTML files carry data-pagefind-body"
+        ]
+    # An empty index satisfies the equality above, and would then let every
+    # check below pass over nothing at all. Refuse to call that a pass.
+    if indexed == 0:
+        return [
+            "index scope: no page carries data-pagefind-body and Pagefind "
+            "indexed nothing, so search is empty and every check below is "
+            "vacuous"
+        ]
+    print(f"  scope OK: {indexed} pages indexed, matching the attribute count")
+    return []
+
+
+def check_never_indexed(fragments: list[dict]) -> list[str]:
+    """Fail if any page that must never be searchable made it into the index."""
+    failures = [
+        f"must never be indexed but is: {fragment['url']} (matched "
+        f"{prefix!r}); the {{% if page %}} guard in overrides/main.html or "
+        "the data-pagefind-body placement has stopped excluding it"
+        for fragment in fragments
+        for prefix in NEVER_INDEXED
+        if fragment["url"].startswith(prefix)
+    ]
+    # Say nothing when there is nothing to say. An "OK" over an empty index is
+    # reassurance the run has not earned, and check_scope has already failed.
+    if not failures and fragments:
+        print(f"  exclusions OK: none of {len(NEVER_INDEXED)} barred prefixes indexed")
+    return failures
+
+
+def check_fused_tokens(fragments: list[dict], indexed: int) -> list[str]:
+    """Fail if any indexed page carries a fused language token."""
+    failures = []
+    checked = 0
+    skipped = 0
+    total_hits = 0
+    for fragment in fragments:
+        if fragment["url"].startswith(LOCAL_ONLY_PREFIX):
+            skipped += 1
+            continue
+        checked += 1
+        hits = FUSED_TOKEN.findall(fragment["content"])
+        if hits:
+            total_hits += len(hits)
+            failures.append(f"fused tokens on {fragment['url']}: {sorted(set(hits))}")
+
+    if failures:
+        failures.append(
+            f"{total_hits} fused tokens across {len(failures)} of {checked} "
+            "indexed pages. Pagefind concatenates adjacent inline elements "
+            "without a separator, so some construct is rendering language "
+            "labels flush against each other. Either an EXCLUDE_SELECTORS "
+            "entry in hooks/pagefind_index.py has stopped matching after a "
+            "theme upgrade, in which case update it to the new class name, or "
+            "a new construct needs adding to it. Do not suppress this by "
+            "narrowing FUSED_TOKEN: the tokens are really in the index and "
+            "really break search for those terms."
+        )
+
+    # Reconcile against the entry file. Without this the check is vacuous
+    # whenever it sees no fragments -- a renamed fragment directory or
+    # extension makes the glob return nothing, and scanning zero pages for
+    # zero tokens reports green on an index nobody looked at.
+    if checked + skipped != indexed:
+        failures.append(
+            f"fragment coverage: read {checked + skipped} fragments but the "
+            f"entry file reports {indexed} indexed pages. The fragment layout "
+            "under pagefind/fragment/ has changed, so the tokenization check "
+            "is not seeing the index it is meant to check"
+        )
+    elif not failures and checked:
+        # Suppressed when nothing was scanned: an empty index reconciles
+        # cleanly (0 == 0) and would otherwise print a clean bill of health
+        # directly above check_scope's report that the index is empty.
+        print(f"  tokenization OK: no fused tokens across {checked} indexed pages")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        # The module docstring is a page long; argparse would reflow it into a
+        # wall of collapsed text. The summary line is the useful part.
+        description=__doc__.strip().splitlines()[0]
+    )
+    parser.add_argument(
+        "site", nargs="?", default="site", help="path to the built site directory"
+    )
+    args = parser.parse_args()
+    site = Path(args.site)
+
+    if not (site / "pagefind" / "pagefind-entry.json").is_file():
+        print(f"error: no Pagefind index found under {site}", file=sys.stderr)
+        return 1
+
+    print(f"Verifying Pagefind index in {site}")
+    try:
+        indexed = _reported_page_count(site)
+    except ValueError as exc:
+        sys.stdout.flush()  # see the note on the failure block below
+        print("\nFAILED:", file=sys.stderr)
+        print(f"  - {exc}", file=sys.stderr)
+        return 1
+    failures = check_scope(site, indexed)
+
+    # A malformed or renamed fragment schema is a finding, not a crash: CI
+    # readers should get the FAILED block below, not a bare traceback.
+    try:
+        fragments = _load_fragments(site)
+    except (OSError, ValueError) as exc:
+        failures.append(f"could not read Pagefind fragments: {exc}")
+    else:
+        failures += check_never_indexed(fragments)
+        failures += check_fused_tokens(fragments, indexed)
+
+    if failures:
+        # stdout is block-buffered when redirected but stderr is not, so
+        # without this the failure list lands above the progress lines it is
+        # supposed to follow.
+        sys.stdout.flush()
+        print("\nFAILED:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+    print("All search index checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Replaces the built-in `search` plugin (lunr.js) with [Pagefind](https://pagefind.app), plus a search modal whose markup and behaviour live in this repo.

Two problems, solved together:

**Relevance.** The lunr index is tokenized with the bare default separator (`[\s\-]+` — whitespace and hyphens only), while **60% of the index sits inside `<code>`**. Searching `append_event`, `LlmAgent`, `google.adk.agents` or `before_agent_callback` currently returns **nothing**. Separately, Pagefind and lunr both concatenate adjacent inline elements, so the language badge and tab-label strip fuse into single tokens — `ADKPython` × 154, `PythonTypeScriptGoJava` × 59, across **193 of 226 pages**. A reader searching `Python` misses all of them.

**Interface.** Material's dropdown returns a flat list of section rows. This returns results grouped by page with the matching headings nested beneath, like [genkit.dev](https://genkit.dev) and [pydantic.dev/docs](https://pydantic.dev/docs) (both of which also use Pagefind).

## The indexed page set is unchanged

The main risk in swapping search engines is quietly changing what is searchable. It did not happen:

| | pages | URL set |
| --- | --- | --- |
| lunr on `main` | 226 | — |
| Pagefind here | 226 | **identical** |

Zero pages added, zero dropped. Verified by extracting both sets from CI-equivalent builds (`git archive`).

## Measured effects

| | before | after |
| --- | --- | --- |
| search bytes per page load | 841 KB gz index + 39 KB worker | **~9 KB gz** (`search.js` + `search.css`) |
| index / WASM / engine | fetched eagerly on every page | deferred to first modal open |
| `append_event`, `LlmAgent`, `google.adk.agents`, `before_agent_callback` | 0 results | all return results |
| fused language tokens | 219 across 193 pages | **0** |
| build time | — | +2.4s on a ~30s build |
| CI install | — | +5.4 MB |

The index is sharded, so a query fetches only the shards it touches (~162 KB to initialise, ~460 KB for a full cold search). A reader who never searches pays nothing beyond the ~9 KB.

## How it works

A `on_post_build` hook runs the Pagefind binary over the rendered HTML in `site_dir`. `data-pagefind-body` on `<article>` scopes the index — and because Pagefind indexes *only* pages carrying that attribute, it also keeps the 3,140 generated API-reference files out, matching the current lunr scope exactly. The attribute is conditional on `{% if page %}`, which keeps it off `404.html` (MkDocs renders theme templates without a page in context).

`--exclude-selectors ".headerlink, .tabbed-labels, .language-support-tag"` fixes the token fusion; tab *contents* stay indexed, so per-language content remains searchable. `--include-characters ".-@#+"` keeps `google.adk.agents` from splitting into three unrelated words.

Pagefind is used as a query API rather than a widget, so result rendering, keyboard handling and styling are ours — which is what makes the page-grouped layout and the deferred loading possible.

## Notable details

- **The trigger and the dialog are deliberately split across the `</header>` boundary.** The dialog must sit outside the seven elements instant navigation replaces (so it survives client-side navigation) *and* outside `.md-header`, because `custom.css`'s `[data-md-color-scheme="slate"] .md-header *` at specificity 0-2-0 beats the modal's own rules and flattens every colour in dark mode. Only the split satisfies both.
- **`target="_self"` on result links is load-bearing.** Material intercepts internal links by stripping query and hash and testing the bare URL against its sitemap, so `?pagefind-highlight=` links would be intercepted — leaving the dialog open and preventing the arrival highlighter from running. Material's handler bails on a truthy `target`.
- **Material's `__search` toggle input stays.** `toggle/index.ts` resolves it eagerly at module scope and throws if missing, which would take down all Material JS.
- **Keyboard**: `Ctrl`/`Cmd`+`K`, plus `/`, `s` and `f` rebound — those were bound inside Material's `mountSearch`, which no longer runs, so they would otherwise have silently stopped working. Suppressed while typing in a field.
- **Accessibility**: ARIA combobox/listbox with `aria-activedescendant`; native `<dialog>` for focus trapping and Escape.
- Search-term highlighting on arrival is preserved (`pagefind-highlight.js`, loaded only when the URL carries the param, and palette-aware via `--md-typeset-mark-color`).
- No Node toolchain — Pagefind ships as a Python wheel. `pagefind-bin` is pinned explicitly because `pagefind[bin]` only constrains the binary to `<2`.

## Guardrails

`hooks/pagefind_index.py` fails the build on: a missing or failing indexer, zero indexable pages, a page-count mismatch, and any `--exclude-selectors` entry that has stopped matching (a stale-but-valid selector would otherwise silently let fused tokens back in).

`scripts/verify_search_index.py` runs after the build in both `build-docs.yaml` and `publish-docs.yaml`, asserting index scope, that nothing under the generated API-reference subtrees or `404.html` is indexed, and that no fused tokens survive. Counts are always measured, never hardcoded.

`PAGEFIND_SKIP=1` skips indexing for `mkdocs serve` authoring loops; it logs a warning, so `--strict` builds fail while it is set.

## Testing

- `mkdocs build --strict` clean; all 10 commits build individually (bisect-safe).
- Verified interactively in Chrome: lazy loading (zero pagefind requests on page load), `Ctrl+K`, `/`/`s`/`f`, Escape, grouped results, arrow-key navigation, `aria-activedescendant`, full-document navigation on Enter, 167 terms marked on arrival, dark mode, and header layout from 1000px to 1920px.
- Fused-token fix proven with a control build: identical site indexed without `--exclude-selectors` → 219 tokens across 193 pages; with → 0.
