### PR TITLE
Add Kotlin safety settings and includeContents to the agent docs

### DIFF
--- a/docs/agents/llm-agents.md
+++ b/docs/agents/llm-agents.md
@@ -663,6 +663,12 @@ Control whether the agent receives the prior conversation history.
             .build();
     ```
 
+=== "Kotlin"
+
+    ```kotlin
+    --8<-- "examples/kotlin/snippets/agents/llm-agent/CapitalAgent.kt:include_contents"
+    ```
+
 !!! note "Go v2.0.0: agent execution modes"
 
     ADK Go v2.0.0 introduces an explicit `Mode` field on `llmagent.Config` that

--- a/docs/safety/index.md
+++ b/docs/safety/index.md
@@ -1,7 +1,7 @@
 # Safety and Security for AI Agents
 
 <div class="language-support-tag">
-  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span><span class="lst-typescript">TypeScript</span><span class="lst-go">Go</span><span class="lst-java">Java</span>
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span><span class="lst-typescript">TypeScript</span><span class="lst-go">Go</span><span class="lst-java">Java</span><span class="lst-kotlin">Kotlin</span>
 </div>
 
 As AI agents grow in capability, ensuring they operate safely, securely, and align with your brand values is paramount. Uncontrolled agents can pose risks, including executing misaligned or harmful actions, such as data exfiltration, and generating inappropriate content that can impact your brand’s reputation. **Sources of risk include vague instructions, model hallucination, jailbreaks and prompt injections from adversarial users, and indirect prompt injections via tool use.**
@@ -359,13 +359,38 @@ Gemini models come with in-built safety mechanisms that can be leveraged to impr
     	// ...
     	GenerateContentConfig: &genai.GenerateContentConfig{
     		SafetySettings: []*genai.SafetySetting{
-    			{
+    			    		{
     				Category:  genai.HarmCategoryHateSpeech,
     				Threshold: genai.HarmBlockThresholdBlockLowAndAbove,
     			},
     		},
     	},
     })
+    ```
+
+=== "Kotlin"
+
+    ```kotlin
+    import com.google.adk.kt.agents.LlmAgent
+    import com.google.adk.kt.types.GenerateContentConfig
+    import com.google.adk.kt.types.HarmBlockThreshold
+    import com.google.adk.kt.types.HarmCategory
+    import com.google.adk.kt.types.SafetySetting
+
+    val agent =
+        LlmAgent(
+            // ...
+            generateContentConfig =
+                GenerateContentConfig(
+                    safetySettings =
+                        listOf(
+                            SafetySetting(
+                                category = HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+                                threshold = HarmBlockThreshold.OFF,
+                            ),
+                        ),
+                ),
+        )
     ```
 
 * **System instructions for safety**: [System instructions](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/safety-system-instructions) for Gemini models on Agent Platform provide direct guidance to the model on how to behave and what type of content to generate. By providing specific instructions, you can proactively steer the model away from generating undesirable content to meet your organization’s unique needs. You can craft system instructions to define content safety guidelines, such as prohibited and sensitive topics, and disclaimer language, as well as brand safety guidelines to ensure the model's outputs align with your brand's voice, tone, values, and target audience.

