### PR TITLE
docs: explain LoggingPlugin output limits

### DIFF
--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -139,6 +139,20 @@ logging.basicConfig(
 )
 ```
 
+#### Console activity logging
+
+Add a `LoggingPlugin` to your runner's `plugins` list to print agent activity.
+By default, it truncates each text part and rendered system instruction to 200
+characters, and tool arguments and results to 300 characters. Set
+`max_content_length` and `max_args_length` to change these limits, or use `None`
+to disable truncation:
+
+```python
+from google.adk.plugins.logging_plugin import LoggingPlugin
+
+logging_plugin = LoggingPlugin(max_content_length=None, max_args_length=None)
+```
+
 #### Capture prompt content
 
 You can enable full prompt logging programmatically by setting an environment


### PR DESCRIPTION
Document the two LoggingPlugin output limits proposed for
google/adk-python#6056, including their existing defaults and using `None` to
disable truncation.

This draft adds 14 lines to the Python logging guide. It depends on the Python
implementation and should not be published ahead of that release.

Validation: executed the new Python example against the patched package and
checked the diff for whitespace errors. A full MkDocs site build was not run.

Implementation: https://github.com/google/adk-python/pull/7079
