### PR TITLE
Upgrade Kotlin examples and install docs to adk-kotlin 0.8.0

### DIFF
--- a/docs/agents/models/litert-lm.md
+++ b/docs/agents/models/litert-lm.md
@@ -184,8 +184,8 @@ repositories {
 }
 
 dependencies {
-    implementation("com.google.adk:google-adk-kotlin-core:0.5.0")
-    implementation("com.google.adk:google-adk-kotlin-litertlm:0.5.0")
+    implementation("com.google.adk:google-adk-kotlin-core:0.8.0")
+    implementation("com.google.adk:google-adk-kotlin-litertlm:0.8.0")
     implementation("com.google.ai.edge.litertlm:litertlm-jvm:0.13.1")
     // other dependencies...
 }

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -168,8 +168,8 @@ across supported languages. For a guided introduction, start with the
     }
 
     dependencies {
-        implementation("com.google.adk:google-adk-kotlin-core:0.5.0")
-        ksp("com.google.adk:google-adk-kotlin-processor:0.5.0")
+        implementation("com.google.adk:google-adk-kotlin-core:0.8.0")
+        ksp("com.google.adk:google-adk-kotlin-processor:0.8.0")
     }
     ```
 

--- a/docs/get-started/kotlin.md
+++ b/docs/get-started/kotlin.md
@@ -108,8 +108,8 @@ An ADK Kotlin agent project requires the following dependencies in your
 
 ```kotlin title="my_agent/build.gradle.kts (partial)"
 dependencies {
-    implementation("com.google.adk:google-adk-kotlin-core:0.5.0")
-    ksp("com.google.adk:google-adk-kotlin-processor:0.5.0")
+    implementation("com.google.adk:google-adk-kotlin-core:0.8.0")
+    ksp("com.google.adk:google-adk-kotlin-processor:0.8.0")
 }
 ```
 
@@ -129,9 +129,9 @@ dependencies {
     }
 
     dependencies {
-        implementation("com.google.adk:google-adk-kotlin-core:0.5.0")
-        implementation("com.google.adk:google-adk-kotlin-webserver:0.5.0")
-        ksp("com.google.adk:google-adk-kotlin-processor:0.5.0")
+        implementation("com.google.adk:google-adk-kotlin-core:0.8.0")
+        implementation("com.google.adk:google-adk-kotlin-webserver:0.8.0")
+        ksp("com.google.adk:google-adk-kotlin-processor:0.8.0")
     }
 
     kotlin {
@@ -235,9 +235,9 @@ to your `build.gradle.kts`:
 
 ```kotlin title="my_agent/build.gradle.kts (add to dependencies)"
 dependencies {
-    implementation("com.google.adk:google-adk-kotlin-core:0.5.0")
-    implementation("com.google.adk:google-adk-kotlin-webserver:0.5.0")
-    ksp("com.google.adk:google-adk-kotlin-processor:0.5.0")
+    implementation("com.google.adk:google-adk-kotlin-core:0.8.0")
+    implementation("com.google.adk:google-adk-kotlin-webserver:0.8.0")
+    ksp("com.google.adk:google-adk-kotlin-processor:0.8.0")
 }
 ```
 

--- a/examples/kotlin/build.gradle.kts
+++ b/examples/kotlin/build.gradle.kts
@@ -14,14 +14,14 @@ repositories {
 }
 
 dependencies {
-    implementation("com.google.adk:google-adk-kotlin-core:0.7.0")
-    implementation("com.google.adk:google-adk-kotlin-webserver:0.7.0")
-    ksp("com.google.adk:google-adk-kotlin-processor:0.7.0")
+    implementation("com.google.adk:google-adk-kotlin-core:0.8.0")
+    implementation("com.google.adk:google-adk-kotlin-webserver:0.8.0")
+    ksp("com.google.adk:google-adk-kotlin-processor:0.8.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
     // The Vertex AI session and memory services expose Ktor's HttpClient as a
     // defaulted constructor parameter, so any snippet naming them needs Ktor on
     // the COMPILE classpath, not just at runtime. Version matches what
-    // adk-kotlin 0.7.0 already resolves to.
+    // adk-kotlin 0.8.0 already resolves to.
     implementation("io.ktor:ktor-client-core:2.3.13")
     implementation("io.ktor:ktor-client-java:2.3.13")
     implementation("com.google.cloud:google-cloud-storage:2.48.2")


### PR DESCRIPTION
## Summary

The Kotlin examples project was pinned to adk-kotlin **0.7.0**, and the install
instructions readers copy from were still on **0.5.0**. This moves both to
**0.8.0**, so snippets for the BigQuery agent analytics plugin and the JSON
Schema constraint fields on `Schema` can be written, and so a reader following
the quickstart ends up on the same SDK the snippets are written against.

Deliberately just the version move — no new snippets. It is the base for the
remaining 0.8.0 docs work.

## What's in it

**The examples pin** (`examples/kotlin/build.gradle.kts`)

- `google-adk-kotlin-core`, `-webserver`, and `-processor` 0.7.0 → 0.8.0.
- Nothing else. Checked the 0.8.0 POM before bumping: it still resolves
  Ktor **2.3.13** and kotlin-stdlib **2.1.20**, so the explicit Ktor pins and
  the 2.1.20 Kotlin/KSP plugin versions stay correct as they are. Unlike the
  0.7.0 bump, 0.8.0 removes no API the current snippets use, so there is no
  fallout to carry.

**The install instructions** 0.5.0 → 0.8.0, 12 lines

- `docs/get-started/kotlin.md` (three blocks), `docs/get-started/installation.md`,
  `docs/agents/models/litert-lm.md`.
- These had been left behind by the 0.7.0 bump, so the quickstart handed people
  an SDK with no context caching, no Vertex AI memory or session services, and
  no BigQuery analytics plugin — while the snippets on those same pages already
  assumed a newer API.
- Confirmed on Maven Central that 0.8.0 is published for every artifact named:
  `-core`, `-processor`, `-webserver`, `-litertlm`.

**Deliberately not touched**

- The `<span class="lst-kotlin">Kotlin v0.x` support badges (23 × v0.1.0,
  7 × v0.7.0, 2 × v0.6.0, 1 × v0.4.0). Those record the release a feature
  *landed in*; bumping them would make them wrong.
- `docs/api-reference/kotlin/index.html` still renders **0.5.0**. The published
  Kotlin API reference is generated from 0.5.0 and is three releases stale.
  Editing that string alone would be a lie about the content behind it — it
  needs a Dokka regeneration, which is its own change.

## Verification

**The examples have not been compile-verified**, and I'd rather say so than
imply otherwise:

- No JDK 17 available on my machine, and the Gradle wrapper (8.3) rejects the
  JDK 26 that is there, so `./gradlew build` could not run.
- The `kotlin-snippets-pr-check` job only builds `.kt` files **changed in the
  PR**. This PR changes none, so the job will pass without compiling anything.

In practice the first snippet PR stacked on this one is what will exercise
0.8.0. If you'd prefer hard evidence before merging, say the word and I'll get
a JDK 17 in place and post a full `./tools/kotlin-snippets/runner.sh build` run.
