### PR TITLE
Add queryresultmode per issue #1048

### DIFF
--- a/docs/integrations/spanner.md
+++ b/docs/integrations/spanner.md
@@ -142,6 +142,10 @@ The `SpannerVectorStoreSettings` class used above defines how
   as `COSINE` or `EUCLIDEAN`.
 - **`additional_filter`**: An optional SQL filter string to apply during the
   search, for example: "inventoryCount > 0".
+- **`query_result_mode`**: Determines the format in 
+  which the `execute_sql` tool returns database query results. Setting this 
+  parameter to `QueryResultMode.DICT_LIST` configures the tool to return the 
+  results as a list of dictionaries.
 
 ## Spanner Admin Toolset
 


### PR DESCRIPTION
Staged link> https://deploy-preview-2183--adk-docs-preview.netlify.app/integrations/spanner/
Documents the new query_result_mode optional parameter in SpannerToolSettings, which configures the execute_sql tool to return database query results as a list of dictionaries.

**Agent's PR**: #1054 and #1055 

---

## Citations

- **`QueryResultMode` Definition:**
  [`src/google/adk/tools/spanner/settings.py#L48-L60`](https://github.com/google/adk-python/blob/main/src/google/adk/tools/spanner/settings.py#L48-L60)
- **`SpannerToolSettings.query_result_mode` Field:**
  [`src/google/adk/tools/spanner/settings.py#L251-L269`](https://github.com/google/adk-python/blob/main/src/google/adk/tools/spanner/settings.py#L251-L269)
- **`execute_sql` Query Processing (`to_dict_list`):**
  [`src/google/adk/tools/spanner/utils.py#L111-L130`](https://github.com/google/adk-python/blob/main/src/google/adk/tools/spanner/utils.py#L111-L130)
- **`get_execute_sql` Tool Factory & Docstring Wrapper:**
  [`src/google/adk/tools/spanner/query_tool.py#L171-L196`](https://github.com/google/adk-python/blob/main/src/google/adk/tools/spanner/query_tool.py#L171-L196)