### PR TITLE
docs(integrations): fix broken a2ui-agent-sdk imports in A2UI guide

### DIFF
--- a/docs/integrations/a2ui.md
+++ b/docs/integrations/a2ui.md
@@ -32,16 +32,19 @@ pip install a2ui-agent-sdk
 
 ### 1. Set up the Schema Manager
 
-The `A2uiSchemaManager` loads component catalogs and generates system prompts
-that teach the LLM how to produce valid A2UI JSON.
+The `DirectJsonFormat` schema manager loads component catalogs and generates
+system prompts that teach the LLM how to produce valid A2UI JSON.
 
 ```python
-from a2ui.core.schema.manager import A2uiSchemaManager
+from a2ui.schema.constants import VERSION_0_9
+from a2ui.inference_formats.direct_json import DirectJsonFormat
 from a2ui.basic_catalog.provider import BasicCatalog
 
-schema_manager = A2uiSchemaManager(
+schema_manager = DirectJsonFormat(
+    version=VERSION_0_9,
     catalogs=[
         BasicCatalog.get_config(
+            version=VERSION_0_9,
             examples_path="examples",
         ),
     ],
@@ -99,8 +102,8 @@ Always validate the LLM's JSON output before sending it to the client. The SDK
 provides parsing, fixing, and validation utilities:
 
 ```python
-from a2ui.core.parser.parser import parse_response
-from a2ui.a2a import parse_response_to_parts
+from a2ui.parser.parser import parse_response
+from a2ui.a2a.parts import parse_response_to_parts
 
 # Get the active catalog's validator
 selected_catalog = schema_manager.get_selected_catalog()
@@ -123,7 +126,7 @@ A2UI payloads are wrapped in A2A `DataPart` with the MIME type
 `application/json+a2ui` so renderers can identify them:
 
 ```python
-from a2ui.a2a import create_a2ui_part
+from a2ui.a2a.parts import create_a2ui_part
 
 part = create_a2ui_part({"type": "Card", "props": {"title": "Hello"}})
 # → DataPart(data={...}, metadata={"mimeType": "application/json+a2ui"})
@@ -171,11 +174,15 @@ async def _prepare_session(self, context, run_request, runner):
 You can define your own component catalogs for domain-specific UI:
 
 ```python
-from a2ui.core.schema.manager import CatalogConfig
+from a2ui.schema.constants import VERSION_0_9
+from a2ui.schema.catalog import CatalogConfig
+from a2ui.inference_formats.direct_json import DirectJsonFormat
+from a2ui.basic_catalog.provider import BasicCatalog
 
-schema_manager = A2uiSchemaManager(
+schema_manager = DirectJsonFormat(
+    version=VERSION_0_9,
     catalogs=[
-        BasicCatalog.get_config(),
+        BasicCatalog.get_config(version=VERSION_0_9),
         CatalogConfig.from_path(
             name="my_dashboard_catalog",
             catalog_path="catalogs/dashboard.json",
@@ -191,7 +198,8 @@ Orchestrator agents can aggregate A2UI capabilities from sub-agents and
 advertise them in the agent card:
 
 ```python
-from a2ui.a2a import get_a2ui_agent_extension
+from a2ui.schema.constants import VERSION_0_9
+from a2ui.a2a.extension import get_a2ui_agent_extension
 
 # Collect catalog IDs from sub-agents
 supported_catalog_ids = set()
@@ -207,6 +215,7 @@ agent_card = AgentCard(
     capabilities=AgentCapabilities(
         extensions=[
             get_a2ui_agent_extension(
+                version=VERSION_0_9,
                 supported_catalog_ids=list(supported_catalog_ids),
             )
         ]


### PR DESCRIPTION
## Problem

Every Python code block on the [A2UI integration page](docs/integrations/a2ui.md) fails against the released `a2ui-agent-sdk` 0.5.0:

- `from a2ui.core.schema.manager import A2uiSchemaManager` -> `ModuleNotFoundError: No module named 'a2ui.core.schema.manager'` (there is no `a2ui.core` namespace in `a2ui-agent-sdk`; `A2uiSchemaManager` lives in `a2ui.schema.manager`, and the recommended class is `DirectJsonFormat` in `a2ui.inference_formats.direct_json`)
- `from a2ui.core.parser.parser import parse_response` -> `ModuleNotFoundError: No module named 'a2ui.core.parser'` (real path: `a2ui.parser.parser`)
- `from a2ui.a2a import parse_response_to_parts` / `from a2ui.a2a import create_a2ui_part` / `from a2ui.a2a import get_a2ui_agent_extension` -> `ImportError` (the `a2ui.a2a` package has no `__init__.py`; these symbols live in `a2ui.a2a.parts` and `a2ui.a2a.extension`)
- `DirectJsonFormat(...)`, `BasicCatalog.get_config(...)`, and `get_a2ui_agent_extension(...)` were called without the required `version` argument -> `TypeError: missing 1 required positional argument: 'version'`

## Fix

- Pointed every import at the real module paths (`a2ui.inference_formats.direct_json`, `a2ui.parser.parser`, `a2ui.a2a.parts`, `a2ui.a2a.extension`, `a2ui.schema.catalog`, `a2ui.schema.constants`).
- Switched the schema manager to the recommended, non-deprecated `DirectJsonFormat` class (`A2uiSchemaManager` in `a2ui.schema.manager` is a deprecated compatibility shim).
- Added `version=VERSION_0_9` (imported from `a2ui.schema.constants`) to `DirectJsonFormat`, `BasicCatalog.get_config`, and `get_a2ui_agent_extension`.

## Verification

Installed `a2ui-agent-sdk==0.5.0` (with its declared deps `a2ui-core` and `a2a-sdk`) in a clean virtualenv and executed every code block from the updated page end-to-end, including `generate_system_prompt`, `parse_response` + `selected_catalog.validator.validate`, `parse_response_to_parts`, `create_a2ui_part`, and `get_a2ui_agent_extension`. All blocks pass.

Fixes the import reported in #2131 and the additional broken imports found on the same page.