### PR TITLE
Apply post-merge review on the context caching Kotlin snippet

### DIFF
--- a/docs/context/caching.md
+++ b/docs/context/caching.md
@@ -67,8 +67,6 @@ these settings, as shown in the following code sample:
 === "Kotlin"
 
     ```kotlin
-    @file:OptIn(ExperimentalContextCachingFeature::class)
-
     import com.google.adk.kt.agents.ContextCacheConfig
     import com.google.adk.kt.agents.LlmAgent
     import com.google.adk.kt.annotations.ExperimentalContextCachingFeature
@@ -84,14 +82,14 @@ these settings, as shown in the following code sample:
         )
 
     // Create the app with context caching configuration
+    @OptIn(ExperimentalContextCachingFeature::class)
     val app =
         App(
             appName = "my-caching-agent-app",
             rootAgent = rootAgent,
             contextCacheConfig =
                 ContextCacheConfig(
-                    // Gemini enforces a hard 4096-token floor of its own, so only a
-                    // value above that has any further effect.
+                    // Gemini applies its own minimum cacheable size, which varies by model
                     minTokens = 8192,
                     ttl = 10.minutes, // Store for up to 10 minutes
                     cacheIntervals = 5, // Refresh after 5 uses


### PR DESCRIPTION
## Summary

Follow-up to #2091, applying review comments from @joefernandez and @wikaaaaa
that arrived shortly before it merged and were missed. That branch was deleted
on merge and a merged PR can't be reopened, so the fixes land here.

Kept to the minimum: two hunks, +2/−4, in the Kotlin tab of
`docs/context/caching.md`.

## Changes

**1. `@file:OptIn` → statement-level `@OptIn` on the `app` declaration** (@wikaaaaa)

The file-level form only worked as rendered because the snippet has no `package`
line; pasted into a real file the ordering would be wrong. This also matches how
the resumability opt-in was written before #2088 removed it.

**2. Dropped the "hard 4096-token floor" claim** (@joefernandez)

It quoted the adk-kotlin KDoc faithfully, but as Joe found that KDoc is the
outlier — adk-python and adk-kotlin's own `ContextCachingDemoAgent` both
describe *roughly 2048 for Gemini 2.5 and 4096 for Gemini 3*. The comment no
longer names a number. `minTokens = 8192` is unchanged.

## On the badge — keeping `Kotlin v0.7.0`

Joe offered a choice: drop to `v0.6.0` and rename the app to
`my_caching_agent_app`, or keep `v0.7.0` and fix the rationale. Taking the
second, for two reasons:

- These docs track the current pin and 1.0 is close, so badges shouldn't move
  backwards.
- The badge is accurate as it stands. Joe's own finding is why: the hyphenated
  `appName` in this sample genuinely requires 0.7.0, since v0.6.0's `App` regex
  is `[a-zA-Z_][a-zA-Z0-9_]*` and rejects hyphens.

He was right that the *stated reason* was wrong — "the page had no prior Kotlin
content" is a fact about the docs, not about the SDK. The correct reason is the
hyphen.

## Verification

Extracted the snippet, compiled and **ran** it against the 0.7.0 pin in a
throwaway project (the appName rule is a runtime `require`, so compiling alone
wouldn't catch it):

```
OK app=my-caching-agent-app minTokens=8192
```

`verify_snippets.py` passes L0/L1/L2/L3/L5/L6.
