### PR TITLE
Add Kotlin snippet for Vertex AI model routing

### DIFF
--- a/docs/agents/llm-agents.md
+++ b/docs/agents/llm-agents.md
@@ -421,6 +421,20 @@ You can adjust how the underlying AI model generates responses using
     --8<-- "examples/kotlin/snippets/agents/llm-agent/CapitalAgent.kt:gen_config"
     ```
 
+### Route requests across models
+
+<div class="language-support-tag" title="">
+   <span class="lst-supported">Supported in ADK</span><span class="lst-kotlin">Kotlin v0.6.0</span>
+</div>
+
+`routingConfig` asks Vertex AI to choose the model for each request, rather than
+pinning one. Use `autoMode` with a `ModelRoutingPreference` to let Vertex balance
+quality against cost, or `manualMode` to name a model explicitly.
+
+```kotlin
+--8<-- "examples/kotlin/snippets/agents/llm-agent/CapitalAgent.kt:routing_config"
+```
+
 ### Configure a default model
 
 <div class="language-support-tag" title="">

--- a/examples/kotlin/snippets/agents/llm-agent/CapitalAgent.kt
+++ b/examples/kotlin/snippets/agents/llm-agent/CapitalAgent.kt
@@ -5,10 +5,14 @@ import com.google.adk.kt.agents.LlmAgent
 import com.google.adk.kt.annotations.Param
 import com.google.adk.kt.annotations.Tool
 import com.google.adk.kt.models.Gemini
+import com.google.adk.kt.models.VertexCredentials
 import com.google.adk.kt.runners.InMemoryRunner
 import com.google.adk.kt.sessions.InMemorySessionService
 import com.google.adk.kt.types.Content
 import com.google.adk.kt.types.GenerateContentConfig
+import com.google.adk.kt.types.GenerationConfigRoutingConfig
+import com.google.adk.kt.types.GenerationConfigRoutingConfigAutoRoutingMode
+import com.google.adk.kt.types.ModelRoutingPreference
 import com.google.adk.kt.types.Part
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.runBlocking
@@ -80,6 +84,35 @@ fun main() =
                     ),
             )
         // --8<-- [end:gen_config]
+
+        // --8<-- [start:routing_config]
+        val routedAgent =
+            LlmAgent(
+                name = "capital_agent",
+                // Routing is a Vertex AI feature; it is not supported by the Gemini API.
+                model =
+                    Gemini(
+                        name = "gemini-flash-latest",
+                        vertexCredentials =
+                            VertexCredentials(project = "PROJECT_ID", location = "LOCATION"),
+                    ),
+                generateContentConfig =
+                    GenerateContentConfig(
+                        // Let Vertex pick the model, favouring cost over quality.
+                        routingConfig =
+                            GenerationConfigRoutingConfig(
+                                autoMode =
+                                    GenerationConfigRoutingConfigAutoRoutingMode(
+                                        modelRoutingPreference =
+                                            ModelRoutingPreference.PRIORITIZE_COST,
+                                    ),
+                            ),
+                        // Labels are also Vertex-only: they are stripped from requests
+                        // made with an AI Studio API key.
+                        labels = mapOf("team" to "search"),
+                    ),
+            )
+        // --8<-- [end:routing_config]
 
         // --8<-- [start:full_example]
         val finalAgent =


### PR DESCRIPTION
## Summary

`routingConfig` and `GenerateContentConfig` labels landed in adk-kotlin **0.6.0**
and were undocumented — the docs had **no mention of routing config in any
language**. This adds a `### Route requests across models` subsection to
`docs/agents/llm-agents.md`, transcluded from the existing `CapitalAgent.kt`.

## Why a new subsection, not the existing Kotlin tab

The `Fine-tune AI model operation` group is about generation *parameters* —
`temperature`, `maxOutputTokens`. Routing picks a *model* rather than tuning one,
so it reads as a separate concern. Extending that tab would also mean editing a
group that already has Kotlin.

## Notes for reviewers

- **Both features are Vertex-only, and the snippet has to show that, not just say
  it.** `routingConfig` is documented as *"Not supported in the Gemini API"*, and
  `labels` are silently stripped by `sanitizeForGeminiApi()` when calling with an
  AI Studio API key — a caller would see them vanish with no error. So the model
  is configured with `VertexCredentials`.
- **Badged `Kotlin v0.6.0`, and I tested that rather than assuming it.** The docs
  pin is 0.7.0, so the easy move was to badge 0.7.0. Instead I extracted the
  region and ran it against a temporary **0.6.0** pin as well:

  | pin | result |
  |---|---|
  | 0.6.0 | `OK pref=PRIORITIZE_COST labels={team=search}` |
  | 0.7.0 | `OK pref=PRIORITIZE_COST labels={team=search}` |

  A reader on 0.6.0 can use this exactly as written, so 0.6.0 is the honest floor.
- **`manualMode` is named in the prose but not shown.** It's a one-field
  alternative (`modelName`); showing both modes would double the snippet for
  little gain.
- **The subsection is Kotlin-only.** Precedented on this very page — the next
  section, `Configure a default model`, carries a Python-only badge.
- **Transcluded** from `CapitalAgent.kt`, already registered, so CI compiles and
  lints it.

## Verification

- CI compiles and lints the changed `.kt`.
- Ran the region standalone: constructing a Vertex-backed `Gemini` needs no
  credentials at build time, so the snippet loads without crashing.
- `verify_snippets.py` passes all six levels.