### PR TITLE
docs(callbacks): align live after-agent callback timing

### DIFF
--- a/docs/callbacks/types-of-callbacks.md
+++ b/docs/callbacks/types-of-callbacks.md
@@ -121,7 +121,7 @@ These callbacks are available on *any* agent that inherits from `BaseAgent` (inc
 
 ### After Agent Callback
 
-**When:** Called *immediately after* the agent's `_run_async_impl` (or `_run_live_impl`) method successfully completes. It does *not* run if the agent was skipped due to `before_agent_callback` returning content. In Python, setting `end_invocation` during the agent's run also skips it, but only on the `run_async` path; `run_live` does not re-check `end_invocation` after `_run_live_impl` finishes, so the callback still runs there.
+**When:** Called *immediately after* the agent's `_run_async_impl` (or `_run_live_impl`) method successfully completes. It does *not* run if the agent was skipped due to `before_agent_callback` returning content. In Python, setting `end_invocation` during the agent's run also skips it on both the `run_async` and `run_live` paths.
 
 **Purpose:** Useful for cleanup tasks, post-execution validation, logging the completion of an agent's activity, or modifying final state.
 


### PR DESCRIPTION
## Summary

Update the after-agent callback timing note for Python to reflect that
`end_invocation` skips the callback in both async and live execution. The
companion runtime fix adds the missing post-execution check to `run_live()`.

Companion runtime PR: https://github.com/google/adk-python/pull/7081

Runtime issue: https://github.com/google/adk-python/issues/7080

This guide update should land with or after the runtime fix.

## Validation

- `mkdocs build --strict`: passed; Pagefind indexed 235 pages.
- `git diff --check`: passed.
- Verified the timing against the companion four-case regression test and a
  local `Runner.run_live()` smoke test.

Only the existing lifecycle timing paragraph changes; generated API reference
files are untouched.
