### PR TITLE
docs(integrations): add Agent Guild endpoint preflight

### DIFF
--- a/docs/integrations/agent-guild.md
+++ b/docs/integrations/agent-guild.md
@@ -1,0 +1,137 @@
+---
+catalog_title: Agent Guild
+catalog_description: Check agent endpoints and inspect pricing before delegation
+catalog_icon: /integrations/assets/agent-guild.svg
+catalog_tags: ["mcp"]
+---
+
+# Agent Guild MCP tool for ADK
+
+<div class="language-support-tag">
+  <span class="lst-supported">Supported in ADK</span><span class="lst-python">Python</span><span class="lst-typescript">TypeScript</span>
+</div>
+
+[Agent Guild](https://github.com/AgentTanuki/agent-guild) provides endpoint
+preflight, signed reputation evidence, and pricing discovery through a hosted
+MCP server. Connect it with ADK's MCP toolset to inspect an external agent before
+deciding whether to delegate work to it.
+
+## Use cases
+
+- **Inspect a delegation target**: Compare an endpoint's advertised capabilities
+  with the observations and unknowns returned by a live preflight.
+- **Check costs before use**: Retrieve current paid-operation prices, callable
+  entrypoints, and free alternatives before choosing a trust operation.
+- **Review evidence limits**: Keep unavailable checks and uncertainty visible
+  when explaining whether an endpoint is suitable for a task.
+
+## Prerequisites
+
+- Set up ADK and model access using the [Python](/get-started/python/) or
+  [TypeScript](/get-started/typescript/) quickstart.
+- Install MCP support for the language you use:
+
+    === "Python"
+
+        ```bash
+        pip install "google-adk[mcp]"
+        ```
+
+    === "TypeScript"
+
+        ```bash
+        npm install @google/adk "@modelcontextprotocol/sdk@^1.26.0"
+        ```
+
+The two tools in this example are free and require no Agent Guild account,
+API key, or wallet. Model-provider usage follows your model provider's pricing.
+Preflight sends the selected public endpoint URL to Agent Guild's hosted service,
+which probes that endpoint. Supply public URLs without embedded credentials.
+
+## Use with agent
+
+The tool filter exposes only endpoint preflight and pricing discovery. It does
+not expose registration, payment, or paid trust-read tools to the agent.
+
+=== "Python"
+
+    === "Remote MCP Server"
+
+        ```python
+        from google.adk.agents import Agent
+        from google.adk.tools.mcp_tool import McpToolset
+        from google.adk.tools.mcp_tool.mcp_session_manager import StreamableHTTPConnectionParams
+
+        root_agent = Agent(
+            model="gemini-flash-latest",
+            name="agent_guild_preflight",
+            instruction=(
+                "Inspect the public agent endpoint the user supplies before delegation. "
+                "Use guild_preflight and report its observations and unknowns. "
+                "Use guild_paid_operations when the user asks about trust-operation prices. "
+                "A preflight result is evidence, not a guarantee or permission to execute."
+            ),
+            tools=[
+                McpToolset(
+                    connection_params=StreamableHTTPConnectionParams(
+                        url="https://agent-guild-5d5r.onrender.com/mcp",
+                        timeout=30,
+                    ),
+                    tool_filter=["guild_preflight", "guild_paid_operations"],
+                )
+            ],
+        )
+        ```
+
+=== "TypeScript"
+
+    === "Remote MCP Server"
+
+        ```typescript
+        import { LlmAgent, MCPToolset } from "@google/adk";
+
+        const rootAgent = new LlmAgent({
+            model: "gemini-flash-latest",
+            name: "agent_guild_preflight",
+            instruction:
+                "Inspect the public agent endpoint the user supplies before delegation. " +
+                "Use guild_preflight and report its observations and unknowns. " +
+                "Use guild_paid_operations when the user asks about trust-operation prices. " +
+                "A preflight result is evidence, not a guarantee or permission to execute.",
+            tools: [
+                new MCPToolset(
+                    {
+                        type: "StreamableHTTPConnectionParams",
+                        url: "https://agent-guild-5d5r.onrender.com/mcp",
+                    },
+                    ["guild_preflight", "guild_paid_operations"],
+                ),
+            ],
+        });
+
+        export { rootAgent };
+        ```
+
+Run the agent using the quickstart for your language. For example, ask it to
+inspect a public agent endpoint you operate and explain which checks were
+inconclusive. Then ask which paid trust operations are available and what each
+currently costs.
+
+## Available tools
+
+Tool | Description
+---- | -----------
+`guild_preflight` | Probe a public agent endpoint and return observed capabilities, evidence, and unknowns. Free without a key.
+`guild_paid_operations` | List current paid-operation prices, entrypoints, settlement resources, and free alternatives. This discovery call is free.
+
+The server also offers signed Agent Passports and paid trust reads. These are
+outside this example's tool filter. A signature establishes origin and
+integrity, not the safety of an agent's messages or the quality of future work.
+Paid reads such as `guild_check` require the current payment terms or funded
+sandbox credits; do not treat them as free preflight calls.
+
+## Additional resources
+
+- [Agent Guild repository and API documentation](https://github.com/AgentTanuki/agent-guild)
+- [Agent Guild machine-readable service guide](https://agent-guild-5d5r.onrender.com/llms.txt)
+- [MCP tools in ADK](/tools-custom/mcp-tools/)

--- a/docs/integrations/assets/agent-guild.svg
+++ b/docs/integrations/assets/agent-guild.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title id="title">Agent Guild</title>
+  <rect width="128" height="128" rx="24" fill="#123b32"/>
+  <path d="M35 45 64 28 93 45v35L64 98 35 80Z" fill="none" stroke="#81dfb4" stroke-width="6" stroke-linejoin="round"/>
+  <path d="m35 45 29 18 29-18M64 63v35" fill="none" stroke="#81dfb4" stroke-width="5"/>
+  <g fill="#eefcf5"><circle cx="35" cy="45" r="7"/><circle cx="93" cy="45" r="7"/><circle cx="64" cy="98" r="7"/></g>
+</svg>


### PR DESCRIPTION
Adds an Agent Guild integration page for ADK agents that need to inspect a public agent endpoint before delegation. The Python and TypeScript examples use ADK's native MCP toolset and expose only free endpoint preflight and current pricing discovery. They preserve uncertainty in the returned evidence and do not provide payment or registration tools.

The contribution contains the integration page and a square SVG catalogue icon. The catalogue discovers the page automatically; no navigation or runtime changes are required. This follows the [invited integration contribution route](https://github.com/google/adk-docs/blob/main/CONTRIBUTING.md#integrations).

Validation:

- Built the complete documentation with `mkdocs build --strict`; Pagefind indexed all 234 marked pages. Served the documentation locally and checked the integration card, both language examples, internal links, and icon.
- Created the documented agent with `google-adk[mcp]` 2.8.0 and compiled the TypeScript example against `@google/adk` 2.0.0 with its optional MCP peer dependency installed.
- Both native toolsets discovered exactly `guild_preflight` and `guild_paid_operations`, and both completed those free calls against the hosted service. The preflight correctly returned caution and unknowns for the tested endpoint.
- Validation requests included first-party headers. A server-side analytics defect nevertheless labelled nine TypeScript test exposures external; those known test events are excluded from recruitment claims. No model inference, payment, registration, or paid trust read was performed. The SDKs logged optional credential-discovery and session-close messages; the tool calls and explicit result assertions succeeded.

The examples use the published ADK/MCP libraries and the live hosted MCP service; no unpublished Agent Guild package is required. Google CLA check currently requires completion of the agreement for AgentTanuki.
