### PR TITLE
docs: correct nonexistent google-adk[vertexai] extra to [gcp]

### DIFF
--- a/docs/integrations/express-mode.md
+++ b/docs/integrations/express-mode.md
@@ -88,7 +88,7 @@ is compatible with Agent Platform Express Mode API Keys. You can instead initial
 the session object without any project or location.
 
 ```py
-# Requires: pip install google-adk[vertexai]
+# Requires: pip install google-adk[gcp]
 # Plus environment variable setup:
 # GOOGLE_GENAI_USE_ENTERPRISE=TRUE
 # GOOGLE_API_KEY=PASTE_YOUR_ACTUAL_EXPRESS_MODE_API_KEY_HERE
@@ -117,7 +117,7 @@ is compatible with Agent Platform express mode API Keys. You can instead initial
 the memory object without any project or location.
 
 ```py
-# Requires: pip install google-adk[vertexai]
+# Requires: pip install google-adk[gcp]
 # Plus environment variable setup:
 # GOOGLE_GENAI_USE_ENTERPRISE=TRUE
 # GOOGLE_API_KEY=PASTE_YOUR_ACTUAL_EXPRESS_MODE_API_KEY_HERE


### PR DESCRIPTION
The `vertexai` extra does not exist in google-adk's pyproject.toml, so `pip install google-adk[vertexai]` silently installs the base package without the Agent Platform dependencies. Readers following these snippets hit an ImportError when constructing VertexAiSessionService or VertexAiMemoryBankService.

The correct extra is `gcp`, which pulls in
google-cloud-aiplatform[agent-engines].

Follow-up to review feedback on #2031, which flagged the two occurrences in express-mode.md. The same stale extra appears once in sessions/session/index.md, fixed here too.