### PR TITLE
Add Kotlin tabs to the Skills page

### DIFF
--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -17,7 +17,8 @@ impact on the operating context window of the agent.
     respective ADK GitHub repositories:
     [ADK Python](https://github.com/google/adk-python/issues/new?template=feature_request.md&labels=skills),
     [ADK TypeScript](https://github.com/google/adk-js/issues/new?template=feature_request.md&labels=skills),
-    [ADK Go](https://github.com/google/adk-go/issues/new?template=feature_request.md&labels=skills).
+    [ADK Go](https://github.com/google/adk-go/issues/new?template=feature_request.md&labels=skills),
+    [ADK Kotlin](https://github.com/google/adk-kotlin/issues/new).
 
 ## Get started
 

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -1,7 +1,7 @@
 # Skills for ADK agents
 
 <div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v1.25.0</span><span class="lst-typescript">TypeScript v0.6.1</span><span class="lst-go">Go v1.2.0</span><span class="lst-preview">Experimental</span>
+    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v1.25.0</span><span class="lst-typescript">TypeScript v0.6.1</span><span class="lst-go">Go v1.2.0</span><span class="lst-kotlin">Kotlin v0.8.0</span><span class="lst-preview">Experimental</span>
 </div>
 
 An agent ***Skill*** is a self-contained unit of functionality that an ADK agent
@@ -100,6 +100,15 @@ You can define [skills in code](#inline-skills) or load
 
     For a complete example, see the code sample in
     [skills](https://github.com/google/adk-go/tree/main/examples/skills).
+
+=== "Kotlin"
+
+    ```kotlin
+    --8<-- "examples/kotlin/snippets/skills/SkillsExample.kt:get_started"
+    ```
+
+    For a complete example, see the code sample in
+    [skills](https://github.com/google/adk-kotlin/tree/main/examples/src/main/kotlin/com/google/adk/kt/examples/skills).
 
 !!! note "Check your working directory"
 
@@ -288,6 +297,17 @@ You can define Skills within the code of your agent, as shown below.
     }
     ```
 
+=== "Kotlin"
+
+    !!! note
+        ADK Kotlin does not currently provide a standard Source for inline skills.
+        To define skills directly in code, you must implement the `SkillSource`
+        interface yourself, as shown below.
+
+    ```kotlin
+    --8<-- "examples/kotlin/snippets/skills/SkillsExample.kt:inline_skill"
+    ```
+
 !!! note
     The `Source` interface can be backed by any data store (such as a database)
     to support dynamic use cases like live updates and personalization.
@@ -343,6 +363,12 @@ You can define Skills within the code of your agent, as shown below.
     }
     ```
 
+=== "Kotlin"
+
+    ```kotlin
+    --8<-- "examples/kotlin/snippets/skills/SkillsExample.kt:filesystem_skill"
+    ```
+
 ## Skill processing and validation
 
 When you include skills in your agent, the agent uses a standardized process
@@ -356,4 +382,5 @@ Check out these resources for building agents with Skills:
 
 - [Skills in Python - code sample](https://github.com/google/adk-python/tree/main/contributing/samples/environment_and_skills/skills_agent)
 - [Skills in Go - code sample](https://github.com/google/adk-go/tree/main/examples/skills)
+- [Skills in Kotlin - code sample](https://github.com/google/adk-kotlin/tree/main/examples/src/main/kotlin/com/google/adk/kt/examples/skills)
 - Agent Skills [specification documentation](https://agentskills.io/)

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -1,7 +1,7 @@
 # Skills for ADK agents
 
 <div class="language-support-tag">
-    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v1.25.0</span><span class="lst-typescript">TypeScript v0.6.1</span><span class="lst-go">Go v1.2.0</span><span class="lst-kotlin">Kotlin v0.8.0</span><span class="lst-preview">Experimental</span>
+    <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python v1.25.0</span><span class="lst-typescript">TypeScript v0.6.1</span><span class="lst-go">Go v1.2.0</span><span class="lst-kotlin">Kotlin v0.1.0</span><span class="lst-preview">Experimental</span>
 </div>
 
 An agent ***Skill*** is a self-contained unit of functionality that an ADK agent

--- a/examples/kotlin/snippets/skills/SkillsExample.kt
+++ b/examples/kotlin/snippets/skills/SkillsExample.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.adk.kt.examples.skills
+
+import com.google.adk.kt.agents.Instruction
+import com.google.adk.kt.agents.LlmAgent
+import com.google.adk.kt.models.Gemini
+import com.google.adk.kt.skills.Frontmatter
+import com.google.adk.kt.skills.NewFileSystemSource
+import com.google.adk.kt.skills.SkillSource
+import com.google.adk.kt.skills.SkillSourceException
+import com.google.adk.kt.tools.SkillToolset
+
+// --8<-- [start:get_started]
+// NewFileSystemSource discovers every skill directory under the base directory,
+// so there is no per-skill load call.
+val mySkillToolset = SkillToolset(NewFileSystemSource("skills"))
+
+val skillUserAgent =
+    LlmAgent(
+        name = "skill_user_agent",
+        model = Gemini(name = "gemini-flash-latest"),
+        description = "An agent that can use specialized skills.",
+        instruction =
+            Instruction("You are a helpful assistant that can leverage skills to perform tasks."),
+        // A SkillToolset contributes only the skill tools. Any other tool the agent
+        // needs is passed separately in `tools`.
+        toolsets = listOf(mySkillToolset),
+    )
+// --8<-- [end:get_started]
+
+// --8<-- [start:inline_skill]
+
+/**
+ * ADK Kotlin does not provide a standard [SkillSource] for skills defined in code, so implement the
+ * interface yourself to serve them from memory.
+ */
+class StaticSkillSource : SkillSource {
+    private val greetingSkill =
+        Frontmatter(
+            name = "greeting-skill",
+            description = "A friendly greeting skill that can say hello to a specific person.",
+        )
+
+    private val instructions =
+        "Step 1: Read the 'references/hello_world.txt' file to understand how to greet the " +
+            "user. Step 2: Return a greeting based on the reference."
+
+    private val resources =
+        mapOf(
+            "references/hello_world.txt" to "Hello! So glad to have you here!",
+            "references/example.md" to "This is an example reference.",
+        )
+
+    private fun notFound(skillName: String) = SkillSourceException("Skill $skillName not found.")
+
+    override suspend fun listFrontmatters(): Result<List<Frontmatter>> =
+        Result.success(listOf(greetingSkill))
+
+    override suspend fun loadFrontmatter(skillName: String): Result<Frontmatter> =
+        if (skillName == greetingSkill.name) {
+            Result.success(greetingSkill)
+        } else {
+            Result.failure(notFound(skillName))
+        }
+
+    override suspend fun loadInstructions(skillName: String): Result<String> =
+        if (skillName == greetingSkill.name) {
+            Result.success(instructions)
+        } else {
+            Result.failure(notFound(skillName))
+        }
+
+    override suspend fun listResources(
+        skillName: String,
+        resourceDirectoryPath: String,
+    ): Result<List<String>> {
+        if (skillName != greetingSkill.name) return Result.failure(notFound(skillName))
+        val prefix = resourceDirectoryPath.removePrefix("./").removeSuffix("/")
+        if (prefix.isEmpty() || prefix == ".") return Result.success(resources.keys.toList())
+        // Skill resources live only under references/, assets/ and scripts/.
+        if (prefix.substringBefore("/") !in SkillSource.VALID_RESOURCE_DIRS) {
+            return Result.failure(
+                SkillSourceException("Invalid resource path: $resourceDirectoryPath"),
+            )
+        }
+        return Result.success(resources.keys.filter { it.startsWith("$prefix/") })
+    }
+
+    override suspend fun loadResource(
+        skillName: String,
+        resourcePath: String,
+    ): Result<ByteArray> {
+        if (skillName != greetingSkill.name) return Result.failure(notFound(skillName))
+        val content =
+            resources[resourcePath]
+                ?: return Result.failure(
+                    SkillSourceException("Resource $resourcePath not found in skill $skillName."),
+                )
+        return Result.success(content.encodeToByteArray())
+    }
+}
+
+val inlineSkillAgent =
+    LlmAgent(
+        name = "greeting_agent",
+        model = Gemini(name = "gemini-flash-latest"),
+        instruction = Instruction("Greet the user by following the greeting skill."),
+        toolsets = listOf(SkillToolset(StaticSkillSource())),
+    )
+// --8<-- [end:inline_skill]
+
+// --8<-- [start:filesystem_skill]
+// Every immediate subdirectory of "skills" that contains a SKILL.md is exposed as
+// a skill, so individual skills are discovered rather than named one by one.
+val filesystemSource = NewFileSystemSource("skills")
+
+val filesystemSkillToolset = SkillToolset(filesystemSource)
+// --8<-- [end:filesystem_skill]

--- a/tools/kotlin-snippets/files_to_test.txt
+++ b/tools/kotlin-snippets/files_to_test.txt
@@ -43,3 +43,4 @@ snippets/tools/overview/OrderTools.kt
 snippets/sessions/RewindExample.kt
 snippets/tools/confirmation/ToolConfirmationExample.kt
 snippets/tools/confirmation/dynamic/ReimbursementTools.kt
+snippets/skills/SkillsExample.kt


### PR DESCRIPTION
## What

Adds Kotlin to all three tab groups on `docs/skills/index.md` (get started, skills defined in code, skills read from the filesystem), plus the `Kotlin v0.1.0` language badge and a Kotlin entry under **Next steps**.

New snippet file: `examples/kotlin/snippets/skills/SkillsExample.kt`, registered in `files_to_test.txt`.

## Why

`SkillToolset` has existed since adk-kotlin v0.1.0, but the page has never shown Kotlin. Earlier coverage audits diffed one release tag against the next, so anything that already existed at v0.1.0 was invisible to them.

## Kotlin differs from the sibling tabs in two ways

Both are deliberate, not translation shortcuts:

- **`SkillToolset` takes a single `SkillSource`**, not a list of pre-loaded skills plus `additional_tools`. `NewFileSystemSource` discovers every skill directory under a base directory, so there is no per-skill load call. Extra tools go on the agent's `tools`, not on the toolset.
- **There is no built-in source for skills defined in code.** Only `NewFileSystemSource` (JVM/Android) and `AssetSkillSource` (Android-only) implement `SkillSource` at v0.8.0. The inline-skills tab therefore implements `SkillSource` directly, mirroring how the ADK Go tab handles the same gap, rather than inventing a Python-style model class.

`AssetSkillSource` is `androidMain` and is intentionally left out of scope.

## Verification

Grounded against the `v0.8.0` git tag (not the adk-kotlin working tree). Full ladder green:

| Level | Check | Result |
| --- | --- | --- |
| L0 | symbols/named args exist at 0.8.0 | PASS |
| L1 | `gradlew build` (JDK 17, KSP) | PASS |
| L2 | ktlint (report-parsed) | PASS |
| L3 | transclusions + tab structure | PASS |
| L5 | `files_to_test.txt` registration | PASS |
| L6 | language badge | PASS |

L4 (`runSnippets`) reports SKIP — no such Gradle task exists in this repo, so it is skipped for every snippet, not just these.

The page is badged Experimental for the other languages; I checked and `SkillToolset` carries no opt-in annotation at v0.8.0, so the Kotlin badge is added plainly.

Tracked as KT-23.


---

**Update:** the badge originally read `Kotlin v0.8.0`, which is the version adk-docs compiles against, not the release the feature shipped in. Corrected to the introducing version, matching the sibling badges and the rest of the site.