### PR TITLE
Fix link for sample agent configs

### DIFF
--- a/docs/agents/config.md
+++ b/docs/agents/config.md
@@ -303,7 +303,7 @@ limitations:
 ## Next steps
 
 For ideas on what to build, see the
-[sample agent configs](https://github.com/search?q=repo:google/adk-python+path:/%5Econtributing%5C/samples%5C//+root_agent.yaml&type=code)
+[sample agent configs](https://github.com/search?q=repo:google/adk-python+path:/%5Econtributing%5C/samples%5C/.*%5C/root_agent%5C.yaml$/&type=code)
 in the `adk-python` repository. For detailed information on the syntax and settings supported by
 the Agent Config format, see the
 [Agent Config syntax reference](/api-reference/agentconfig/).


### PR DESCRIPTION
Narrow the sample agent config search to `root_agent.yaml` files under `contributing/samples`.
This prevents README files that mention `root_agent.yaml` from appearing in the results.

https://github.com/google/adk-python/blob/v2.7.0/src/google/adk/cli/utils/agent_loader.py#L72-L73
>d)  {agent_name} as a YAML config folder:
>    agents_dir/{agent_name}/root_agent.yaml defines the root agent