### PR TITLE
Add Toolset Authentication per issue #1227 - 4

### DIFF
--- a/docs/tools-custom/authentication.md
+++ b/docs/tools-custom/authentication.md
@@ -402,6 +402,61 @@ handles the redirection flow, and retries the tool call once authorized.
 
 ![Authentication](../assets/auth_part1.svg)
 
+### Authenticate at a toolset level
+
+Instead of authenticating each tool individually, you can authenticate an entire suite of tools at once at the Toolset level.
+
+Under the hood, the `BaseLlmFlow` automatically checks your `BaseToolset` for authentication requirements *before* it even lists or executes any tools; it does this by checking the toolset's `get_auth_config()` method. 
+
+If your toolset returns an `AuthConfig` object and the session doesn't already have the required credentials, the ADK framework will step in and:
+
+1. **Pause execution:** It safely halts the current flow.
+2. **Request credentials:** It issues an `adk_request_credential` event to the client, similar to the interactive flow detailed in [Handle the interactive OAuth/OIDC flow](https://adk.dev/tools-custom/authentication/#handle-the-interactive-oauthoidc-flow-client-side)).
+
+This gives you a single, centralized place to define auth requirements for a group of related tools. The framework handles the heavy lifting, ensuring the necessary credentials are resolved before any tool in the toolset is touched.
+
+#### How to enable it
+To set this up, override the `get_auth_config()` method in your custom `BaseToolset` subclass:
+
+```python
+from google.adk.auth import AuthConfig
+from google.adk.tools.base_toolset import BaseToolset
+
+
+class MyAuthenticatedToolset(BaseToolset):
+  # ... your other toolset methods ...
+
+  def get_auth_config(self) -> AuthConfig | None:
+    # Return the AuthConfig required for this entire toolset
+    return AuthConfig(...)
+```
+
+#### Toolset authentication flow
+
+```mermaid
+%%{init: {"theme": "base", "themeVariables": {"fontFamily": "Google Sans, Roboto, sans-serif"}}}%%
+sequenceDiagram
+    participant User as End User
+    participant Agent as Agent & Client
+    participant Tool as BQ Tool
+    participant Google as Google Services
+
+    User->>Agent: User Query
+    Agent->>Tool: Execute Call
+    
+    Note over Tool: No active token
+    
+    Tool-->>Agent: Request Credentials
+    Agent->>User: Redirect to Auth URI
+    User->>Google: Authenticate & Approve
+    Google-->>Agent: Auth Code (Callback)
+    
+    Agent->>Tool: Resume with Credentials
+    Tool->>Google: Run API Call (BigQuery)
+    Google-->>Tool: Return Data
+    Tool-->>Agent: Output
+    Agent-->>User: Final Answer
+```
 
 ### Handle the interactive OAuth/OIDC flow (client-side)
 


### PR DESCRIPTION
Added documentation for the new Toolset-level authentication feature and improved the visual rendering of our authentication flow diagrams.

- Staged: https://deploy-preview-2138--adk-docs-preview.netlify.app/tools-custom/authentication/
- Agent's PRs: #1233 and #1234
- Original issue: #1227 


---

# Technical Report: Toolset Authentication Documentation Verification

* **Reference Implementation Repository:** [google/adk-python](https://github.com/google/adk-python)
* **Status:** **ALL CHECKS PASSED**

---

## 1. Verification of Import Statements

### Snippet Under Review
```python
from google.adk.auth import AuthConfig
from google.adk.tools.base_toolset import BaseToolset
```

* **Status:** `PASS`
* **Citations & Verification:**
  * [`src/google/adk/auth/__init__.py:L25`](https://github.com/google/adk-python/blob/main/src/google/adk/auth/__init__.py#L25)  
    `AuthConfig` is exposed directly by the `google.adk.auth` top-level namespace (`from .auth_tool import AuthConfig`).
  * [`src/google/adk/tools/base_toolset.py:L63`](https://github.com/google/adk-python/blob/main/src/google/adk/tools/base_toolset.py#L63)  
    `BaseToolset` is defined at `google.adk.tools.base_toolset.BaseToolset`. Importing from `google.adk.tools.base_toolset` resolves without error.

---

## 2. Method Signature and Subclassing

### Snippet Under Review
```python
class MyAuthenticatedToolset(BaseToolset):

  def get_auth_config(self) -> AuthConfig | None:
    return AuthConfig(...)
```

* **Status:** `PASS`
* **Citations & Verification:**
  * [`src/google/adk/tools/base_toolset.py:L225-L241`](https://github.com/google/adk-python/blob/main/src/google/adk/tools/base_toolset.py#L225-L241)  
    `BaseToolset.get_auth_config` defines `def get_auth_config(self) -> Optional[AuthConfig]: return None`. The return type annotation `AuthConfig | None` is valid in Python 3.10+ and conforms with `Optional[AuthConfig]`.
  * [`tests/unittests/auth/test_toolset_auth.py:L43-L57`](https://github.com/google/adk-python/blob/main/tests/unittests/auth/test_toolset_auth.py#L43-L57)  
    Unit tests demonstrate custom toolsets (`MockToolset(BaseToolset)`) overriding `get_auth_config()` using this exact pattern.

---

## 3. Pre-Execution Authentication Resolution

### Draft Statement Under Review
> *"Under the hood, the BaseLlmFlow automatically checks your BaseToolset for authentication requirements before it even lists or executes any tools. It does this by checking the toolset's get_auth_config() method."*

* **Status:** `PASS`
* **Citations & Verification:**
  * [`src/google/adk/flows/llm_flows/base_llm_flow.py:L1414-L1427`](https://github.com/google/adk-python/blob/main/src/google/adk/flows/llm_flows/base_llm_flow.py#L1414-L1427)  
    In `BaseLlmFlow._preprocess_async`, `self._resolve_toolset_auth(invocation_context, agent)` executes prior to `_process_agent_tools`, guaranteeing credentials are resolved before `get_tools()` is invoked.
  * [`src/google/adk/flows/llm_flows/base_llm_flow.py:L187-L193`](https://github.com/google/adk-python/blob/main/src/google/adk/flows/llm_flows/base_llm_flow.py#L187-L193)  
    `_resolve_toolset_auth` loops over `agent.tools`, inspects instances of `BaseToolset`, and queries `tool_union.get_auth_config()`.

---

## 4. Pausing Execution and Emitting `adk_request_credential`

### Draft Statement Under Review
> *"1. Pause execution: It safely halts the current flow. 2. Request credentials: It issues an adk_request_credential event to the client..."*

* **Status:** `PASS`
* **Citations & Verification:**
  * [`src/google/adk/flows/llm_flows/functions.py:L64`](https://github.com/google/adk-python/blob/main/src/google/adk/flows/llm_flows/functions.py#L64)  
    `REQUEST_EUC_FUNCTION_CALL_NAME` is defined as `'adk_request_credential'`.
  * [`src/google/adk/flows/llm_flows/functions.py:L350-L362`](https://github.com/google/adk-python/blob/main/src/google/adk/flows/llm_flows/functions.py#L350-L362)  
    `build_auth_request_event` constructs the function call event using `name=REQUEST_EUC_FUNCTION_CALL_NAME`.
  * [`src/google/adk/flows/llm_flows/base_llm_flow.py:L236-L244`](https://github.com/google/adk-python/blob/main/src/google/adk/flows/llm_flows/base_llm_flow.py#L236-L244)  
    Yields the auth request event and sets `invocation_context.end_invocation = True`, safely interrupting the execution flow.

