### PR TITLE
docs: fix 404 link to relocated Deep Search sample

### DIFF
--- a/docs/grounding/index.md
+++ b/docs/grounding/index.md
@@ -40,6 +40,6 @@ ADK supports multiple grounding approaches:
 
     A production-ready fullstack research agent that transforms topics into comprehensive reports with citations. Features a two-phase workflow with human-in-the-loop plan approval, iterative search refinement, and multi-agent architecture for planning, researching, critiquing, and composing.
 
-    - [Deep Search Agent](https://github.com/google/adk-samples/tree/main/python/agents/deep-search)
+    - [Deep Search Agent](https://github.com/google/adk-samples/tree/main/core/python/deep-search)
 
 </div>


### PR DESCRIPTION
## Summary

Fixes one of the four broken links currently failing the `Check external links` workflow on `main`.

The `adk-samples` repo restructured its layout, moving the Deep Search sample out of `python/agents/`. The link in the grounding overview was left pointing at the old path.

| | URL | Status |
|---|---|---|
| Before | `.../adk-samples/tree/main/python/agents/deep-search` | 404 |
| After | `.../adk-samples/tree/main/core/python/deep-search` | 200 |

New target verified: https://github.com/google/adk-samples/tree/main/core/python/deep-search

## Context

`main` has been failing the link check since 9f21af3c (Sep 10). Because [`link-checker.yaml`](https://github.com/google/adk-docs/blob/main/.github/workflows/link-checker.yaml#L41) globs `./**/*.md` (the whole repo, not just changed files), this breakage fails the check on **every open PR**, regardless of what those PRs touch.

The remaining three errors are dead `Perseus-Computing-LLC` links in `docs/integrations/perseus.md` and `docs/integrations/perseus-vault.md`; those are handled separately since they need the integration author's input.

## Testing

Verified the new URL returns 200 and the old one returns 404. No other occurrences of the stale path exist in the repo.