### PR TITLE
docs(graphs): remove live streaming from known limitations

### DIFF
--- a/docs/graphs/index.md
+++ b/docs/graphs/index.md
@@ -217,7 +217,6 @@ For information about building advanced pipelines, see
 There are some known limitations with graph-based workflows. They
 are *not compatible* with the following ADK features:
 
--   **Live streaming:** Not supported in graph-based workflows.
 -   **Integrations:** Some third-party
     [integrations](/integrations/) may not be compatible with graph-based
     workflows.


### PR DESCRIPTION
## Description

Removes the outdated note claiming live streaming is not supported in graph-based workflows from the Workflow Graphs documentation (`https://adk.dev/graphs/`).

Live streaming is supported in ADK graph workflows (for example, task-mode live agents orchestrated in `Workflow` graphs).

## Changes

- Removed `-   **Live streaming:** Not supported in graph-based workflows.` under the **Known limitations** section in `docs/graphs/index.md`.