### PR TITLE
docs(integrations): remove dead Perseus repo links

### DIFF
--- a/docs/integrations/perseus-vault.md
+++ b/docs/integrations/perseus-vault.md
@@ -12,12 +12,11 @@ catalog_tags: ["data"]
 </div>
 
 The [`adk-perseus-vault-memory`](https://github.com/Perseus-Computing-LLC/adk-mimir-memory)
-integration connects your ADK agent to
-[Perseus Vault](https://github.com/Perseus-Computing-LLC/perseus-vault), a
-persistent, cross-session memory backend. Backed by a single Rust binary with an
-embedded SQLite database, it requires **zero cloud dependencies**, and everything
-runs locally. Memory is encrypted at rest with AES-256-GCM, and search combines
-FTS5 keyword matching with dense vector retrieval.
+integration connects your ADK agent to Perseus Vault, a persistent,
+cross-session memory backend. Backed by a single Rust binary with an embedded
+SQLite database, it requires **zero cloud dependencies**, and everything runs
+locally. Memory is encrypted at rest with AES-256-GCM, and search combines FTS5
+keyword matching with dense vector retrieval.
 
 ## Use cases
 
@@ -44,11 +43,9 @@ Install the Python package:
 pip install adk-perseus-vault-memory
 ```
 
-Then install the `perseus-vault` binary: download the build for your platform
-from the
-[releases page](https://github.com/Perseus-Computing-LLC/perseus-vault/releases)
-and place it on your `PATH`. The service looks for `perseus-vault` by default, or
-pass `vault_binary="/absolute/path/to/perseus-vault"` to
+Then install the `perseus-vault` binary and place it on your `PATH`. The service
+looks for `perseus-vault` by default, or pass
+`vault_binary="/absolute/path/to/perseus-vault"` to
 `PerseusVaultMemoryService`.
 
 ## Use with agent
@@ -146,5 +143,4 @@ session = await runner.session_service.create_session(
 
 - [adk-perseus-vault-memory on GitHub](https://github.com/Perseus-Computing-LLC/adk-mimir-memory)
 - [adk-perseus-vault-memory on PyPI](https://pypi.org/project/adk-perseus-vault-memory/)
-- [Perseus Vault (backing service)](https://github.com/Perseus-Computing-LLC/perseus-vault)
 - [Perseus Context integration](/integrations/perseus/)

--- a/docs/integrations/perseus.md
+++ b/docs/integrations/perseus.md
@@ -13,12 +13,10 @@ catalog_tags: ["data", "mcp"]
 
 The [`adk-perseus-context`](https://github.com/Perseus-Computing-LLC/adk-perseus-context)
 integration injects a deterministically compiled context into your ADK agent's
-system instruction. It is powered by
-[Perseus](https://github.com/Perseus-Computing-LLC/perseus), an open-source
-context compiler: Perseus resolves directives like `@file`, `@search`, and
-`@memory` into one byte-stable context string at inference time, with no
-retrieval index, no embeddings, and no extra LLM round-trip. Everything runs
-locally.
+system instruction. It is powered by Perseus, an open-source context compiler:
+Perseus resolves directives like `@file`, `@search`, and `@memory` into one
+byte-stable context string at inference time, with no retrieval index, no
+embeddings, and no extra LLM round-trip. Everything runs locally.
 
 Perseus is a context compiler, not a memory or RAG backend. For persistent
 cross-session memory, pair it with its companion, [Perseus Vault](/integrations/perseus-vault/).
@@ -163,5 +161,4 @@ agent = Agent(
 
 - [adk-perseus-context on GitHub](https://github.com/Perseus-Computing-LLC/adk-perseus-context)
 - [adk-perseus-context on PyPI](https://pypi.org/project/adk-perseus-context/)
-- [Perseus (context engine)](https://github.com/Perseus-Computing-LLC/perseus)
 - [Perseus Vault Memory integration](/integrations/perseus-vault/)


### PR DESCRIPTION
## Summary

Removes the three remaining broken links failing the `Check external links` workflow on `main`. Companion to #2225 (which fixes the fourth, unrelated one).

Both backing repositories return 404:

| File | Dead URL |
|---|---|
| `perseus.md` | `Perseus-Computing-LLC/perseus` |
| `perseus-vault.md` | `Perseus-Computing-LLC/perseus-vault` |
| `perseus-vault.md` | `Perseus-Computing-LLC/perseus-vault/releases` |

Nothing in this repo broke them — they rotted externally. The first failing run on `main` was 9f21af3c (Sep 10), an unrelated TypeScript version bump.

## Why removal rather than a redirect

I looked for a replacement before deleting anything:

- Neither `perseus` nor `perseus-vault` exists among the **31 public repos** in the `Perseus-Computing-LLC` org. The org's public presence is the integration libraries plus satellites like `perseus-vault-demo`.
- The `adk-perseus-vault-memory` PyPI metadata still lists `.../perseus-vault` as a project URL, so upstream also expects that repo to exist — it appears to have gone private rather than moved.
- `perseus.computer` is an **unrelated company** (efficient systems inc.), not this vendor. Not a valid substitute.

So there is no URL to swap in. Links are dropped, prose kept.

The two surviving `Perseus-Computing-LLC` links (`adk-perseus-context`, `adk-perseus-vault-memory`) both resolve 200 and are untouched.

## @tcconnally — two things need your call

You authored #1891 and #1928, so flagging these rather than deciding them here:

1. **The install step now has no source for the binary.** `perseus-vault.md` told readers to download from a releases page that 404s, so those instructions were already unfollowable. I reduced it to "install the `perseus-vault` binary and place it on your `PATH`" — but readers still have no documented way to *obtain* it. If there's a public download (crates.io, a tarball, an install script), that's the right fix.

2. **`perseus.md` still calls Perseus "an open-source context compiler."** The only evidence for that claim was the link I just removed. I left the wording alone deliberately, but if the source isn't public, it should probably be reworded.

Separately, a **non-blocking nit** left out to keep this diff scoped: `perseus-vault.md` lines 14 and 147 still point at `adk-mimir-memory`, which only resolves via a redirect to `adk-perseus-vault-memory`. Leftovers from the #1928 rename — worth updating whenever you next touch the page.

## Testing

Verified all three removed URLs return 404 and both retained ones return 200. No other references to the dead repos remain in the repo.