--- a/docs/safety/index.md
+++ b/docs/safety/index.md
@@ -359,7 +359,7 @@ Gemini models come with in-built safety mechanisms that can be leveraged to impr
     	// ...
     	GenerateContentConfig: &genai.GenerateContentConfig{
     		SafetySettings: []*genai.SafetySetting{
-    			    		{
+    			{
     				Category:  genai.HarmCategoryHateSpeech,
     				Threshold: genai.HarmBlockThresholdBlockLowAndAbove,
     			},

--- a/examples/kotlin/snippets/agents/llm-agent/CapitalAgent.kt
+++ b/examples/kotlin/snippets/agents/llm-agent/CapitalAgent.kt
@@ -2,6 +2,7 @@ package com.google.adk.kt.examples.agents.llmagent
 
 import com.google.adk.kt.agents.Instruction
 import com.google.adk.kt.agents.LlmAgent
+import com.google.adk.kt.agents.LlmAgent.IncludeContents
 import com.google.adk.kt.annotations.Param
 import com.google.adk.kt.annotations.Tool
 import com.google.adk.kt.models.Gemini
@@ -9,7 +10,10 @@ import com.google.adk.kt.runners.InMemoryRunner
 import com.google.adk.kt.sessions.InMemorySessionService
 import com.google.adk.kt.types.Content
 import com.google.adk.kt.types.GenerateContentConfig
+import com.google.adk.kt.types.HarmBlockThreshold
+import com.google.adk.kt.types.HarmCategory
 import com.google.adk.kt.types.Part
+import com.google.adk.kt.types.SafetySetting
 import com.google.adk.kt.types.Schema
 import com.google.adk.kt.types.Type
 import kotlinx.coroutines.flow.collect
@@ -77,8 +81,16 @@ fun main() =
                 model = Gemini(name = "gemini-flash-latest"),
                 generateContentConfig =
                     GenerateContentConfig(
+                        // More deterministic output
                         temperature = 0.2f,
                         maxOutputTokens = 250,
+                        safetySettings =
+                            listOf(
+                                SafetySetting(
+                                    category = HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+                                    threshold = HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+                                ),
+                            ),
                     ),
             )
         // --8<-- [end:gen_config]
@@ -122,6 +134,16 @@ fun main() =
                 outputKey = "found_capital",
             )
         // --8<-- [end:schema_example]
+
+        // --8<-- [start:include_contents]
+        val statelessAgent =
+            LlmAgent(
+                name = "capital_agent",
+                model = Gemini(name = "gemini-flash-latest"),
+                // ... other params
+                includeContents = IncludeContents.NONE,
+            )
+        // --8<-- [end:include_contents]
 
         // --8<-- [start:full_example]
         val finalAgent =


### PR DESCRIPTION
## What

Three related Kotlin parity gaps, all resting on the same three types (`SafetySetting`, `HarmCategory`, `HarmBlockThreshold`), so they are fixed together:

| Page | Gap |
| --- | --- |
| `docs/safety/index.md` | No Kotlin tab in the built-in Gemini safety section, and no Kotlin in the badge div |
| `docs/agents/llm-agents.md` (`gen_config`) | Kotlin tab existed but set only `temperature` and `maxOutputTokens`; the Python sibling also sets safety settings |
| `docs/agents/llm-agents.md` (`include_contents`) | No Kotlin tab |

None of this is new API — safety settings landed in adk-kotlin 0.5.0, `includeContents` has been on `LlmAgent` since 0.1.0.

## The gap class worth noting

The `gen_config` case is a Kotlin tab that *exists* but under-shows the feature. A "missing Kotlin tab" scan cannot see it, and neither can a symbol diff, since every symbol the tab names is present. Only comparing a tab's contents against its siblings surfaces it.

## Review notes

- **The safety page tab is inline, not a transclusion.** Its siblings are inline, and like them the snippet elides the required `name` and `model` arguments, so there is nothing there that could compile standalone. It is covered by L0 (imports and named arguments checked against real v0.8.0 signatures) but not by the compiler — the same level of assurance the Python and Go tabs on that page get.
- **`gen_config` now shows more than the TypeScript and Java tabs do.** Those two also omit safety settings. This PR brings Kotlin to parity with Python, the semantic source for the group, and deliberately does not touch sibling-language tabs. The TS/Java gap is left as-is.
- **The safety page badge div carries no version numbers** for any language, so the Kotlin span follows suit and reads just `Kotlin`.

## :warning: Conflicts with #2151

Both branches modify `examples/kotlin/snippets/agents/llm-agent/CapitalAgent.kt`, and #2151 inserts its `schema_example` region at the same anchor this one inserts `include_contents` — immediately after `[end:gen_config]`. The import blocks also overlap. Both sides are pure additions, so the resolution is mechanical, but **please land #2151 first and let me rebase**, rather than merging this one on top blind.

## Verification

Grounded against the `v0.8.0` git tag. Full ladder green (L0, L1 compile with KSP, L2 ktlint, L3, L5, L6). L4 `runSnippets` reports SKIP — no such Gradle task exists in this repo.

Tracked as KT-25, KT-32 and KT-36.