### PR TITLE
Retarget the ZoomInfo MCP links after the vendor moved its docs

### DIFF
--- a/docs/integrations/zoominfo.md
+++ b/docs/integrations/zoominfo.md
@@ -11,7 +11,7 @@ catalog_tags: ["mcp", "connectors"]
   <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span><span class="lst-typescript">TypeScript</span>
 </div>
 
-The [ZoomInfo MCP Server](https://docs.zoominfo.com/docs/connect-to-zoominfo-mcp)
+The [ZoomInfo MCP Server](https://gtm.ai/docs/mcp)
 connects your ADK agent to the [ZoomInfo](https://www.zoominfo.com/) B2B
 intelligence platform, giving it access to 100M+ company profiles, 300M+
 professional contacts, and go-to-market signals. This integration gives your
@@ -131,6 +131,6 @@ Tool | Description
 
 ## Additional resources
 
-- [Connect to ZoomInfo MCP](https://docs.zoominfo.com/docs/connect-to-zoominfo-mcp)
+- [Connect to ZoomInfo MCP](https://gtm.ai/docs/mcp/getting-started)
 - [Available MCP Tools](https://docs.zoominfo.com/docs/available-mcp-tools)
 - [ZoomInfo Developer Documentation](https://docs.zoominfo.com/)


### PR DESCRIPTION
## What

Two links in `docs/integrations/zoominfo.md` pointed at `https://docs.zoominfo.com/docs/connect-to-zoominfo-mcp`, which now returns **404**. ZoomInfo moved its MCP documentation to `gtm.ai`.

| Location | Old (404) | New (200) |
| --- | --- | --- |
| Overview paragraph, "ZoomInfo MCP Server" | `docs.zoominfo.com/docs/connect-to-zoominfo-mcp` | `gtm.ai/docs/mcp` |
| Additional resources, "Connect to ZoomInfo MCP" | same | `gtm.ai/docs/mcp/getting-started` |

The overview link goes to the MCP landing page; the Additional resources entry goes to `getting-started`, which is the page that actually covers connecting a client — matching what the link text promises.

## Why it is worth fixing promptly

`link-check` scans the **whole repo** on every pull request, not just changed files. This one dead link is currently the *only* error in the repo:

```
🔍 Total 1685 | ✅ Successful 1435 | 🔀 Redirected 198 | 👻 Excluded 51 | 🚫 Errors 1
```

so it fails `link-check` on every open PR, not just ones touching this page. It is recent — the job passed on `main` and on open PRs as late as Aug 19.

## Scope

Only the two dead URLs changed. The page's other ZoomInfo links were re-checked and left alone because they still resolve:

- `docs.zoominfo.com/docs/available-mcp-tools` → 200
- `docs.zoominfo.com/` → 200
- `www.zoominfo.com/` and `/free-trial-contact-sales` → 200

`https://mcp.zoominfo.com/mcp` returns 401, but it is the server endpoint inside a config code block rather than a documentation link, and `link-check` has never flagged it.

## Verification

Every external URL on the page was fetched after the change; all return 200 except the auth-gated MCP endpoint noted above. Both replacement pages were opened and confirmed to carry the ZoomInfo MCP connection content.
