### PR TITLE
Update apigee  wrapper to accept optional credentials per issue #1743 - 5

### DIFF
--- a/docs/agents/models/apigee.md
+++ b/docs/agents/models/apigee.md
@@ -43,6 +43,8 @@ Integrate Apigee's governance into your agent's workflow by instantiating the
         proxy_url=f"https://{APIGEE_PROXY_URL}",
         # Pass necessary authentication/authorization headers (like an API key)
         custom_headers={"foo": "bar"}
+        # Optional: Pass google-auth credentials if the proxy requires additional OAuth scopes
+        # credentials=my_credentials
     )
 
     # Pass the configured model wrapper to your LlmAgent


### PR DESCRIPTION
Updated python wrapper to accept an optional credentials parameter this support passing explicit google-auth credentials.

Staged> https://deploy-preview-2148--adk-docs-preview.netlify.app/agents/models/apigee/
Agent's PR> #1750 
Original issue> #1743 

---

=== 1. Checking Imports ===
✓ Imports verified successfully (google.adk.agents.LlmAgent, google.adk.models.apigee_llm.ApigeeLlm)

=== 2. Checking ApigeeLlm Signature & Arguments ===
ApigeeLlm.__init__ parameters: ['self', 'model', 'proxy_url', 'custom_headers', 'retry_options', 'api_type', 'credentials']
✓ All snippet parameters (model, proxy_url, custom_headers, credentials) match the ApigeeLlm signature.

=== 3. Checking Model String Validation ===
Model string: 'apigee/gemini-flash-latest'
Validation result: True
Extracted model ID: 'gemini-flash-latest'
✓ Model string passes ApigeeLlm's internal format validation.

=== 4. Instantiating ApigeeLlm ===
Instantiated model: model='apigee/gemini-flash-latest'
✓ ApigeeLlm instance created and proxy/header attributes matched.

=== 5. Using ApigeeLlm with LlmAgent ===
Instantiated LlmAgent: name=test_agent, model=ApigeeLlm(...)
✓ LlmAgent successfully accepts the ApigeeLlm instance.

=== 6. Testing End-to-End Request Mock ===
Received response: 'Hello from Apigee Proxy'
✓ End-to-end generate_content_async executed successfully.