### PR TITLE
Removed the incompatible output_schema=str from graph samples

### DIFF
--- a/docs/graphs/dynamic.md
+++ b/docs/graphs/dynamic.md
@@ -412,7 +412,6 @@ workflows offer much more flexibility to define the routing logic you need.
         name="generator_agent",
         model="gemini-flash-latest",
         instruction="Write python code for user request.",
-        output_schema=str,
     )
 
     @node(name="lint_reviewer")
@@ -427,7 +426,6 @@ workflows offer much more flexibility to define the routing logic you need.
         model="gemini-flash-latest",
         instruction="""Refactor current code {code}.
             Based on compile & lint review: {findings}""",
-        output_schema=str,
     )
 
     @node # workflow node

--- a/docs/graphs/index.md
+++ b/docs/graphs/index.md
@@ -67,7 +67,6 @@ function, and the final agent reports the information.
         model="gemini-flash-latest",
         instruction="""Return the name of a random city.
           Return only the name, nothing else.""",
-        output_schema=str,
     )
 
     class CityTime(BaseModel):
@@ -84,7 +83,6 @@ function, and the final agent reports the information.
         input_schema=CityTime,
         instruction="""Output following line:
         It is {CityTime.time_info} in {CityTime.city} right now.""",
-        output_schema=str,
     )
 
     def completed_message_function(node_input: str):
@@ -176,7 +174,6 @@ translated into a graph-based agent:
           or "LOGISTICS". If you think a message applies to more than one category,
           reply with a comma separated list of categories.
        """,
-        output_schema=str,
     )
 
     def router(node_input: str):


### PR DESCRIPTION
Fixes #2220

### Changes
- Removed the incompatible `output_schema=str` parameter from five agent samples across `docs/graphs/index.md` and `docs/graphs/dynamic.md`.
- This prevents JSON parsing errors (`ValueError: Invalid JSON in schema value`) when these examples are run with non-Google providers (such as OpenAI-compatible models via LiteLLM).