### PR TITLE
Update lifespan per issue #1521 - 15

### DIFF
--- a/docs/a2a/quickstart-exposing.md
+++ b/docs/a2a/quickstart-exposing.md
@@ -272,6 +272,32 @@ You can inject a list of `execute_interceptors` to add middleware logic to the `
     export ADK_SUPPRESS_A2A_EXPERIMENTAL_FEATURE_WARNINGS=true
     ```
 
+### Manage the application lifecycle
+
+Use the `lifespan` argument of the `to_a2a` function to manage the application's lifecycle. Pass an asynchronous context manager to perform setup and teardown tasks, such as initiate a database connection on startup and closing it on shutdown.
+
+The context manager receives the `Starlette` app instance. Use `app.state` to store resources that your application needs to access globally.
+
+```python
+from contextlib import asynccontextmanager
+from google.adk.a2a.utils.agent_to_a2a import to_a2a
+from starlette.applications import Starlette
+
+
+@asynccontextmanager
+async def lifespan(app: Starlette):
+  # Initialize resources on application startup
+  app.state.db = await init_db()
+
+  yield
+
+  # Clean up resources on application shutdown
+  await app.state.db.close()
+
+
+a2a_app = to_a2a(agent, lifespan=lifespan)
+```
+
 ## Agent Executor V2
 
 The new version of the [agent executor](https://github.com/google/adk-python/blob/main/src/google/adk/a2a/executor/a2a_agent_executor_impl.py) is typically enabled when a client sends the required [A2A extension](a2a-extension.md).


### PR DESCRIPTION
Adding documentation for lifespan argument in the `to_a2a` function to manage external resources like database connections.

- Staged> https://deploy-preview-2140--adk-docs-preview.netlify.app/a2a/quickstart-exposing/#manage-the-application-lifecycle
- Agent's Pr> #1529 
- Original Issue> #1521 

---

## 1. Import Statements Verification

### Snippet Under Review
```python
from contextlib import asynccontextmanager
from google.adk.a2a.utils.agent_to_a2a import to_a2a
from starlette.applications import Starlette
```

* **Status:** `PASS`
* **Citations & Verification:**
  * [`src/google/adk/a2a/utils/agent_to_a2a.py:L79`](https://github.com/google/adk-python/blob/main/src/google/adk/a2a/utils/agent_to_a2a.py#L79)  
    `to_a2a` is defined in module `google.adk.a2a.utils.agent_to_a2a`. Importing `to_a2a` from this exact path resolves without error.
  * [`src/google/adk/a2a/utils/agent_to_a2a.py:L18`](https://github.com/google/adk-python/blob/main/src/google/adk/a2a/utils/agent_to_a2a.py#L18) & [`src/google/adk/a2a/utils/agent_to_a2a.py:L28`](https://github.com/google/adk-python/blob/main/src/google/adk/a2a/utils/agent_to_a2a.py#L28)  
    `contextlib.asynccontextmanager` and `starlette.applications.Starlette` are the standard, supported dependencies used internally by the A2A server implementation.

---

## 2. Function Signature & Parameter Verification (`to_a2a`)

### Snippet Under Review
```python
a2a_app = to_a2a(agent, lifespan=lifespan)
```

* **Status:** `PASS`
* **Citations & Verification:**
  * [`src/google/adk/a2a/utils/agent_to_a2a.py:L79-L94`](https://github.com/google/adk-python/blob/main/src/google/adk/a2a/utils/agent_to_a2a.py#L79-L94)  
    The `to_a2a` function signature explicitly accepts the keyword-only parameter `lifespan: Callable[[Starlette], AbstractAsyncContextManager[None]] | None = None` and returns `Starlette`.
  * [`src/google/adk/a2a/utils/agent_to_a2a.py:L243-L257`](https://github.com/google/adk-python/blob/main/src/google/adk/a2a/utils/agent_to_a2a.py#L243-L257)  
    `to_a2a` creates a composed lifespan `_combined_lifespan` that executes the internal A2A route setup before entering the user-provided `lifespan(app)` context, passing `app` to `Starlette(lifespan=_combined_lifespan)`.

---

## 3. Lifespan Definition & `app.state` State Management

### Snippet Under Review
```python
@asynccontextmanager
async def lifespan(app: Starlette):
  # Initialize resources on application startup
  app.state.db = await init_db()

  yield

  # Clean up resources on application shutdown
  await app.state.db.close()
```

* **Status:** `PASS`
* **Citations & Verification:**
  * [`src/google/adk/a2a/utils/agent_to_a2a.py:L117-L120`](https://github.com/google/adk-python/blob/main/src/google/adk/a2a/utils/agent_to_a2a.py#L117-L120)  
    The official docstring specifies: *"Optional async context manager for Starlette lifespan events. Use this to run startup/shutdown logic (e.g. initializing database connections or loading resources). The context manager receives the Starlette app instance and can set state on `app.state`."*
  * [`src/google/adk/a2a/utils/agent_to_a2a.py:L136-L144`](https://github.com/google/adk-python/blob/main/src/google/adk/a2a/utils/agent_to_a2a.py#L136-L144)  
    The module's own docstring example uses this identical async context manager pattern with `app.state.db`.
  * [`tests/unittests/a2a/utils/test_agent_to_a2a.py:L767-L793`](https://github.com/google/adk-python/blob/main/tests/unittests/a2a/utils/test_agent_to_a2a.py#L767-L793)  
    Unit test `test_to_a2a_with_lifespan` validates that `app.state` mutations inside a custom lifespan persist across the application runtime and clean up on shutdown.

---

## 4. Execution Order & Technical Claims

### Draft Statements Under Review
> *"Use the `lifespan` argument of the `to_a2a` function to manage the application's lifecycle. Pass an asynchronous context manager to perform setup and teardown tasks, such as initiate a database connection on startup and closing it on shutdown."*
>
> *"The context manager receives the `Starlette` app instance. Use `app.state` to store resources that your application needs to access globally."*

* **Status:** `PASS`
* **Citations & Verification:**
  * [`src/google/adk/a2a/utils/agent_to_a2a.py:L244-L253`](https://github.com/google/adk-python/blob/main/src/google/adk/a2a/utils/agent_to_a2a.py#L244-L253)  
    `_combined_lifespan` guarantees that `await setup_a2a(app)` completes before entering `async with lifespan(app): yield`.
  * [`tests/unittests/a2a/utils/test_agent_to_a2a.py:L804-L827`](https://github.com/google/adk-python/blob/main/tests/unittests/a2a/utils/test_agent_to_a2a.py#L804-L827)  
    Unit test `test_to_a2a_lifespan_setup_runs_before_user_lifespan` verifies that routes are attached prior to the user's lifespan startup hook executing.
