### PR TITLE
docs(integrations): use Agent Platform client in Express Mode example

### DIFF
--- a/docs/integrations/express-mode.md
+++ b/docs/integrations/express-mode.md
@@ -56,15 +56,14 @@ Next, create your Agent Runtime instance using the Agent Platform SDK.
 1. Import Agent Platform SDK.
 
     ```py
-    import vertexai
-    from vertexai import agent_engines
+    import agentplatform
     ```
 
 2. Initialize the Agent Platform Client with your API key and create an agent engine instance.
 
     ```py
     # Create Agent Runtime with Gen AI SDK
-    client = vertexai.Client(
+    client = agentplatform.Client(
       api_key="YOUR_API_KEY",
     )
 


### PR DESCRIPTION
### What

Use `agentplatform.Client` in the Express Mode Agent Runtime example instead of the deprecated
`vertexai.Client` entry point.

### Why

Running the documented client construction with `google-cloud-aiplatform==1.165.1` emits:

```text
FutureWarning: The vertexai.Client class is deprecated. Please use agentplatform.Client instead.
```

The page currently directs new Express Mode users through that deprecated constructor.

### How

- Import `agentplatform` instead of `vertexai`.
- Construct `agentplatform.Client` with the existing Express Mode API key.
- Retain `client.agent_engines.create(...)`, which is the runtime collection exposed by the
  released `1.165.1` SDK.

### Test

With `google-cloud-aiplatform[agent_engines]==1.165.1`:

```text
vertexai.Client warnings: [FutureWarning: ... use agentplatform.Client instead.]
agentplatform.Client warnings: []
agentplatform.Client.agent_engines: AgentEngines
agentplatform.Client.agent_engines.create: present
```

The check constructs the clients without sending a request. I also confirmed the edited snippet is
valid Python. Runtime creation itself still requires an Express Mode API key.

```text
git apply --check: passed
git diff --check: passed
mkdocs build --strict: passed (230 pages indexed)
```

### Scope

This changes only the deprecated client entry point in the Express Mode creation example. It does
not migrate other pages or adopt the unreleased `client.runtimes` rename.

### Related

PR #2019 updates installation extras and a link later in this page. It does not change the client
constructor, so this is a separate correction.
