### PR TITLE
Update experimental JSON schema per issue #1048

### DIFF
--- a/docs/tools-custom/function-tools.md
+++ b/docs/tools-custom/function-tools.md
@@ -273,6 +273,121 @@ LLM. The LLM will not be aware of them and cannot pass arguments to them. It's
 best to rely on explicitly defined parameters for all data you expect from the
 LLM.
 
+##### Configure JSON schema tool declarations
+
+ADK generates JSON schemas from your function signatures using Pydantic for model function declarations. This feature (`JSON_SCHEMA_FOR_FUNC_DECL`) is **enabled by default** in ADK. 
+
+You can explicitly control or override this behavior using environment variables or directly in Python.
+
+###### Option 1: Configure via Command Line
+
+Set the appropriate environment variable in your terminal before launching your agent process:
+
+=== "macOS/Linux"
+
+    ```bash
+    export ADK_ENABLE_JSON_SCHEMA_FOR_FUNC_DECL=1
+    ```
+    
+=== "Windows (Command Prompt)"
+
+    ```cmd
+    set ADK_ENABLE_JSON_SCHEMA_FOR_FUNC_DECL=1
+    ```
+    
+=== "Windows (PowerShell)"
+
+    ```powershell
+    $env:ADK_ENABLE_JSON_SCHEMA_FOR_FUNC_DECL="1"
+    ```
+
+To disable JSON schema generation and fall back to legacy manual type parsing:
+
+=== "macOS/Linux"
+
+    ```bash
+    export ADK_DISABLE_JSON_SCHEMA_FOR_FUNC_DECL=1
+    ```
+
+=== "Windows (Command Prompt)"
+
+    ```cmd
+    set ADK_DISABLE_JSON_SCHEMA_FOR_FUNC_DECL=1
+    ```
+
+=== "Windows (PowerShell)"
+
+    ```powershell
+    $env:ADK_DISABLE_JSON_SCHEMA_FOR_FUNC_DECL="1"
+    ```
+
+###### Option 2: Configure in Python
+
+Use ADK's `override_feature_enabled` function before creating tools and agents:
+
+```python
+import asyncio
+from google.adk.features import FeatureName, override_feature_enabled
+from google.adk.agents import Agent
+from google.adk.tools import FunctionTool
+
+# Programmatically enable or disable the feature
+override_feature_enabled(FeatureName.JSON_SCHEMA_FOR_FUNC_DECL, True)
+
+def get_current_weather(location: str, unit: str = "celsius") -> str:
+    """Get the current weather for a given location.
+    
+    Args:
+        location: The city and state, e.g. San Francisco, CA
+        unit: Temperature unit ('celsius' or 'fahrenheit')
+    """
+    return f"Weather in {location}: 22° {unit.capitalize()}"
+
+async def main():
+    weather_tool = FunctionTool(func=get_current_weather)
+    
+    agent = Agent(
+        model="gemini-2.5-flash",
+        name="my_agent",
+        instruction="You are a helpful assistant.",
+        tools=[weather_tool]
+    )
+    # Execution logic here
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Alternatively, set the environment variable in your script before initializing agent components:
+
+```python
+import os
+import asyncio
+
+os.environ["ADK_ENABLE_JSON_SCHEMA_FOR_FUNC_DECL"] = "1"
+
+from google.adk.agents import Agent
+from google.adk.tools import FunctionTool
+
+def get_current_weather(location: str) -> str:
+    """Get the current weather for a given location."""
+    return f"Weather in {location}: 20°C"
+
+async def main():
+    weather_tool = FunctionTool(func=get_current_weather)
+    
+    agent = Agent(
+        model="gemini-2.5-flash",
+        name="my_agent",
+        instruction="You are a helpful assistant.",
+        tools=[weather_tool]
+    )
+    # Execution logic here
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
 #### Context injection
 
 Context injection allows your custom functions to access the agent's


### PR DESCRIPTION
Adds documentation for the experimental JSON schema-based function declaration feature to `function-tools.md`. 

Includes:
* An explanation of the `ADK_ENABLE_JSON_SCHEMA_FOR_FUNC_DECL` environment variable.
* CLI instructions for enabling and disabling the feature across macOS, Linux, and Windows (CMD & PowerShell) using tabbed code blocks.
* A Python code snippet demonstrates how to explicitly configure the feature in-code.

---

### 1. JSON Schema Generation Capability & Default Status

#### Quoted Claim
> "ADK automatically generates JSON schemas from your function signatures using Pydantic for model function declarations. This feature (`JSON_SCHEMA_FOR_FUNC_DECL`) is **enabled by default** in ADK."

  1. `FeatureName.JSON_SCHEMA_FOR_FUNC_DECL` is registered in `_FEATURE_REGISTRY` with `FeatureConfig(FeatureStage.EXPERIMENTAL, default_on=True)`.
  2. When constructing a `FunctionTool`, `_get_declaration()` passes `is_feature_enabled(FeatureName.JSON_SCHEMA_FOR_FUNC_DECL)` to `build_function_declaration()`, which delegates to `_function_tool_declarations.build_function_declaration_with_json_schema()`.
  3. `_build_parameters_json_schema()` extracts parameter types from the callable using Python `inspect` and `get_type_hints`, dynamically generates a Pydantic model via `pydantic.create_model`, and exports the schema using `model_json_schema()`.
- **Citations:**
  - [`src/google/adk/features/_feature_registry.py#L52`](https://github.com/google/adk-python/blob/main/src/google/adk/features/_feature_registry.py#L52)
  - [`src/google/adk/features/_feature_registry.py#L174-L176`](https://github.com/google/adk-python/blob/main/src/google/adk/features/_feature_registry.py#L174-L176)
  - [`src/google/adk/tools/_automatic_function_calling_util.py#L220-L237`](https://github.com/google/adk-python/blob/main/src/google/adk/tools/_automatic_function_calling_util.py#L220-L237)
  - [`src/google/adk/tools/_function_tool_declarations.py#L15-L23`](https://github.com/google/adk-python/blob/main/src/google/adk/tools/_function_tool_declarations.py#L15-L23)
  - [`src/google/adk/tools/_function_tool_declarations.py#L191-L215`](https://github.com/google/adk-python/blob/main/src/google/adk/tools/_function_tool_declarations.py#L191-L215)
  - [`src/google/adk/tools/_function_tool_declarations.py#L282-L356`](https://github.com/google/adk-python/blob/main/src/google/adk/tools/_function_tool_declarations.py#L282-L356)
  - [`src/google/adk/tools/function_tool.py#L145-L156`](https://github.com/google/adk-python/blob/main/src/google/adk/tools/function_tool.py#L145-L156)

---

### 2. Feature Resolution Hierarchy & Environment Variables

#### Quoted Claim
> "You can explicitly control or override this behavior using environment variables or directly in Python code."

- **Status:** `PASS`
- **Verification Details:**
  `is_feature_enabled()` implements a strict 3-tier priority resolution:
  1. **Programmatic Overrides:** Checked in `_FEATURE_OVERRIDES` (set via `override_feature_enabled()`).
  2. **Environment Variables:** `ADK_ENABLE_<NAME>` returns `True` if set to `1` or `true`. If not enabled, `ADK_DISABLE_<NAME>` returns `False` if set to `1` or `true`.
  3. **Registry Default:** Returns `config.default_on` (`True` for `JSON_SCHEMA_FOR_FUNC_DECL`).
- **Citations:**
  - [`src/google/adk/features/_feature_registry.py#L258-L284`](https://github.com/google/adk-python/blob/main/src/google/adk/features/_feature_registry.py#L258-L284)
  - [`src/google/adk/features/_feature_registry.py#L286-L344`](https://github.com/google/adk-python/blob/main/src/google/adk/features/_feature_registry.py#L286-L344)
  - [`src/google/adk/utils/env_utils.py#L27-L60`](https://github.com/google/adk-python/blob/main/src/google/adk/utils/env_utils.py#L27-L60)
  - [`docs/guides/features/feature_registry/index.md#L36-L90`](https://github.com/google/adk-python/blob/main/docs/guides/features/feature_registry/index.md#L36-L90)

---

### 3. Option 1: Command Line Configuration (Enable & Disable)

- **Verification Details:**
  - `ADK_ENABLE_JSON_SCHEMA_FOR_FUNC_DECL` is formed dynamically via `f"ADK_ENABLE_{feature_name_str}"`.
  - `ADK_DISABLE_JSON_SCHEMA_FOR_FUNC_DECL` is formed dynamically via `f"ADK_DISABLE_{feature_name_str}"`.
  - `is_env_enabled()` executes `os.environ.get(env_var_name, default).lower() in ['true', '1']`. Setting `"1"` in Bash, CMD, and PowerShell satisfies this requirement.
- **Citations:**
  - [`src/google/adk/features/_feature_registry.py#L331-L339`](https://github.com/google/adk-python/blob/main/src/google/adk/features/_feature_registry.py#L331-L339)
  - [`src/google/adk/utils/env_utils.py#L27-L60`](https://github.com/google/adk-python/blob/main/src/google/adk/utils/env_utils.py#L27-L60)
  - [`docs/guides/features/feature_registry/index.md#L39-L54`](https://github.com/google/adk-python/blob/main/docs/guides/features/feature_registry/index.md#L39-L54)

---

### 4. Option 2 - Method A: Programmatic Feature Override

- **Verification Details:**
  1. `FeatureName` and `override_feature_enabled` are exported in `src/google/adk/features/__init__.py`.
  2. `override_feature_enabled(FeatureName.JSON_SCHEMA_FOR_FUNC_DECL, True)` registers the boolean in `_FEATURE_OVERRIDES`, superseding environment variables and defaults.
  3. `FunctionTool(func=...)` receives callable `get_current_weather`, parses its docstring, annotations, and parameters cleanly.
  4. `Agent(model="gemini-2.5-flash", name="my_agent", instruction="...", tools=[...])` matches:
     - `name`: `str` validated identifier from `BaseNode` (`src/google/adk/workflow/_base_node.py#L48-L56`).
     - `model`: `Union[str, BaseLlm]` from `LlmAgent` (`src/google/adk/agents/llm_agent.py#L291`).
     - `instruction`: `Union[str, InstructionProvider]` from `LlmAgent` (`src/google/adk/agents/llm_agent.py#L314`).
     - `tools`: `list[ToolUnion]` from `LlmAgent` (`src/google/adk/agents/llm_agent.py#L392`).
- **Citations:**
  - [`src/google/adk/features/__init__.py#L1-L26`](https://github.com/google/adk-python/blob/main/src/google/adk/features/__init__.py#L1-L26)
  - [`src/google/adk/features/_feature_registry.py#L258-L279`](https://github.com/google/adk-python/blob/main/src/google/adk/features/_feature_registry.py#L258-L279)
  - [`src/google/adk/agents/__init__.py#L29-L62`](https://github.com/google/adk-python/blob/main/src/google/adk/agents/__init__.py#L29-L62)
  - [`src/google/adk/agents/llm_agent.py#L260-L394`](https://github.com/google/adk-python/blob/main/src/google/adk/agents/llm_agent.py#L260-L394)
  - [`src/google/adk/agents/llm_agent.py#L1451`](https://github.com/google/adk-python/blob/main/src/google/adk/agents/llm_agent.py#L1451)
  - [`src/google/adk/tools/__init__.py#L34-L72`](https://github.com/google/adk-python/blob/main/src/google/adk/tools/__init__.py#L34-L72)
  - [`src/google/adk/tools/function_tool.py#L99-L143`](https://github.com/google/adk-python/blob/main/src/google/adk/tools/function_tool.py#L99-L143)
  - [`src/google/adk/workflow/_base_node.py#L48-L56`](https://github.com/google/adk-python/blob/main/src/google/adk/workflow/_base_node.py#L48-L56)

---

### 5. Option 2 - Method B: In-Script Environment Variable Setting

- **Verification Details:**
  `is_feature_enabled()` does not cache initial `os.environ` lookups at import time; it evaluates `os.environ` on every invocation when resolving flags. Setting `os.environ` before tool declaration instantiation takes effect reliably.
- **Citations:**
  - [`src/google/adk/features/_feature_registry.py#L331-L336`](https://github.com/google/adk-python/blob/main/src/google/adk/features/_feature_registry.py#L331-L336)
  - [`src/google/adk/utils/env_utils.py#L27-L60`](https://github.com/google/adk-python/blob/main/src/google/adk/utils/env_utils.py#L27-L60)
  - [`docs/guides/features/feature_registry/index.md#L99-L100`](https://github.com/google/adk-python/blob/main/docs/guides/features/feature_registry/index.md#L99-L100)
